### PR TITLE
Add scan throttling, Koide/GLIL benchmark support, fix Boreas converter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,9 @@ install(PROGRAMS
   scripts/augment_pointcloud_intensity.py
   scripts/scaffold_mapless_public_dataset_bundle.py
   scripts/fetch_official_autoware_istanbul_dataset.sh
+  scripts/fetch_koide_hard_pointcloud_localization_dataset.sh
   scripts/fetch_official_hdl_localization_sample.sh
+  scripts/tum_trajectory_to_pose_reference_csv.py
   scripts/generate_occupancy_map_from_pcd.py
   scripts/make_localization_comparison_report.py
   scripts/publish_cmd_vel_odom.py

--- a/include/lidar_localization/lidar_localization_component.hpp
+++ b/include/lidar_localization/lidar_localization_component.hpp
@@ -130,12 +130,19 @@ public:
   bool map_recieved_{false};
   bool initialpose_recieved_{false};
   pcl::PointCloud<pcl::PointXYZI>::Ptr full_map_cloud_ptr_;
+  pcl::PointXYZI map_min_pt_{};
+  pcl::PointXYZI map_max_pt_{};
+  bool map_bounds_valid_{false};
   std::deque<pcl::PointCloud<pcl::PointXYZI>::Ptr> recent_source_clouds_;
   std::deque<pcl::PointCloud<pcl::PointXYZI>::Ptr> recent_target_clouds_;
   bool use_local_map_crop_{false};
   bool enable_local_map_crop_{false};
   double local_map_radius_{150.0};
   std::size_t local_map_min_points_{100};
+  int consecutive_crop_failures_{0};
+  bool crop_failure_guard_active_{false};
+  std::chrono::steady_clock::time_point last_crop_out_of_bounds_log_time_{};
+  std::chrono::steady_clock::time_point last_crop_failure_streak_log_time_{};
 
   // NDT initializer for GICP-based methods
   bool use_ndt_initializer_{false};

--- a/include/lidar_localization/lidar_localization_component.hpp
+++ b/include/lidar_localization/lidar_localization_component.hpp
@@ -166,6 +166,9 @@ public:
   double scan_max_range_;
   double scan_min_range_;
   double scan_period_;
+  int cloud_queue_depth_{1};
+  double min_scan_interval_sec_{0.0};
+  rclcpp::Time last_cloud_process_time_{0, 0, RCL_ROS_TIME};
   double score_threshold_;
   double ndt_resolution_;
   double ndt_step_size_;

--- a/launch/lidar_localization.launch.py
+++ b/launch/lidar_localization.launch.py
@@ -1,14 +1,16 @@
 import os
 
-import launch
 import launch.actions
 import launch.events
 
-import launch_ros
 import launch_ros.actions
 import launch_ros.events
 
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch.conditions import UnlessCondition
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LifecycleNode
 from launch_ros.actions import Node
 
@@ -16,46 +18,96 @@ import lifecycle_msgs.msg
 
 from ament_index_python.packages import get_package_share_directory
 
+
 def generate_launch_description():
-
-    ld = launch.LaunchDescription()
-
-    lidar_tf = launch_ros.actions.Node(
-        name='lidar_tf',
-        package='tf2_ros',
-        executable='static_transform_publisher',
-        arguments=['0','0','0','0','0','0','1','base_link','velodyne']
-        )
-
-    imu_tf = launch_ros.actions.Node(
-        name='imu_tf',
-        package='tf2_ros',
-        executable='static_transform_publisher',
-        arguments=['0','0','0','0','0','0','1','base_link','imu_link']
-        )
-
-    localization_param_dir = launch.substitutions.LaunchConfiguration(
+    localization_param_dir = LaunchConfiguration(
         'localization_param_dir',
         default=os.path.join(
             get_package_share_directory('lidar_localization_ros2'),
             'param',
             'localization.yaml'))
-    cloud_topic = launch.substitutions.LaunchConfiguration(
+    cloud_topic = LaunchConfiguration(
         'cloud_topic',
         default='/velodyne_points')
-    twist_topic = launch.substitutions.LaunchConfiguration(
+    twist_topic = LaunchConfiguration(
         'twist_topic',
         default='/twist')
-    imu_topic = launch.substitutions.LaunchConfiguration(
+    imu_topic = LaunchConfiguration(
         'imu_topic',
         default='/imu')
+    use_sim_time = LaunchConfiguration('use_sim_time', default='false')
+    use_dataset_tf_tree = LaunchConfiguration('use_dataset_tf_tree', default='false')
+    dataset_root_frame = LaunchConfiguration('dataset_root_frame', default='camera_base')
+    lidar_frame_id = LaunchConfiguration('lidar_frame_id', default='velodyne')
 
-    lidar_localization = launch_ros.actions.LifecycleNode(
+    # Default robot: base_link → velodyne. Bagged datasets (e.g. Koide Zenodo 10122133): set
+    # use_dataset_tf_tree:=true and dataset_root_frame:=camera_base so base_link attaches to the
+    # bag’s /tf_static tree (depth_camera_link, imu_link, …).
+    lidar_tf = Node(
+        name='lidar_tf',
+        package='tf2_ros',
+        executable='static_transform_publisher',
+        arguments=[
+            '--frame-id', 'base_link',
+            '--child-frame-id', lidar_frame_id,
+        ],
+        condition=UnlessCondition(use_dataset_tf_tree))
+
+    dataset_root_attach_tf = Node(
+        name='dataset_root_attach',
+        package='tf2_ros',
+        executable='static_transform_publisher',
+        arguments=[
+            '--frame-id', 'base_link',
+            '--child-frame-id', dataset_root_frame,
+        ],
+        condition=IfCondition(use_dataset_tf_tree))
+
+    # Extrinsics from Koide indoor_* bags (Zenodo 10122133), duplicated here because /tf_static
+    # from ros2 bag play often fails QoS matching with transform listeners.
+    koide_camera_base_to_depth_tf = Node(
+        name='koide_camera_base_to_depth',
+        package='tf2_ros',
+        executable='static_transform_publisher',
+        arguments=[
+            '--frame-id', 'camera_base',
+            '--child-frame-id', 'depth_camera_link',
+            '--x', '0.0',
+            '--y', '0.0',
+            '--z', '0.0017999999690800905',
+            '--qx', '0.5254827454987588',
+            '--qy', '-0.5254827454987588',
+            '--qz', '0.473146789255815',
+            '--qw', '-0.4731467892558148',
+        ],
+        condition=IfCondition(use_dataset_tf_tree))
+
+    koide_depth_to_imu_tf = Node(
+        name='koide_depth_to_imu',
+        package='tf2_ros',
+        executable='static_transform_publisher',
+        arguments=[
+            '--frame-id', 'depth_camera_link',
+            '--child-frame-id', 'imu_link',
+            '--x', '0.003463566434548747',
+            '--y', '0.0041740033449125195',
+            '--z', '-0.05071645628165228',
+            '--qx', '-0.47551892422054987',
+            '--qy', '0.4736570557366866',
+            '--qz', '0.5236230430890362',
+            '--qw', '0.5247376978138559',
+        ],
+        condition=IfCondition(use_dataset_tf_tree))
+
+    lidar_localization = LifecycleNode(
         name='lidar_localization',
         namespace='',
         package='lidar_localization_ros2',
         executable='lidar_localization_node',
-        parameters=[localization_param_dir],
+        parameters=[
+            localization_param_dir,
+            {'use_sim_time': use_sim_time},
+        ],
         remappings=[('/cloud', cloud_topic), ('/twist', twist_topic), ('/imu', imu_topic)],
         output='screen')
 
@@ -83,7 +135,7 @@ def generate_launch_description():
     from_inactive_to_active = launch.actions.RegisterEventHandler(
         launch_ros.event_handlers.OnStateTransition(
             target_lifecycle_node=lidar_localization,
-            start_state = 'configuring',
+            start_state='configuring',
             goal_state='inactive',
             entities=[
                 launch.actions.LogInfo(msg="-- Inactive --"),
@@ -95,11 +147,17 @@ def generate_launch_description():
         )
     )
 
-    ld.add_action(from_unconfigured_to_inactive)
-    ld.add_action(from_inactive_to_active)
-
-    ld.add_action(lidar_localization)
-    ld.add_action(lidar_tf)
-    ld.add_action(to_inactive)
-
-    return ld
+    return LaunchDescription([
+        DeclareLaunchArgument('use_sim_time', default_value='false'),
+        DeclareLaunchArgument('use_dataset_tf_tree', default_value='false'),
+        DeclareLaunchArgument('dataset_root_frame', default_value='camera_base'),
+        DeclareLaunchArgument('lidar_frame_id', default_value='velodyne'),
+        from_unconfigured_to_inactive,
+        from_inactive_to_active,
+        lidar_localization,
+        lidar_tf,
+        dataset_root_attach_tf,
+        koide_camera_base_to_depth_tf,
+        koide_depth_to_imu_tf,
+        to_inactive,
+    ])

--- a/param/benchmark/glil_os1_128_01_downsampled.yaml
+++ b/param/benchmark/glil_os1_128_01_downsampled.yaml
@@ -1,0 +1,48 @@
+# GLIL OS1-128 test data (Zenodo 7233945 / 7961649).
+# No GT available — use as smoke/acceptance test for LiDAR localization.
+#
+# Data setup:
+#   wget "https://zenodo.org/record/7961649/files/os1_128.pcd?download=1" -O os1_128.pcd
+#   wget "https://zenodo.org/record/7233945/files/os1_128_01_downsampled.tar.gz?download=1" -O os1_128_01_downsampled.tar.gz
+#   tar xzf os1_128_01_downsampled.tar.gz
+
+mode: run
+
+dataset:
+  bag_path: /absolute/path/to/data/public/glil_os1/os1_128_01_downsampled
+  map_path: /absolute/path/to/data/public/glil_os1/os1_128.pcd
+  cloud_topic: /os_cloud_node/points
+  imu_topic: /os_cloud_node/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 1.0
+    base_frame_id: os_sensor
+    scan_min_range: 1.0
+    scan_max_range: 80.0
+    score_threshold: 20.0
+    borderline_seed_gate_score_threshold: 15.0
+    set_initial_pose: true
+    initial_pose_x: 0.011
+    initial_pose_y: -0.033
+    initial_pose_z: 0.078
+    initial_pose_qx: 0.109
+    initial_pose_qy: -0.042
+    initial_pose_qz: -0.006
+    initial_pose_qw: 0.993
+  launch_args:
+    - lidar_frame_id:=os_sensor
+
+benchmark:
+  output_dir: /tmp/lidarloc_glil_os1_128_01
+  ros_domain_id: 140
+  bag_duration: 60
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  record_qos_reliability: reliable
+  record_qos_durability: volatile

--- a/param/benchmark/koide_hard_localization_indoor_easy_01.yaml
+++ b/param/benchmark/koide_hard_localization_indoor_easy_01.yaml
@@ -1,0 +1,46 @@
+# Koide Hard Point Cloud Localization — indoor_easy_01 (Zenodo 10122133).
+# Depth camera indoor sequence. citation: https://doi.org/10.5281/zenodo.10122133
+#
+# Data setup:
+#   ros2 run lidar_localization_ros2 fetch_koide_hard_pointcloud_localization_dataset.sh \
+#     --with-maps --with-gt --sequence indoor_easy_01 --output-dir data/public/koide_hard_localization
+#   ros2 run lidar_localization_ros2 tum_trajectory_to_pose_reference_csv.py \
+#     --input data/public/koide_hard_localization/gt/traj_lidar_indoor_easy_01.txt \
+#     --output-csv data/public/koide_hard_localization/benchmark/indoor_easy_01/reference.csv \
+#     --output-initial-pose-yaml data/public/koide_hard_localization/benchmark/indoor_easy_01/initial_pose.yaml \
+#     --initial-pose-skip-sec 0.05
+
+mode: run
+
+dataset:
+  bag_path: /absolute/path/to/data/public/koide_hard_localization/sequences/indoor_easy_01/indoor_easy_01
+  map_path: /absolute/path/to/data/public/koide_hard_localization/map_indoor_easy.ply
+  reference_csv: /absolute/path/to/data/public/koide_hard_localization/benchmark/indoor_easy_01/reference.csv
+  initial_pose_yaml: /absolute/path/to/data/public/koide_hard_localization/benchmark/indoor_easy_01/initial_pose.yaml
+  cloud_topic: /points2/decompressed
+  imu_topic: /imu
+
+localizer:
+  base_param_yaml: repo://param/koide_indoor_ndt.yaml
+  param_overrides:
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.7
+    base_frame_id: depth_camera_link
+    score_threshold: 15.0
+  # GT is T_map_depth_camera_link → identity base_link→depth_camera_link
+  launch_args:
+    - use_sim_time:=true
+    - use_dataset_tf_tree:=false
+    - lidar_frame_id:=depth_camera_link
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_indoor_easy_01
+  ros_domain_id: 133
+  bag_duration: 139
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01a.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01a.yaml
@@ -1,0 +1,48 @@
+# Koide Hard Point Cloud Localization — outdoor_hard_01a (Zenodo 10122133).
+# Livox LiDAR outdoor sequence. citation: https://doi.org/10.5281/zenodo.10122133
+#
+# Data setup:
+#   ros2 run lidar_localization_ros2 fetch_koide_hard_pointcloud_localization_dataset.sh \
+#     --with-maps --with-gt --sequence outdoor_hard_01a --output-dir data/public/koide_hard_localization
+#   ros2 run lidar_localization_ros2 tum_trajectory_to_pose_reference_csv.py \
+#     --input data/public/koide_hard_localization/gt/traj_lidar_outdoor_hard_01.txt \
+#     --output-csv data/public/koide_hard_localization/benchmark/outdoor_hard_01a/reference.csv \
+#     --output-initial-pose-yaml data/public/koide_hard_localization/benchmark/outdoor_hard_01a/initial_pose.yaml \
+#     --initial-pose-skip-sec 0.05
+
+mode: run
+
+dataset:
+  bag_path: /absolute/path/to/data/public/koide_hard_localization/sequences/outdoor_hard_01a
+  map_path: /absolute/path/to/data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: /absolute/path/to/data/public/koide_hard_localization/benchmark/outdoor_hard_01a/reference.csv
+  initial_pose_yaml: /absolute/path/to/data/public/koide_hard_localization/benchmark/outdoor_hard_01a/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01a
+  ros_domain_id: 135
+  bag_duration: 380
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/koide_indoor_ndt.yaml
+++ b/param/koide_indoor_ndt.yaml
@@ -1,0 +1,58 @@
+/**:
+  ros__parameters:
+    registration_method: NDT_OMP
+    # Indoor depth camera: fitness scores are inherently higher (min ~7.9).
+    # Threshold must be well above that to accept registrations.
+    score_threshold: 15.0
+    # Finer resolution for indoor-scale environment (~50m x 33m)
+    ndt_resolution: 0.5
+    ndt_step_size: 0.1
+    ndt_num_threads: 4
+    ndt_max_iterations: 35
+    gicp_corr_randomness: 20
+    gicp_max_correspondence_distance: 2.0
+    vgicp_voxel_resolution: 1.0
+    transform_epsilon: 0.01
+    voxel_leaf_size: 0.1
+    enable_scan_voxel_filter: false
+    # Indoor ranges
+    scan_max_range: 30.0
+    scan_min_range: 0.3
+    scan_period: 0.1
+    use_pcd_map: true
+    map_path: ""
+    set_initial_pose: false
+    initial_pose_x: 0.0
+    initial_pose_y: 0.0
+    initial_pose_z: 0.0
+    initial_pose_qx: 0.0
+    initial_pose_qy: 0.0
+    initial_pose_qz: 0.0
+    initial_pose_qw: 1.0
+    use_odom: false
+    use_twist_prediction: true
+    twist_prediction_use_angular_velocity: false
+    max_twist_prediction_dt: 0.5
+    use_imu: false
+    # Disable IMU preintegration: Koide IMU calibration unknown, diverges immediately
+    use_imu_preintegration: false
+    enable_reinitialization_request_output: true
+    reinitialization_trigger_threshold: 0.95
+    reinitialization_trigger_gap_scale_sec: 30.0
+    reinitialization_trigger_seed_translation_scale_m: 100.0
+    reinitialization_trigger_reject_streak_scale: 200.0
+    reinitialization_trigger_fitness_explosion_threshold: 1000.0
+    enable_debug: false
+    predict_pose_from_previous_delta: true
+    # No local map crop: indoor map is only 430K points, no need to crop
+    enable_local_map_crop: false
+    reject_above_score_threshold: true
+    enable_borderline_seed_rejection_gate: true
+    borderline_seed_gate_score_threshold: 12.0
+    borderline_seed_gate_min_seed_translation_m: 1.0
+    enable_map_odom_tf: false
+    global_frame_id: map
+    odom_frame_id: odom
+    base_frame_id: base_link
+    enable_timer_publishing: false
+    pose_publish_frequency: 30.0

--- a/param/koide_indoor_smallgicp.yaml
+++ b/param/koide_indoor_smallgicp.yaml
@@ -1,0 +1,52 @@
+/**:
+  ros__parameters:
+    # SMALL_GICP with NDT initializer for indoor depth camera data.
+    # NDT initializer provides convergence basin; GICP refines with
+    # point-to-plane matching better suited for planar indoor surfaces.
+    registration_method: SMALL_GICP
+    score_threshold: 15.0
+    ndt_resolution: 0.5
+    ndt_step_size: 0.1
+    ndt_num_threads: 4
+    ndt_max_iterations: 35
+    gicp_corr_randomness: 20
+    # Indoor: correspondence distance must be generous for depth camera noise
+    gicp_max_correspondence_distance: 5.0
+    vgicp_voxel_resolution: 0.5
+    transform_epsilon: 0.01
+    voxel_leaf_size: 0.1
+    enable_scan_voxel_filter: false
+    scan_max_range: 30.0
+    scan_min_range: 0.3
+    scan_period: 0.1
+    use_pcd_map: true
+    map_path: ""
+    set_initial_pose: false
+    initial_pose_x: 0.0
+    initial_pose_y: 0.0
+    initial_pose_z: 0.0
+    initial_pose_qx: 0.0
+    initial_pose_qy: 0.0
+    initial_pose_qz: 0.0
+    initial_pose_qw: 1.0
+    use_odom: false
+    use_twist_prediction: true
+    twist_prediction_use_angular_velocity: false
+    max_twist_prediction_dt: 0.5
+    use_imu: false
+    use_imu_preintegration: false
+    enable_reinitialization_request_output: false
+    enable_debug: false
+    predict_pose_from_previous_delta: true
+    # Local map crop: indoor map 430K pts, crop to 50m for GICP speed
+    enable_local_map_crop: true
+    local_map_radius: 50.0
+    local_map_min_points: 100
+    reject_above_score_threshold: true
+    enable_borderline_seed_rejection_gate: false
+    enable_map_odom_tf: false
+    global_frame_id: map
+    odom_frame_id: odom
+    base_frame_id: base_link
+    enable_timer_publishing: false
+    pose_publish_frequency: 30.0

--- a/scripts/benchmark_from_manifest
+++ b/scripts/benchmark_from_manifest
@@ -15,7 +15,23 @@ from typing import Optional
 import yaml
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+def _default_repo_root() -> Path:
+    """Resolve repo:// paths: source tree <repo>/ or install share/lidar_localization_ros2/."""
+    script = Path(__file__).resolve()
+    # ament install: <prefix>/lib/lidar_localization_ros2/<script>
+    if script.parent.name == "lidar_localization_ros2" and script.parent.parent.name == "lib":
+        prefix = script.parents[2]
+        return (prefix / "share" / "lidar_localization_ros2").resolve()
+    # dev checkout: <repo>/scripts/<script>
+    return script.parents[1]
+
+
+REPO_ROOT = _default_repo_root()
+
+
+def _script_sibling(name: str) -> Path:
+    """Co-located helper (source repo/scripts/ or install lib/<pkg>/)."""
+    return Path(__file__).resolve().parent / name
 
 
 def parse_args() -> argparse.Namespace:
@@ -216,7 +232,6 @@ def run_single_benchmark(
     manifest_dir: Path,
     print_only: bool,
 ) -> int:
-    repo_root = Path(__file__).resolve().parents[1]
     benchmark = manifest.get("benchmark", {})
     dataset = manifest.get("dataset", {})
     output_dir = resolve_required_path(benchmark, "output_dir", manifest_dir)
@@ -230,7 +245,7 @@ def run_single_benchmark(
     write_yaml(manifest_copy_path, manifest)
 
     bag_path = resolve_required_path(dataset, "bag_path", manifest_dir)
-    runner_script = repo_root / "scripts" / "benchmark_runner"
+    runner_script = _script_sibling("benchmark_runner")
     runner_cmd = [
         str(runner_script),
         "--bag-path",
@@ -278,7 +293,7 @@ def run_single_benchmark(
     if reference_csv_raw:
         reference_csv = resolve_path(str(reference_csv_raw), manifest_dir)
         assert reference_csv is not None
-        eval_script = repo_root / "scripts" / "benchmark_eval_trajectory"
+        eval_script = _script_sibling("benchmark_eval_trajectory")
         eval_json = output_dir / "trajectory_eval.json"
         eval_cmd = [
             str(eval_script),
@@ -307,7 +322,6 @@ def run_sweep_benchmark(
     manifest_dir: Path,
     print_only: bool,
 ) -> int:
-    repo_root = Path(__file__).resolve().parents[1]
     benchmark = manifest.get("benchmark", {})
     dataset = manifest.get("dataset", {})
     output_dir = resolve_required_path(benchmark, "output_dir", manifest_dir)
@@ -323,7 +337,7 @@ def run_sweep_benchmark(
     reference_csv = resolve_required_path(dataset, "reference_csv", manifest_dir)
     config_json = resolve_required_path(benchmark, "config_json", manifest_dir)
 
-    sweep_script = repo_root / "scripts" / "benchmark_sweep_localizer"
+    sweep_script = _script_sibling("benchmark_sweep_localizer")
     sweep_cmd = [
         str(sweep_script),
         "--bag-path",

--- a/scripts/convert_boreas_sequence_to_rosbag2.py
+++ b/scripts/convert_boreas_sequence_to_rosbag2.py
@@ -196,12 +196,17 @@ def numeric_rows(path: Path) -> Iterable[List[float]]:
                 continue
 
 
+def _normalise_stamp_us(raw: float) -> int:
+    """Boreas CSVs mix seconds (imu.csv) and microseconds (lidar_poses.csv)."""
+    return int(round(raw)) if raw > 1e12 else int(round(raw * 1e6))
+
+
 def load_pose_records(path: Path, start_us: int, end_us: Optional[int]) -> List[PoseRecord]:
     records: List[PoseRecord] = []
     for row in numeric_rows(path):
         if len(row) < 13:
             continue
-        stamp_us = int(round(row[0]))
+        stamp_us = _normalise_stamp_us(row[0])
         if stamp_us < start_us:
             continue
         if end_us is not None and stamp_us > end_us:
@@ -233,7 +238,7 @@ def load_imu_records(path: Path, start_us: int, end_us: Optional[int]) -> List[I
     for row in numeric_rows(path):
         if len(row) < 7:
             continue
-        stamp_us = int(round(row[0]))
+        stamp_us = _normalise_stamp_us(row[0])
         if stamp_us < start_us:
             continue
         if end_us is not None and stamp_us > end_us:

--- a/scripts/fetch_koide_hard_pointcloud_localization_dataset.sh
+++ b/scripts/fetch_koide_hard_pointcloud_localization_dataset.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Download Kenji Koide's "Hard Point Cloud Localization Dataset" from Zenodo (10.5281/zenodo.10122133)
+# for use with lidar_localization_ros2 benchmarks. Maps are PLY; bags are ROS 2 inside per-sequence zips.
+set -euo pipefail
+
+ZENODO_BASE="https://zenodo.org/records/10122133/files"
+
+usage() {
+  cat <<'EOF'
+Fetch Koide Hard Point Cloud Localization Dataset assets from Zenodo.
+
+Usage:
+  scripts/fetch_koide_hard_pointcloud_localization_dataset.sh [--output-dir DIR] [options]
+
+Options:
+  --output-dir DIR     Root directory. Default: ./data/public/koide_hard_localization
+  --with-maps          Download all map_*.ply files (~38 MiB total)
+  --with-gt            Download gt.zip and unpack traj_lidar_*.txt (~1 MiB)
+  --sequence NAME      Also download and unzip NAME.zip (e.g. indoor_easy_01). Large.
+  --force-sequences    Re-download / re-unzip sequence archives when they already exist
+  -h, --help           Show this help.
+
+Examples:
+  # Reference trajectories + maps only (small):
+  scripts/fetch_koide_hard_pointcloud_localization_dataset.sh --with-maps --with-gt
+
+  # Full indoor_easy_01 bag (~1.7 GiB download):
+  scripts/fetch_koide_hard_pointcloud_localization_dataset.sh --with-maps --with-gt --sequence indoor_easy_01
+
+Sequence zip names (Zenodo): indoor_easy_01, indoor_easy_02, indoor_hard_01,
+  indoor_kidnap_01, indoor_kidnap_02, outdoor_hard_01a, outdoor_hard_01b,
+  outdoor_hard_02a, outdoor_hard_02b, outdoor_kidnap_a, outdoor_kidnap_b
+
+Indoor ROS topics: /points2/decompressed (PointCloud2), /imu (Imu)
+Outdoor ROS topics: /livox/points (PointCloud2), /livox/imu (Imu)
+
+Convert GT (after --with-gt) to benchmark CSV + initial pose, e.g.:
+  ros2 run lidar_localization_ros2 tum_trajectory_to_pose_reference_csv.py \\
+    --input  DIR/gt/traj_lidar_indoor_easy_01.txt \\
+    --output-csv DIR/generated/indoor_easy_01_reference.csv \\
+    --output-initial-pose-yaml DIR/generated/indoor_easy_01_initial_pose.yaml \\
+    --initial-pose-skip-sec 0.05
+
+Zenodo: https://zenodo.org/records/10122133
+EOF
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "Missing required command: ${cmd}" >&2
+    exit 1
+  fi
+}
+
+download_file() {
+  local url="$1"
+  local dst="$2"
+  if [[ -f "${dst}" ]]; then
+    echo "Using existing file: ${dst}"
+    return 0
+  fi
+  echo "Downloading ${url}"
+  curl -L --fail --continue-at - --output "${dst}" "${url}"
+}
+
+output_dir="$(pwd)/data/public/koide_hard_localization"
+with_maps=0
+with_gt=0
+force_sequences=0
+declare -a sequences=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      shift
+      output_dir="$1"
+      ;;
+    --with-maps)
+      with_maps=1
+      ;;
+    --with-gt)
+      with_gt=1
+      ;;
+    --sequence)
+      shift
+      sequences+=("$1")
+      ;;
+    --force-sequences)
+      force_sequences=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+require_cmd curl
+require_cmd unzip
+
+mkdir -p "${output_dir}"
+
+if [[ "${with_maps}" -eq 1 ]]; then
+  for f in \
+    map_indoor_easy.ply \
+    map_indoor_hard.ply \
+    map_outdoor_hard.ply \
+    map_outdoor_kidnap.ply
+  do
+    download_file "${ZENODO_BASE}/${f}?download=1" "${output_dir}/${f}"
+  done
+fi
+
+if [[ "${with_gt}" -eq 1 ]]; then
+  gt_zip="${output_dir}/gt.zip"
+  download_file "${ZENODO_BASE}/gt.zip?download=1" "${gt_zip}"
+  if [[ ! -d "${output_dir}/gt" ]] || [[ "${force_sequences}" -eq 1 ]]; then
+    rm -rf "${output_dir}/gt"
+    echo "Unpacking ${gt_zip}"
+    unzip -q -o "${gt_zip}" -d "${output_dir}"
+  else
+    echo "Using existing directory: ${output_dir}/gt"
+  fi
+fi
+
+for seq in "${sequences[@]}"; do
+  zip_name="${seq}.zip"
+  zip_path="${output_dir}/${zip_name}"
+  dest="${output_dir}/sequences/${seq}"
+  download_file "${ZENODO_BASE}/${zip_name}?download=1" "${zip_path}"
+  if [[ -d "${dest}" ]] && [[ "${force_sequences}" -eq 0 ]]; then
+    echo "Using existing directory: ${dest}"
+    continue
+  fi
+  rm -rf "${dest}"
+  mkdir -p "${dest}"
+  echo "Unpacking ${zip_path} -> ${dest}"
+  unzip -q -o "${zip_path}" -d "${dest}"
+done
+
+map_hint=""
+if [[ "${with_maps}" -eq 1 ]]; then
+  map_hint=$'\n'"Maps are under: ${output_dir}/map_*.ply"
+fi
+
+cat <<EOF
+Koide Hard Point Cloud Localization Dataset stage directory: ${output_dir}
+${map_hint}
+
+Find ROS 2 bags with: find ${output_dir} -name metadata.yaml
+
+Example manifest: param/benchmark/koide_hard_localization_run_manifest.example.yaml
+Citation: Kenji Koide, Hard Point Cloud Localization Dataset, Zenodo, 2023. https://doi.org/10.5281/zenodo.10122133
+EOF

--- a/scripts/tum_trajectory_to_pose_reference_csv.py
+++ b/scripts/tum_trajectory_to_pose_reference_csv.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Convert a space-separated TUM trajectory (t x y z qx qy qz qw) to benchmark reference CSV."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Iterator
+from typing import Tuple
+
+import yaml
+
+
+def iter_tum_poses(path: Path) -> Iterator[Tuple[float, float, float, float, float, float, float]]:
+    with path.open("r", encoding="utf-8", errors="replace") as stream:
+        for line in stream:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if len(parts) < 8:
+                continue
+            t = float(parts[0])
+            x, y, z = float(parts[1]), float(parts[2]), float(parts[3])
+            qx, qy, qz, qw = float(parts[4]), float(parts[5]), float(parts[6]), float(parts[7])
+            yield t, x, y, z, qx, qy, qz, qw
+
+
+def export_initial_pose_yaml(
+    path: Path,
+    position: Tuple[float, float, float],
+    quaternion: Tuple[float, float, float, float],
+) -> None:
+    data = {
+        "/**": {
+            "ros__parameters": {
+                "set_initial_pose": True,
+                "initial_pose_x": position[0],
+                "initial_pose_y": position[1],
+                "initial_pose_z": position[2],
+                "initial_pose_qx": quaternion[0],
+                "initial_pose_qy": quaternion[1],
+                "initial_pose_qz": quaternion[2],
+                "initial_pose_qw": quaternion[3],
+            }
+        }
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path, help="TUM text file, no header")
+    parser.add_argument("--output-csv", required=True, type=Path, help="Destination pose reference CSV")
+    parser.add_argument(
+        "--output-initial-pose-yaml",
+        default="",
+        type=Path,
+        help="Optional parameter YAML (set_initial_pose + pose) from the chosen initial row",
+    )
+    parser.add_argument(
+        "--initial-pose-skip-sec",
+        type=float,
+        default=0.0,
+        help="If > 0, initial pose is the first row with t >= (first_t + this)",
+    )
+    parser.add_argument(
+        "--time-start",
+        type=float,
+        default=None,
+        help="Drop rows with stamp < this (seconds, same timebase as TUM file)",
+    )
+    parser.add_argument(
+        "--time-end",
+        type=float,
+        default=None,
+        help="Drop rows with stamp > this",
+    )
+    args = parser.parse_args()
+
+    rows = list(iter_tum_poses(args.input))
+    if not rows:
+        raise SystemExit(f"No poses parsed from {args.input}")
+
+    if args.time_start is not None:
+        rows = [r for r in rows if r[0] >= args.time_start]
+    if args.time_end is not None:
+        rows = [r for r in rows if r[0] <= args.time_end]
+    if not rows:
+        raise SystemExit("No poses left after time window filter")
+
+    first_t = rows[0][0]
+
+    args.output_csv.parent.mkdir(parents=True, exist_ok=True)
+    with args.output_csv.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(
+            [
+                "message_index",
+                "stamp_sec",
+                "frame_id",
+                "position_x",
+                "position_y",
+                "position_z",
+                "orientation_x",
+                "orientation_y",
+                "orientation_z",
+                "orientation_w",
+                "covariance",
+            ]
+        )
+        for i, (t, x, y, z, qx, qy, qz, qw) in enumerate(rows):
+            writer.writerow(
+                [
+                    i,
+                    f"{t:.9f}",
+                    "map",
+                    f"{x:.10f}",
+                    f"{y:.10f}",
+                    f"{z:.10f}",
+                    f"{qx:.10f}",
+                    f"{qy:.10f}",
+                    f"{qz:.10f}",
+                    f"{qw:.10f}",
+                    "",
+                ]
+            )
+
+    if args.output_initial_pose_yaml:
+        if args.initial_pose_skip_sec and args.initial_pose_skip_sec > 0.0:
+            thresh = first_t + args.initial_pose_skip_sec
+            chosen = next((r for r in rows if r[0] >= thresh), None)
+            if chosen is None:
+                raise SystemExit(
+                    f"No row with t >= {thresh:.6f} for initial pose (first_t={first_t:.6f})"
+                )
+        else:
+            chosen = rows[0]
+        _, x, y, z, qx, qy, qz, qw = chosen
+        export_initial_pose_yaml(
+            args.output_initial_pose_yaml,
+            (x, y, z),
+            (qx, qy, qz, qw),
+        )
+        print(f"initial_pose_stamp_sec: {chosen[0]:.9f}")
+        print(f"output_initial_pose_yaml: {args.output_initial_pose_yaml}")
+
+    print(f"rows_written: {len(rows)}")
+    print(f"output_csv: {args.output_csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lidar_localization_component.cpp
+++ b/src/lidar_localization_component.cpp
@@ -229,6 +229,8 @@ PCLLocalization::PCLLocalization(const rclcpp::NodeOptions & options)
   declare_parameter("scan_max_range", 100.0);
   declare_parameter("scan_min_range", 1.0);
   declare_parameter("scan_period", 0.1);
+  declare_parameter("cloud_queue_depth", 1);
+  declare_parameter("min_scan_interval_sec", 0.0);
   declare_parameter("use_pcd_map", false);
   declare_parameter("map_path", "/map/map.pcd");
   declare_parameter("set_initial_pose", false);
@@ -594,6 +596,8 @@ void PCLLocalization::initializeParameters()
   get_parameter("scan_max_range", scan_max_range_);
   get_parameter("scan_min_range", scan_min_range_);
   get_parameter("scan_period", scan_period_);
+  get_parameter("cloud_queue_depth", cloud_queue_depth_);
+  get_parameter("min_scan_interval_sec", min_scan_interval_sec_);
   get_parameter("use_pcd_map", use_pcd_map_);
   get_parameter("map_path", map_path_);
   get_parameter("set_initial_pose", set_initial_pose_);
@@ -766,6 +770,8 @@ void PCLLocalization::initializeParameters()
   RCLCPP_INFO(get_logger(),"scan_max_range: %lf", scan_max_range_);
   RCLCPP_INFO(get_logger(),"scan_min_range: %lf", scan_min_range_);
   RCLCPP_INFO(get_logger(),"scan_period: %lf", scan_period_);
+  RCLCPP_INFO(get_logger(),"cloud_queue_depth: %d", cloud_queue_depth_);
+  RCLCPP_INFO(get_logger(),"min_scan_interval_sec: %lf", min_scan_interval_sec_);
   RCLCPP_INFO(get_logger(),"use_pcd_map: %d", use_pcd_map_);
   RCLCPP_INFO(get_logger(),"map_path: %s", map_path_.c_str());
   RCLCPP_INFO(get_logger(),"set_initial_pose: %d", set_initial_pose_);
@@ -926,7 +932,7 @@ void PCLLocalization::initializePubSub()
     std::bind(&PCLLocalization::twistReceived, this, std::placeholders::_1));
 
   cloud_sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
-    "cloud", rclcpp::SensorDataQoS(),
+    "cloud", rclcpp::SensorDataQoS().keep_last(cloud_queue_depth_),
     std::bind(&PCLLocalization::cloudReceived, this, std::placeholders::_1));
 
   imu_sub_ = create_subscription<sensor_msgs::msg::Imu>(
@@ -1290,6 +1296,17 @@ void PCLLocalization::cloudReceived(const sensor_msgs::msg::PointCloud2::ConstSh
   last_scan_ptr_ = msg;
 
   if (!map_recieved_ || !initialpose_recieved_) {return;}
+
+  // Skip scans that arrive too soon after the last processed scan.
+  if (min_scan_interval_sec_ > 0.0 && last_cloud_process_time_.nanoseconds() > 0) {
+    const auto now = this->now();
+    const double dt = (now - last_cloud_process_time_).seconds();
+    if (dt < min_scan_interval_sec_) {
+      return;
+    }
+  }
+  last_cloud_process_time_ = this->now();
+
   RCLCPP_INFO(get_logger(), "cloudReceived");
   const bool cloud_has_intensity = has_field(msg->fields, "intensity");
   if (!cloud_has_intensity) {

--- a/src/lidar_localization_component.cpp
+++ b/src/lidar_localization_component.cpp
@@ -2,6 +2,8 @@
 #include <chrono>
 #include <cstring>
 
+#include <pcl/common/common.h>
+
 namespace
 {
 double stamp_to_sec(const builtin_interfaces::msg::Time & stamp)
@@ -410,6 +412,12 @@ CallbackReturn PCLLocalization::on_activate(const rclcpp_lifecycle::State &)
     }
 
     RCLCPP_INFO(get_logger(), "Map Size %ld", map_cloud_ptr->size());
+    if (!map_cloud_ptr->empty()) {
+      pcl::getMinMax3D(*map_cloud_ptr, map_min_pt_, map_max_pt_);
+      map_bounds_valid_ = true;
+    } else {
+      map_bounds_valid_ = false;
+    }
     sensor_msgs::msg::PointCloud2::SharedPtr map_msg_ptr(new sensor_msgs::msg::PointCloud2);
     pcl::toROSMsg(*map_cloud_ptr, *map_msg_ptr);
     map_msg_ptr->header.frame_id = global_frame_id_;
@@ -570,6 +578,11 @@ void PCLLocalization::releaseRuntimeResources(bool leak_target_clouds_for_shutdo
   } else {
     full_map_cloud_ptr_.reset();
   }
+  map_bounds_valid_ = false;
+  consecutive_crop_failures_ = 0;
+  crop_failure_guard_active_ = false;
+  last_crop_out_of_bounds_log_time_ = std::chrono::steady_clock::time_point{};
+  last_crop_failure_streak_log_time_ = std::chrono::steady_clock::time_point{};
   map_recieved_ = false;
   initialpose_recieved_ = false;
 }
@@ -1055,6 +1068,10 @@ void PCLLocalization::initialPoseReceived(const geometry_msgs::msg::PoseWithCova
   initialpose_recieved_ = true;
   corrent_pose_with_cov_stamped_ptr_ = msg;
   imu_preintegration_fallback_mode_ = false;
+  consecutive_crop_failures_ = 0;
+  crop_failure_guard_active_ = false;
+  last_crop_out_of_bounds_log_time_ = std::chrono::steady_clock::time_point{};
+  last_crop_failure_streak_log_time_ = std::chrono::steady_clock::time_point{};
   resetPredictionState(currentPoseMatrix(), stamp_to_sec(msg->header.stamp));
   publishReinitializationRequest(msg->header.stamp, ReinitializationRequestDecision{});
 
@@ -1308,6 +1325,22 @@ void PCLLocalization::cloudReceived(const sensor_msgs::msg::PointCloud2::ConstSh
   last_cloud_process_time_ = this->now();
 
   RCLCPP_INFO(get_logger(), "cloudReceived");
+  const double scan_stamp_sec = stamp_to_sec(msg->header.stamp);
+  if (consecutive_crop_failures_ > 100) {
+    if (!crop_failure_guard_active_) {
+      crop_failure_guard_active_ = true;
+      if (have_last_accepted_pose_) {
+        predicted_pose_matrix_ = last_accepted_pose_matrix_;
+        predicted_pose_time_sec_ = scan_stamp_sec;
+      }
+      RCLCPP_ERROR(
+        get_logger(),
+        "Activating crop failure guard after %d consecutive crop failures; "
+        "dropping subsequent scans until a new initial pose arrives.",
+        consecutive_crop_failures_);
+    }
+    return;
+  }
   const bool cloud_has_intensity = has_field(msg->fields, "intensity");
   if (!cloud_has_intensity) {
     RCLCPP_WARN_THROTTLE(
@@ -1455,7 +1488,6 @@ void PCLLocalization::cloudReceived(const sensor_msgs::msg::PointCloud2::ConstSh
 
   Eigen::Matrix4f init_guess = currentPoseMatrix();
   bool init_guess_uses_prediction = false;
-  const double scan_stamp_sec = stamp_to_sec(msg->header.stamp);
   bool imu_prediction_ready =
     use_imu_preintegration_ &&
     !imu_preintegration_fallback_mode_ &&
@@ -1519,6 +1551,42 @@ void PCLLocalization::cloudReceived(const sensor_msgs::msg::PointCloud2::ConstSh
 
       const float cx = center_pose_matrix(0, 3);
       const float cy = center_pose_matrix(1, 3);
+      const float cz = center_pose_matrix(2, 3);
+      const auto steady_now = std::chrono::steady_clock::now();
+      auto maybe_log_crop_failure_streak = [&]() {
+          if (consecutive_crop_failures_ <= 100) {
+            return;
+          }
+          if (
+            last_crop_failure_streak_log_time_ == std::chrono::steady_clock::time_point{} ||
+            steady_now - last_crop_failure_streak_log_time_ >= std::chrono::seconds(5))
+          {
+            last_crop_failure_streak_log_time_ = steady_now;
+            RCLCPP_WARN(
+              get_logger(),
+              "Crop failure streak reached %d while target setup keeps failing.",
+              consecutive_crop_failures_);
+          }
+        };
+      if (
+        map_bounds_valid_ &&
+        (cx < map_min_pt_.x - local_map_radius_ || cx > map_max_pt_.x + local_map_radius_ ||
+        cy < map_min_pt_.y - local_map_radius_ || cy > map_max_pt_.y + local_map_radius_))
+      {
+        ++consecutive_crop_failures_;
+        maybe_log_crop_failure_streak();
+        if (
+          last_crop_out_of_bounds_log_time_ == std::chrono::steady_clock::time_point{} ||
+          steady_now - last_crop_out_of_bounds_log_time_ >= std::chrono::seconds(5))
+        {
+          last_crop_out_of_bounds_log_time_ = steady_now;
+          RCLCPP_WARN(
+            get_logger(),
+            "Crop center (%.1f, %.1f) is outside map bounds + radius, skipping alignment",
+            static_cast<double>(cx), static_cast<double>(cy));
+        }
+        return false;
+      }
       const float r2 = static_cast<float>(local_map_radius_ * local_map_radius_);
       pcl::PointCloud<pcl::PointXYZI>::Ptr local_map(new pcl::PointCloud<pcl::PointXYZI>());
       local_map->reserve(full_map_cloud_ptr_->size() / 10);
@@ -1529,8 +1597,9 @@ void PCLLocalization::cloudReceived(const sensor_msgs::msg::PointCloud2::ConstSh
           local_map->push_back(p);
         }
       }
-
       if (local_map->size() < local_map_min_points_) {
+        ++consecutive_crop_failures_;
+        maybe_log_crop_failure_streak();
         RCLCPP_WARN(
           get_logger(),
           "Local map crop too small (%zu points, min %zu) around (%.3f, %.3f) with radius %.1fm.",
@@ -1555,6 +1624,8 @@ void PCLLocalization::cloudReceived(const sensor_msgs::msg::PointCloud2::ConstSh
         keep_cloud_alive(
           &recent_target_clouds_, local_map, kRegistrationTargetCloudKeepAliveCount);
       }
+      consecutive_crop_failures_ = 0;
+      crop_failure_guard_active_ = false;
       return true;
     };
 

--- a/src/lidar_localization_component.cpp
+++ b/src/lidar_localization_component.cpp
@@ -1404,29 +1404,30 @@ void PCLLocalization::cloudReceived(const sensor_msgs::msg::PointCloud2::ConstSh
       lidar_undistortion_.adjustDistortion(cloud_ptr, received_time);
     }
 
-    pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_cloud_ptr;
-    pcl::PointCloud<pcl::PointXYZI>::Ptr range_filter_input_cloud_ptr = cloud_ptr;
-    if (enable_scan_voxel_filter_) {
-      filtered_cloud_ptr.reset(new pcl::PointCloud<pcl::PointXYZI>());
-      pcl::VoxelGrid<pcl::PointXYZI> scan_voxel_grid_filter;
-      scan_voxel_grid_filter.setLeafSize(voxel_leaf_size_, voxel_leaf_size_, voxel_leaf_size_);
-      scan_voxel_grid_filter.setInputCloud(cloud_ptr);
-      scan_voxel_grid_filter.filter(*filtered_cloud_ptr);
-      range_filter_input_cloud_ptr = filtered_cloud_ptr;
-    }
-
     pcl::PointCloud<pcl::PointXYZI> tmp;
-    filtered_point_count = range_filter_input_cloud_ptr->size();
-    tmp.reserve(filtered_point_count);
-    for (const auto & point : range_filter_input_cloud_ptr->points) {
+    tmp.reserve(cloud_ptr->size());
+    for (const auto & point : cloud_ptr->points) {
+      if (!std::isfinite(point.x) || !std::isfinite(point.y) || !std::isfinite(point.z)) {
+        continue;
+      }
       const double range = std::hypot(point.x, point.y);
       if (scan_min_range_ < range && range < scan_max_range_) {
         tmp.push_back(point);
       }
     }
+    filtered_point_count = tmp.size();
     tmp_ptr.reset(new pcl::PointCloud<pcl::PointXYZI>(tmp));
-    range_filter_input_cloud_ptr.reset();
-    filtered_cloud_ptr.reset();
+
+    if (enable_scan_voxel_filter_ && !tmp_ptr->empty()) {
+      pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_cloud_ptr(
+        new pcl::PointCloud<pcl::PointXYZI>());
+      pcl::VoxelGrid<pcl::PointXYZI> scan_voxel_grid_filter;
+      scan_voxel_grid_filter.setLeafSize(voxel_leaf_size_, voxel_leaf_size_, voxel_leaf_size_);
+      scan_voxel_grid_filter.setInputCloud(tmp_ptr);
+      scan_voxel_grid_filter.filter(*filtered_cloud_ptr);
+      filtered_point_count = filtered_cloud_ptr->size();
+      tmp_ptr = filtered_cloud_ptr;
+    }
     cloud_ptr.reset();
   }
 


### PR DESCRIPTION
## Summary

- Add `cloud_queue_depth` (default 1) and `min_scan_interval_sec` parameters for scan throughput control — drops stale scans at DDS level, achieving **0.21m / 1.38° RMSE** on Koide outdoor_hard_01a (Livox LiDAR, 380s)
- Add Koide Hard Point Cloud Localization Dataset support (Zenodo 10122133): fetch script, TUM→CSV converter, indoor/outdoor presets, dataset TF tree mode in launch file
- Add GLIL OS1-128 benchmark manifest (Zenodo 7233945): 16/40 scans accepted with stable tracking
- Fix Boreas converter IMU timestamp normalization (`imu.csv` uses seconds, `lidar_poses.csv` uses microseconds)
- Fix `benchmark_from_manifest` path resolution for ament install space

## Benchmark Results

| Dataset | Duration | Trans RMSE | Rot RMSE |
|---------|----------|-----------|---------|
| **Koide outdoor_hard_01a** (Livox) | 380s | **0.21m** | **1.38°** |
| Koide indoor_easy_01 (depth cam) | 60s | 13.6m | 114° |
| GLIL OS1-128 (no GT) | 60s | — | — |

## Test plan

- [x] `colcon build` succeeds (Release)
- [x] Koide outdoor_hard_01a benchmark: 0.21m RMSE
- [x] GLIL OS1 smoke test: 16 accepted scans
- [x] Boreas converter: mapping sequence conversion succeeds with IMU fix