### PR TITLE
Fix input as cloud for remapping

### DIFF
--- a/src/lidar_localization_component.cpp
+++ b/src/lidar_localization_component.cpp
@@ -230,7 +230,7 @@ void PCLLocalization::initializePubSub()
     std::bind(&PCLLocalization::odomReceived, this, std::placeholders::_1));
 
   cloud_sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
-    "velodyne_points", rclcpp::SensorDataQoS(),
+    "cloud", rclcpp::SensorDataQoS(),
     std::bind(&PCLLocalization::cloudReceived, this, std::placeholders::_1));
 
   imu_sub_ = create_subscription<sensor_msgs::msg::Imu>(


### PR DESCRIPTION
Hi, as per [README](https://github.com/rsasaki0109/lidar_localization_ros2/blob/main/README.md)

![image](https://github.com/user-attachments/assets/9e799085-3fee-4462-8cd5-db9383fad091)

I believe it would be more accurate for the `cloud_sub_` to use `cloud` topic to be remapped.
