### PR TITLE
[codex] Add user docs and benchmark helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ build
 __pycache__/
 *.pyc
 map/bin_tc-2017-10-15--ndmap.pcd
+/data/public/
 param/benchmark/*.local.yaml
 param/benchmark/private/
+param/benchmark/boreas_localization_120s.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# Agent Notes
+
+## Project Scope
+
+- This repository is the ROS 2 package `lidar_localization_ros2`.
+- Runtime code lives in `src/`, `include/`, `launch/`, `param/`, and `scripts/`.
+- Experimental alternatives live under `experiments/` and are intentionally discardable until a variant wins the shared comparison.
+- The local workspace layout is expected to be:
+
+```text
+lidarloc_ws/
+  build_ws/
+  local_prefix/
+  repo/
+```
+
+## Environment
+
+- Use the no-sudo local environment from the repository root:
+
+```bash
+source scripts/setup_local_env.sh
+```
+
+- The setup script sources ROS 2 Humble, adds `../local_prefix`, and then sources `../build_ws/install/setup.bash` when present.
+- Do not replace the local-prefix workflow with system-wide dependency installs unless explicitly requested.
+- Build from the overlay workspace, not from this repository directory:
+
+```bash
+cd ../build_ws
+colcon build --symlink-install --packages-up-to lidar_localization_ros2
+```
+
+## Validation
+
+- For C++/launch/package changes, run at least:
+
+```bash
+source scripts/setup_local_env.sh
+cd ../build_ws
+colcon build --symlink-install --packages-up-to lidar_localization_ros2
+```
+
+- For localization behavior, recovery logic, or parameter-default changes, also run the focused experiment suite after the build:
+
+```bash
+ros2 run lidar_localization_ros2 run_experiment_suite.py
+```
+
+- For public-smoke validation use:
+
+```bash
+scripts/run_public_regression_suite.sh
+```
+
+- For release-style validation use:
+
+```bash
+ros2 run lidar_localization_ros2 run_release_regression_suite.sh
+```
+
+- If required public datasets are absent or a regression run is too heavy for the current task, state exactly which validation was skipped.
+
+## Development Rules
+
+- New behavior should first be introduced as multiple comparable variants under `experiments/`.
+- Promote only the winning behavior into runtime code after the shared fixture/rubric comparison.
+- `docs/interfaces.md`, `docs/experiments.md`, and `docs/decisions.md` are generated from experiment results; do not hand-edit them as source-of-truth documents.
+- Keep `param/nav2_ndt_urban.yaml` conservative. Long-horizon urban replay is still a known robustness boundary, not a solved production claim.
+- If adding a user-facing script, add it to the `install(PROGRAMS ...)` list in `CMakeLists.txt`.
+- If adding a parameter, keep declarations, YAML presets, README/docs, and diagnostics aligned.
+- Keep `small_gicp` optional behind the existing CMake/config guards.
+- Preserve ROS topic and frame contracts unless the task explicitly changes them.
+
+## Benchmark And Dataset Rules
+
+- Prefer binary little-endian float32 PLY maps for benchmark/runtime validation.
+- Generated PCD maps are acceptable for inspection, but not the preferred benchmark/runtime path.
+- Use a unique `ROS_DOMAIN_ID` for rosbag replay benchmarks to avoid unrelated ROS 2 graph traffic.
+- Istanbul localization-only public runs are default-on no-IMU safety checks; do not describe them as IMU benefit benchmarks.
+- Publishable benchmark claims should use official public datasets such as Autoware Istanbul or the official `hdl_localization` sample, with upstream sources cited.
+- Do not present local field-recorded bags or graph-derived synthetic bags as open benchmark data.
+
+## Generated Files
+
+- Avoid editing or committing generated/heavy local outputs unless the task specifically asks for them.
+- Treat these paths as generated or local workspace state: `build/`, `install/`, `log/`, `data/official/`, `artifacts/`, `../build_ws/`, `../local_prefix/`, `../third_party_build/`, and `../third_party_debs/`.
+- Prefer `/tmp` for ad hoc benchmark output directories.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,12 +113,15 @@ install(PROGRAMS
   scripts/benchmark_runner
   scripts/benchmark_sweep_localizer
   scripts/benchmark_eval_trajectory
+  scripts/benchmark_eval_evo_ape
   scripts/augment_pointcloud_intensity.py
   scripts/scaffold_mapless_public_dataset_bundle.py
   scripts/fetch_official_autoware_istanbul_dataset.sh
   scripts/fetch_koide_hard_pointcloud_localization_dataset.sh
   scripts/fetch_official_hdl_localization_sample.sh
+  scripts/build_gt_aligned_map_from_reference_csv.py
   scripts/tum_trajectory_to_pose_reference_csv.py
+  scripts/tum_trajectory_to_pose_reference_csv_for_rosbag2.py
   scripts/generate_occupancy_map_from_pcd.py
   scripts/make_localization_comparison_report.py
   scripts/publish_cmd_vel_odom.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,33 @@
 # lidar_localization_ros2
 A ROS2 package of 3D LIDAR-based Localization.
 
+## Quick Start
+
+From this repository in the local workspace:
+
+```bash
+source scripts/setup_local_env.sh
+cd ../build_ws
+colcon build --symlink-install --packages-up-to lidar_localization_ros2
+cd ../repo
+source scripts/setup_local_env.sh
+```
+
+Then choose the path that matches what you want to do:
+
+| Goal | Start here |
+|---|---|
+| Build the package in this workspace | [Local Build](docs/local_build.md) |
+| Launch the LiDAR localizer for Nav2 | [Nav2 launch](#nav2-launch) |
+| Run a self-contained Nav2 smoke path | [Recommended entry points](docs/v1_status.md#recommended-entry-points) |
+| Run public replay/regression checks | [Benchmarking](#benchmarking) |
+| Evaluate a rosbag against reference poses | [Benchmarking guide](docs/benchmarking.md) |
+| Develop or compare recovery behavior | [Experiment-First Development](#experiment-first-development) |
+| Check what `v1.0.0` does and does not claim | [v1 status](docs/v1_status.md) |
+
+For Nav2 use, provide a pointcloud map, matching 2D `map_yaml` when launching the full Nav2 stack,
+an odom source publishing `odom -> base_link`, and an initial pose on `/initialpose`.
+
 ## Status
 
 The repo is now packaged as `v1.0.0`.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ and writes a combined summary under `artifacts/public/release_regression_suite/`
 |enable_scan_voxel_filter|bool|true|apply the built-in `VoxelGrid` downsampling pass to each incoming scan before range filtering|
 |enable_debug|bool|false|whether debug is done or not|
 |predict_pose_from_previous_delta|bool|true|use the previous accepted pose delta as the next registration initial guess|
-|enable_local_map_crop|bool|false|crop the PCD target map around the current seed before registration; useful for large city-scale maps that overflow full-map NDT targets|
+|enable_local_map_crop|bool|false|crop the target map around the current seed before registration; useful for large city-scale maps that overflow full-map NDT targets|
 |local_map_radius|double|150.0|radius of the cropped local map around the current seed[m]|
 |local_map_min_points|int|100|minimum number of cropped map points required before attempting registration|
 |reject_above_score_threshold|bool|true|skip pose updates when `fitness_score` exceeds `score_threshold`|
@@ -202,8 +202,17 @@ early correction guard is also parameterized through
 `imu_prediction_correction_guard_yaw_deg`.
 
 The default Nav2 preset also enables `enable_local_map_crop:=true`, which avoids the
-full-map NDT overflow/crash path on large city-scale PCD maps by rebuilding the NDT target
+full-map NDT overflow/crash path on large city-scale pointcloud maps by rebuilding the NDT target
 around the current seed each scan.
+
+### Map Format Notes
+
+- Runtime `map_path` supports `.ply` and `.pcd`, but the current benchmarked path in this repo
+  should prefer `.ply`.
+- For generated benchmark maps, use binary little-endian float32 PLY (`property float x/y/z`).
+- Avoid Open3D's default double-precision PLY output for runtime benchmarking.
+- Generated `.pcd` maps are fine for inspection tools, but they are not the recommended
+  benchmark/runtime path in this repo today.
 
 The Nav2 presets also set `enable_scan_voxel_filter:=false` because the Autoware Istanbul
 `/localization/util/downsample/pointcloud` topic is already downsampled upstream.

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -18,6 +18,16 @@ This repository now includes a small benchmark harness so that localization chan
   - Records `diagnostic_msgs/msg/DiagnosticArray` into CSV
 - `benchmark_eval_trajectory`
   - Compares an estimated trajectory CSV against a reference trajectory CSV
+- `benchmark_eval_evo_ape`
+  - Converts the benchmark CSVs to TUM format and evaluates them with `evo_ape`
+  - Useful when you need a paper-style `ATE` workflow instead of only the built-in RMSE JSON
+- `tum_trajectory_to_pose_reference_csv_for_rosbag2.py`
+  - Crops a TUM trajectory to the time window of a rosbag2 bag and exports benchmark `reference.csv`
+  - Useful for split datasets such as Koide `outdoor_hard_01a` / `01b`, where one GT trajectory spans multiple bag files
+- `build_gt_aligned_map_from_reference_csv.py`
+  - Builds a diagnostic map by transforming PointCloud2 scans with benchmark `reference.csv` poses
+  - Writes float32 binary `.ply` output by default so the runtime stack sees `property float x/y/z`
+  - Useful for proving whether a failure is due to map coverage or to registration itself
 - `benchmark_compare_runs`
   - Aggregates `summary.json`, `trajectory_eval.json`, and `alignment_status.csv`
   - Prints a quick human-readable comparison across multiple run directories
@@ -46,6 +56,15 @@ This repository now includes a small benchmark harness so that localization chan
 colcon build --packages-select lidar_localization_ros2
 source install/setup.bash
 ```
+
+## Map Format Notes
+
+- Runtime manifests accept `.ply` and `.pcd` paths, but current benchmark validation in this repo
+  should prefer `.ply`.
+- For generated maps, use binary little-endian float32 PLY fields (`property float x/y/z`).
+- Avoid Open3D's default double-precision PLY output for runtime benchmarking.
+- Generated `.pcd` maps are still useful for inspection tools, but they are not the recommended
+  benchmark/runtime path in this repo today.
 
 ## Run a benchmark
 
@@ -481,6 +500,51 @@ ros2 run lidar_localization_ros2 benchmark_eval_trajectory \
   --reference-csv /path/to/reference_pose.csv \
   --output-json /tmp/lidarloc_benchmark/run_001/trajectory_eval.json
 ```
+
+To run the same pair through `evo_ape`:
+
+```bash
+ros2 run lidar_localization_ros2 benchmark_eval_evo_ape \
+  --estimated-csv /tmp/lidarloc_benchmark/run_001/pose_trace.csv \
+  --reference-csv /path/to/reference_pose.csv \
+  --output-json /tmp/lidarloc_benchmark/run_001/evo_ape_translation.json \
+  --save-results-zip /tmp/lidarloc_benchmark/run_001/evo_ape_translation.zip
+```
+
+Notes:
+
+- default `--pose-relation trans_part` corresponds to translation APE in meters
+- for datasets already expressed in the same map frame, keep the default unaligned evaluation
+- if you need paper-by-paper comparability, make sure the sequence unit and initialization policy also match
+
+To crop a TUM GT trajectory to the time span of a split rosbag2 sequence:
+
+```bash
+ros2 run lidar_localization_ros2 tum_trajectory_to_pose_reference_csv_for_rosbag2.py \
+  --input data/public/koide_hard_localization/gt/traj_lidar_outdoor_hard_01.txt \
+  --bag-path data/public/koide_hard_localization/sequences/outdoor_hard_01b/outdoor_hard_01b \
+  --output-csv data/public/koide_hard_localization/benchmark/outdoor_hard_01b/reference.csv \
+  --output-initial-pose-yaml data/public/koide_hard_localization/benchmark/outdoor_hard_01b/initial_pose.yaml \
+  --initial-pose-skip-sec 0.05
+```
+
+To build a GT-aligned diagnostic map from a PointCloud2 rosbag2 sequence and a
+reference CSV:
+
+```bash
+ros2 run lidar_localization_ros2 build_gt_aligned_map_from_reference_csv.py \
+  --bag-path data/public/koide_hard_localization/sequences/outdoor_hard_01 \
+  --reference-csv data/public/koide_hard_localization/benchmark/outdoor_hard_01/reference.csv \
+  --cloud-topic /livox/points \
+  --point-stride 10 \
+  --voxel-size 0.5 \
+  --output-map /tmp/koide_outdoor01_gt_map_stride10_voxel05.ply
+```
+
+This is useful as an engineering check when you suspect map-coverage mismatch.
+When writing `.ply`, the helper emits a binary little-endian float32 PLY (`property float x/y/z`)
+because the runtime stack does not behave reliably with Open3D's default double-precision PLY fields.
+Do not use a map built from the same evaluation run for external performance claims.
 
 ## Compare multiple runs
 

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_full.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_full.yaml
@@ -1,0 +1,59 @@
+# Koide Hard Point Cloud Localization — outdoor_hard_01 full sequence (01a + 01b).
+# This manifest is intended for paper-style comparison against Outdoor01 in Koide et al. ICRA 2024.
+#
+# Data setup:
+#   ros2 run lidar_localization_ros2 fetch_koide_hard_pointcloud_localization_dataset.sh \
+#     --with-maps --with-gt --sequence outdoor_hard_01a --sequence outdoor_hard_01b \
+#     --output-dir data/public/koide_hard_localization
+#
+#   # Merge the split rosbag2 sequences into one output bag.
+#   # See ros2/rosbag2 "Converting bags (merge, split, etc.)" examples.
+#   # Example:
+#   #   ros2 bag convert \
+#   #     --input data/public/koide_hard_localization/sequences/outdoor_hard_01a \
+#   #     --input data/public/koide_hard_localization/sequences/outdoor_hard_01b \
+#   #     --output-options /tmp/koide_outdoor_hard_01_merge.yaml
+#
+#   ros2 run lidar_localization_ros2 tum_trajectory_to_pose_reference_csv_for_rosbag2.py \
+#     --input data/public/koide_hard_localization/gt/traj_lidar_outdoor_hard_01.txt \
+#     --bag-path data/public/koide_hard_localization/sequences/outdoor_hard_01 \
+#     --output-csv data/public/koide_hard_localization/benchmark/outdoor_hard_01/reference.csv \
+#     --output-initial-pose-yaml data/public/koide_hard_localization/benchmark/outdoor_hard_01/initial_pose.yaml \
+#     --initial-pose-skip-sec 0.05
+
+mode: run
+
+dataset:
+  bag_path: /absolute/path/to/data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: /absolute/path/to/data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: /absolute/path/to/data/public/koide_hard_localization/benchmark/outdoor_hard_01/reference.csv
+  initial_pose_yaml: /absolute/path/to/data/public/koide_hard_localization/benchmark/outdoor_hard_01/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_full
+  ros_domain_id: 136
+  bag_duration: 0
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_full_gt_diag_map.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_full_gt_diag_map.yaml
@@ -1,0 +1,39 @@
+# Koide Hard Point Cloud Localization — full Outdoor01 on a GT-aligned diagnostic map.
+# This map is built from the same route and is for engineering diagnosis only.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_full_gt_diag_map
+  ros_domain_id: 156
+  bag_duration: 0
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_full_gt_diag_map_ndt_original.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_full_gt_diag_map_ndt_original.yaml
@@ -1,0 +1,40 @@
+# Koide Hard Point Cloud Localization -- full Outdoor01 on the GT-aligned diagnostic map
+# using NDT_OMP with the original diagnostic-map parameter set after the voxfilter fix.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: NDT_OMP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_full_gt_diag_map_ndt_original
+  ros_domain_id: 186
+  bag_duration: 0
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_full_gt_diag_map_ndt_smallgicp_params.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_full_gt_diag_map_ndt_smallgicp_params.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- full Outdoor01 on the GT-aligned diagnostic map
+# using NDT_OMP with the same runtime envelope as the SMALL_GICP diagnostic manifest.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: NDT_OMP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 15.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_full_gt_diag_map_ndt_smallgicp_params
+  ros_domain_id: 185
+  bag_duration: 0
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_full_gt_diag_map_small_gicp.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_full_gt_diag_map_small_gicp.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- full Outdoor01 on the GT-aligned diagnostic map
+# using SMALL_GICP to measure the route-wide ceiling once map coverage is no longer the blocker.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 15.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_full_gt_diag_map_small_gicp
+  ros_domain_id: 158
+  bag_duration: 0
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_full_gt_diag_map_small_gicp_2way_score_range.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_full_gt_diag_map_small_gicp_2way_score_range.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- full Outdoor01 on the GT-aligned diagnostic map
+# using SMALL_GICP with the best late-window 2-way combination: score=25 and range=80.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 80.0
+    score_threshold: 25.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_full_gt_diag_map_small_gicp_2way_score_range
+  ros_domain_id: 183
+  bag_duration: 0
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_full_gt_diag_map_small_gicp_crop120.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_full_gt_diag_map_small_gicp_crop120.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- full Outdoor01 on the GT-aligned diagnostic map
+# using SMALL_GICP with a wider local map crop to test survival beyond the +214 s ceiling.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 15.0
+    local_map_radius: 120.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_full_gt_diag_map_small_gicp_crop120
+  ros_domain_id: 159
+  bag_duration: 0
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_full_gt_diag_map_small_gicp_tuned.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_full_gt_diag_map_small_gicp_tuned.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- full Outdoor01 on the GT-aligned
+# diagnostic map using the tuned SMALL_GICP envelope from the late-window retry.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 80.0
+    score_threshold: 25.0
+    local_map_radius: 100.0
+    gicp_max_correspondence_distance: 5.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_full_gt_diag_map_small_gicp_tuned
+  ros_domain_id: 163
+  bag_duration: 0
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_150_120_gt_diag_map_small_gicp.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_150_120_gt_diag_map_small_gicp.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- Outdoor01 window starting at +150s
+# on the GT-aligned diagnostic map using SMALL_GICP.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_150_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_150_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 15.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_150_120_gt_diag_map_small_gicp
+  ros_domain_id: 159
+  bag_duration: 120
+  bag_start_offset: 150
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_15_120.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_15_120.yaml
@@ -1,0 +1,50 @@
+# Koide Hard Point Cloud Localization — Outdoor01 failure-onset replay window.
+# This window starts shortly before the first reject streak seen in the full 01a+01b run.
+#
+# Generate the offset-specific reference / initial pose first:
+#   ros2 run lidar_localization_ros2 tum_trajectory_to_pose_reference_csv_for_rosbag2.py \
+#     --input data/public/koide_hard_localization/gt/traj_lidar_outdoor_hard_01.txt \
+#     --bag-path data/public/koide_hard_localization/sequences/outdoor_hard_01 \
+#     --output-csv data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_15_120/reference.csv \
+#     --output-initial-pose-yaml data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_15_120/initial_pose.yaml \
+#     --initial-pose-skip-sec 0.05 \
+#     --bag-start-offset 15 \
+#     --bag-duration 120
+
+mode: sweep
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_15_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_15_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_15_120_compare
+  config_json: repo://param/benchmark/koide_hard_localization_outdoor_hard_01_window_15_120_recovery_compare.json
+  ros_domain_base: 140
+  bag_duration: 120
+  bag_start_offset: 15
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_15_120_original_map_pcd.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_15_120_original_map_pcd.yaml
@@ -1,0 +1,39 @@
+# Koide Hard Point Cloud Localization -- early Outdoor01 replay window on the original map,
+# converted to float32 PCD to isolate the PCD loader path from diagnostic-map content.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard.pcd
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_15_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_15_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_15_120_original_map_pcd
+  ros_domain_id: 156
+  bag_duration: 120
+  bag_start_offset: 15
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_15_120_recovery_compare.json
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_15_120_recovery_compare.json
@@ -1,0 +1,69 @@
+{
+  "common_params": {
+    "registration_method": "NDT_OMP",
+    "score_threshold": 6.0,
+    "ndt_resolution": 1.0,
+    "ndt_step_size": 0.1,
+    "ndt_num_threads": 4,
+    "ndt_max_iterations": 35,
+    "transform_epsilon": 0.01,
+    "voxel_leaf_size": 0.5,
+    "enable_scan_voxel_filter": true,
+    "scan_min_range": 1.0,
+    "scan_max_range": 100.0,
+    "predict_pose_from_previous_delta": true,
+    "reject_above_score_threshold": true,
+    "use_imu": false,
+    "use_imu_preintegration": false,
+    "use_odom": false,
+    "enable_debug": false,
+    "use_twist_prediction": true,
+    "twist_prediction_use_angular_velocity": false,
+    "max_twist_prediction_dt": 0.5,
+    "enable_local_map_crop": true,
+    "local_map_radius": 150.0,
+    "local_map_min_points": 100,
+    "enable_borderline_seed_rejection_gate": true,
+    "borderline_seed_gate_score_threshold": 5.25,
+    "borderline_seed_gate_min_seed_translation_m": 1.0,
+    "base_frame_id": "livox_frame"
+  },
+  "runs": [
+    {
+      "name": "baseline"
+    },
+    {
+      "name": "recovery_retry_r3_gap1_seed15",
+      "params": {
+        "enable_recovery_retry_from_last_pose": true,
+        "recovery_retry_from_last_pose_min_rejections": 3,
+        "recovery_retry_from_last_pose_max_accepted_gap_sec": 1.0,
+        "recovery_retry_from_last_pose_max_seed_translation_m": 15.0
+      }
+    },
+    {
+      "name": "rejected_seed_update_r3_fit10_t3_yaw8",
+      "params": {
+        "enable_rejected_seed_update": true,
+        "rejected_seed_update_min_rejections": 3,
+        "rejected_seed_update_max_fitness": 10.0,
+        "rejected_seed_update_max_correction_translation_m": 3.0,
+        "rejected_seed_update_max_correction_yaw_deg": 8.0
+      }
+    },
+    {
+      "name": "combined_retry_and_seed_update",
+      "params": {
+        "enable_recovery_retry_from_last_pose": true,
+        "recovery_retry_from_last_pose_min_rejections": 3,
+        "recovery_retry_from_last_pose_max_accepted_gap_sec": 1.0,
+        "recovery_retry_from_last_pose_max_seed_translation_m": 15.0,
+        "enable_rejected_seed_update": true,
+        "rejected_seed_update_min_rejections": 3,
+        "rejected_seed_update_max_fitness": 10.0,
+        "rejected_seed_update_max_correction_translation_m": 3.0,
+        "rejected_seed_update_max_correction_yaw_deg": 8.0
+      }
+    }
+  ]
+}

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_180_120_gt_diag_map_small_gicp.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_180_120_gt_diag_map_small_gicp.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- Outdoor01 window starting at +180s
+# on the GT-aligned diagnostic map using SMALL_GICP.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_180_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_180_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 15.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_180_120_gt_diag_map_small_gicp
+  ros_domain_id: 160
+  bag_duration: 120
+  bag_start_offset: 180
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_240_120_gt_diag_map_small_gicp.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_240_120_gt_diag_map_small_gicp.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- Outdoor01 window starting at +240s
+# on the GT-aligned diagnostic map using SMALL_GICP.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_240_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_240_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 15.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_240_120_gt_diag_map_small_gicp
+  ros_domain_id: 161
+  bag_duration: 120
+  bag_start_offset: 240
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120.yaml
@@ -1,0 +1,50 @@
+# Koide Hard Point Cloud Localization — Outdoor01 late replay window.
+# This uses a GT-derived initial pose well after the full-run failure point to
+# check whether the later segment is still locally matchable when seeded well.
+#
+# Generate the offset-specific reference / initial pose first:
+#   ros2 run lidar_localization_ros2 tum_trajectory_to_pose_reference_csv_for_rosbag2.py \
+#     --input data/public/koide_hard_localization/gt/traj_lidar_outdoor_hard_01.txt \
+#     --bag-path data/public/koide_hard_localization/sequences/outdoor_hard_01 \
+#     --output-csv data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv \
+#     --output-initial-pose-yaml data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml \
+#     --initial-pose-skip-sec 0.05 \
+#     --bag-start-offset 300 \
+#     --bag-duration 120
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120
+  ros_domain_id: 145
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_dense_ndt.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_dense_ndt.yaml
@@ -1,0 +1,38 @@
+# Koide Hard Point Cloud Localization — Outdoor01 late replay window with denser NDT input.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_dense_ndt
+  ros_domain_id: 150
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_dense_ndt_crop80.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_dense_ndt_crop80.yaml
@@ -1,0 +1,40 @@
+# Koide Hard Point Cloud Localization — Outdoor01 late replay window with denser NDT input
+# and tighter local-map crop.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+    local_map_radius: 80.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_dense_ndt_crop80
+  ros_domain_id: 151
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_dense_ndt_crop80_range60.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_dense_ndt_crop80_range60.yaml
@@ -1,0 +1,40 @@
+# Koide Hard Point Cloud Localization — Outdoor01 late replay window with denser NDT input,
+# tighter local-map crop, and shorter range clamp.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 6.0
+    local_map_radius: 80.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_dense_ndt_crop80_range60
+  ros_domain_id: 152
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map.yaml
@@ -1,0 +1,39 @@
+# Koide Hard Point Cloud Localization — late Outdoor01 window on a GT-aligned diagnostic map.
+# This map is built from the same route and is for engineering diagnosis only.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map
+  ros_domain_id: 155
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_crop.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_crop.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned
+# diagnostic map using NDT_OMP with only the local map crop radius widened.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: NDT_OMP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 15.0
+    local_map_radius: 150.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_crop
+  ros_domain_id: 173
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_range.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_range.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned
+# diagnostic map using NDT_OMP with only the max scan range widened.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: NDT_OMP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 15.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_range
+  ros_domain_id: 172
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_score.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_score.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned
+# diagnostic map using NDT_OMP with only the fitness score threshold relaxed.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: NDT_OMP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 6.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_score
+  ros_domain_id: 174
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_voxfilter.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_voxfilter.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned
+# diagnostic map using NDT_OMP with only scan voxel filtering re-enabled.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: NDT_OMP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 15.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_voxfilter
+  ros_domain_id: 170
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_voxsize.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_voxsize.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned
+# diagnostic map using NDT_OMP with only the scan voxel leaf size widened.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: NDT_OMP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 15.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_ndt_bisect_voxsize
+  ros_domain_id: 171
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_ndt_smallgicp_params.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_ndt_smallgicp_params.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned diagnostic map
+# using NDT_OMP with the same runtime envelope as the SMALL_GICP diagnostic manifest.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: NDT_OMP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 15.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_ndt_smallgicp_params
+  ros_domain_id: 158
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_pcd.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_pcd.yaml
@@ -1,0 +1,39 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on a GT-aligned diagnostic map.
+# This variant uses a float32 PCD map to avoid Open3D's double-precision PLY encoding.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.pcd
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_pcd
+  ros_domain_id: 155
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_pcd_no_crop.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_pcd_no_crop.yaml
@@ -1,0 +1,40 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on a GT-aligned diagnostic map.
+# This variant disables local map cropping to isolate crop-path issues from registration quality.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.pcd
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+    enable_local_map_crop: false
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_pcd_no_crop
+  ros_domain_id: 155
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned diagnostic map
+# using SMALL_GICP to separate NDT-specific failures from map-coverage issues.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 15.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp
+  ros_domain_id: 157
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_2way_corr_range.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_2way_corr_range.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned diagnostic map
+# using SMALL_GICP with corr=5 and range=80.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 80.0
+    score_threshold: 15.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 5.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_2way_corr_range
+  ros_domain_id: 180
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_2way_score_corr.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_2way_score_corr.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned diagnostic map
+# using SMALL_GICP with score=25 and corr=5.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 25.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 5.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_2way_score_corr
+  ros_domain_id: 182
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_2way_score_range.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_2way_score_range.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned diagnostic map
+# using SMALL_GICP with score=25 and range=80.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 80.0
+    score_threshold: 25.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_2way_score_range
+  ros_domain_id: 181
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_iso_corr.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_iso_corr.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned
+# diagnostic map using SMALL_GICP with only the correspondence distance widened.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 15.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 5.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_iso_corr
+  ros_domain_id: 176
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_iso_crop.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_iso_crop.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned
+# diagnostic map using SMALL_GICP with only the local crop radius widened.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 15.0
+    local_map_radius: 100.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_iso_crop
+  ros_domain_id: 177
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_iso_range.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_iso_range.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned
+# diagnostic map using SMALL_GICP with only the max scan range widened.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 80.0
+    score_threshold: 15.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_iso_range
+  ros_domain_id: 178
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_iso_score.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_iso_score.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned
+# diagnostic map using SMALL_GICP with only the score threshold widened.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 25.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_iso_score
+  ros_domain_id: 175
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_tuned.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_tuned.yaml
@@ -1,0 +1,43 @@
+# Koide Hard Point Cloud Localization -- late Outdoor01 window on the GT-aligned
+# diagnostic map using SMALL_GICP with a wider correspondence and crop envelope.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard_full_gt_stride10_voxel05.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 80.0
+    score_threshold: 25.0
+    local_map_radius: 100.0
+    gicp_max_correspondence_distance: 5.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_gt_diag_map_small_gicp_tuned
+  ros_domain_id: 162
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_measurement.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_measurement.yaml
@@ -1,0 +1,42 @@
+# Koide Hard Point Cloud Localization — Outdoor01 late replay window measurement sweep.
+# Use this after generating:
+#   data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+#   data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+
+mode: sweep
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_measurement_compare
+  config_json: repo://param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_measurement_compare.json
+  ros_domain_base: 150
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_measurement_compare.json
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_measurement_compare.json
@@ -1,0 +1,60 @@
+{
+  "common_params": {
+    "registration_method": "NDT_OMP",
+    "score_threshold": 6.0,
+    "ndt_resolution": 1.0,
+    "ndt_step_size": 0.1,
+    "ndt_num_threads": 4,
+    "ndt_max_iterations": 35,
+    "transform_epsilon": 0.01,
+    "voxel_leaf_size": 0.5,
+    "enable_scan_voxel_filter": true,
+    "scan_min_range": 1.0,
+    "scan_max_range": 100.0,
+    "predict_pose_from_previous_delta": true,
+    "reject_above_score_threshold": true,
+    "use_imu": false,
+    "use_imu_preintegration": false,
+    "use_odom": false,
+    "enable_debug": false,
+    "use_twist_prediction": true,
+    "twist_prediction_use_angular_velocity": false,
+    "max_twist_prediction_dt": 0.5,
+    "enable_local_map_crop": true,
+    "local_map_radius": 150.0,
+    "local_map_min_points": 100,
+    "enable_borderline_seed_rejection_gate": true,
+    "borderline_seed_gate_score_threshold": 5.25,
+    "borderline_seed_gate_min_seed_translation_m": 1.0,
+    "base_frame_id": "livox_frame"
+  },
+  "runs": [
+    {
+      "name": "baseline"
+    },
+    {
+      "name": "dense_ndt",
+      "params": {
+        "enable_scan_voxel_filter": false,
+        "voxel_leaf_size": 0.2
+      }
+    },
+    {
+      "name": "dense_ndt_crop80",
+      "params": {
+        "enable_scan_voxel_filter": false,
+        "voxel_leaf_size": 0.2,
+        "local_map_radius": 80.0
+      }
+    },
+    {
+      "name": "dense_ndt_crop80_range60",
+      "params": {
+        "enable_scan_voxel_filter": false,
+        "voxel_leaf_size": 0.2,
+        "local_map_radius": 80.0,
+        "scan_max_range": 60.0
+      }
+    }
+  ]
+}

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_small_gicp.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01_window_300_120_small_gicp.yaml
@@ -1,0 +1,42 @@
+# Koide Hard Point Cloud Localization — Outdoor01 late replay window with SMALL_GICP.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01_window_300_120/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: SMALL_GICP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: false
+    voxel_leaf_size: 0.2
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 60.0
+    score_threshold: 15.0
+    local_map_radius: 80.0
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.5
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01_window_300_120_small_gicp
+  ros_domain_id: 153
+  bag_duration: 120
+  bag_start_offset: 300
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01a_rejected_seed_update.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01a_rejected_seed_update.yaml
@@ -1,0 +1,45 @@
+# Koide Hard Point Cloud Localization — outdoor_hard_01a with rejected-seed-update recovery.
+# This candidate came from the Outdoor01 failure-onset replay sweep and is meant to
+# test whether we can extend tracking beyond the current ~22 s wall on 01a.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01a
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01a/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01a/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+    enable_rejected_seed_update: true
+    rejected_seed_update_min_rejections: 3
+    rejected_seed_update_max_fitness: 10.0
+    rejected_seed_update_max_correction_translation_m: 3.0
+    rejected_seed_update_max_correction_yaw_deg: 8.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01a_rejected_seed_update
+  ros_domain_id: 146
+  bag_duration: 380
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01b.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01b.yaml
@@ -1,0 +1,40 @@
+# Koide Hard Point Cloud Localization — outdoor_hard_01b (split second half of Outdoor01).
+# Use this to test whether localization recovers once the trajectory re-enters the
+# coverage of map_outdoor_hard.ply.
+
+mode: run
+
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01b/outdoor_hard_01b
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01b/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01b/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_outdoor_hard_01b
+  ros_domain_id: 154
+  bag_duration: 302
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_run_manifest.example.yaml
+++ b/param/benchmark/koide_hard_localization_run_manifest.example.yaml
@@ -1,0 +1,50 @@
+# Example benchmark manifest: Koide "Hard Point Cloud Localization Dataset" (Zenodo 10122133).
+# Indoor sequence indoor_easy_01: map map_indoor_easy.ply, topics /points2/decompressed + /imu.
+#
+# Prepare data:
+#   scripts/fetch_koide_hard_pointcloud_localization_dataset.sh --with-maps --with-gt --sequence indoor_easy_01
+# Find bag path:
+#   find data/public/koide_hard_localization -path '*/indoor_easy_01*' -name metadata.yaml
+# Reference + initial pose from shipped TUM trajectory:
+#   ros2 run lidar_localization_ros2 tum_trajectory_to_pose_reference_csv.py \
+#     --input  data/public/koide_hard_localization/gt/traj_lidar_indoor_easy_01.txt \
+#     --output-csv /tmp/koide_hard_indoor_easy_01_reference.csv \
+#     --output-initial-pose-yaml /tmp/koide_hard_indoor_easy_01_initial_pose.yaml \
+#     --initial-pose-skip-sec 0.05
+#
+# Copy this file to e.g. param/benchmark/koide_hard_localization.local.yaml and replace paths.
+# Citation: https://doi.org/10.5281/zenodo.10122133
+
+mode: run
+
+dataset:
+  bag_path: /absolute/path/to/indoor_easy_01_rosbag2_directory
+  map_path: /absolute/path/to/map_indoor_easy.ply
+  reference_csv: /absolute/path/to/koide_hard_indoor_easy_01_reference.csv
+  initial_pose_yaml: /absolute/path/to/koide_hard_indoor_easy_01_initial_pose.yaml
+  cloud_topic: /points2/decompressed
+  imu_topic: /imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: true
+    use_imu_preintegration: true
+    use_twist_prediction: true
+    scan_min_range: 0.3
+  launch_args:
+    - use_sim_time:=true
+    - use_dataset_tf_tree:=true
+    - dataset_root_frame:=camera_base
+
+benchmark:
+  output_dir: /tmp/lidarloc_koide_hard_indoor_easy_01
+  ros_domain_id: 133
+  bag_duration: 60
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/scripts/benchmark_eval_evo_ape
+++ b/scripts/benchmark_eval_evo_ape
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Dict
+from typing import Optional
+
+
+def count_csv_rows(path: Path) -> int:
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        return max(sum(1 for _ in stream) - 1, 0)
+
+
+def write_tum_trajectory(csv_path: Path, tum_path: Path) -> None:
+    with csv_path.open("r", encoding="utf-8", newline="") as stream:
+        reader = csv.DictReader(stream)
+        with tum_path.open("w", encoding="utf-8") as output:
+            for row in reader:
+                output.write(
+                    f"{float(row['stamp_sec']):.9f} "
+                    f"{float(row['position_x']):.10f} "
+                    f"{float(row['position_y']):.10f} "
+                    f"{float(row['position_z']):.10f} "
+                    f"{float(row['orientation_x']):.10f} "
+                    f"{float(row['orientation_y']):.10f} "
+                    f"{float(row['orientation_z']):.10f} "
+                    f"{float(row['orientation_w']):.10f}\n"
+                )
+
+
+def load_zip_json(archive_path: Path, member_name: str) -> Dict[str, object]:
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        with archive.open(member_name, "r") as stream:
+            return json.loads(stream.read().decode("utf-8"))
+
+
+def maybe_load_matched_sample_count(archive_path: Path) -> Optional[int]:
+    try:
+        import numpy as np
+    except ImportError:
+        return None
+
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        with archive.open("timestamps.npy", "r") as stream:
+            timestamps = np.load(stream, allow_pickle=False)
+            return int(timestamps.shape[0])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate pose/reference CSV files with evo_ape after converting them to TUM format."
+    )
+    parser.add_argument("--estimated-csv", required=True)
+    parser.add_argument("--reference-csv", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument(
+        "--max-time-diff",
+        type=float,
+        default=0.05,
+        help="Maximum timestamp difference for evo data association",
+    )
+    parser.add_argument(
+        "--pose-relation",
+        default="trans_part",
+        choices=["full", "trans_part", "rot_part", "angle_deg", "angle_rad", "point_distance"],
+        help="evo_ape pose relation",
+    )
+    parser.add_argument("--align", action="store_true", help="Apply Umeyama alignment in evo_ape")
+    parser.add_argument("--align-origin", action="store_true", help="Align trajectory origin in evo_ape")
+    parser.add_argument("--correct-scale", action="store_true", help="Enable scale correction in evo_ape")
+    parser.add_argument(
+        "--save-results-zip",
+        default="",
+        help="Optional path to copy the evo results zip for later inspection",
+    )
+    parser.add_argument(
+        "--save-estimated-tum",
+        default="",
+        help="Optional path to persist the converted estimated TUM trajectory",
+    )
+    parser.add_argument(
+        "--save-reference-tum",
+        default="",
+        help="Optional path to persist the converted reference TUM trajectory",
+    )
+    parser.add_argument(
+        "--evo-binary",
+        default="evo_ape",
+        help="evo_ape executable name or absolute path",
+    )
+    args = parser.parse_args()
+
+    estimated_csv = Path(args.estimated_csv).expanduser().resolve()
+    reference_csv = Path(args.reference_csv).expanduser().resolve()
+    output_json = Path(args.output_json).expanduser().resolve()
+
+    evo_binary = shutil.which(args.evo_binary) if os.sep not in args.evo_binary else args.evo_binary
+    if not evo_binary:
+        raise RuntimeError(f"Could not find evo binary: {args.evo_binary}")
+
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="benchmark_eval_evo_ape_") as temp_dir_raw:
+        temp_dir = Path(temp_dir_raw)
+        estimated_tum = temp_dir / "estimated.tum"
+        reference_tum = temp_dir / "reference.tum"
+        results_zip = temp_dir / "evo_results.zip"
+
+        write_tum_trajectory(estimated_csv, estimated_tum)
+        write_tum_trajectory(reference_csv, reference_tum)
+
+        if args.save_estimated_tum:
+            save_estimated_tum = Path(args.save_estimated_tum).expanduser().resolve()
+            save_estimated_tum.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(estimated_tum, save_estimated_tum)
+        else:
+            save_estimated_tum = None
+
+        if args.save_reference_tum:
+            save_reference_tum = Path(args.save_reference_tum).expanduser().resolve()
+            save_reference_tum.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(reference_tum, save_reference_tum)
+        else:
+            save_reference_tum = None
+
+        command = [
+            evo_binary,
+            "tum",
+            str(reference_tum),
+            str(estimated_tum),
+            "--pose_relation",
+            args.pose_relation,
+            "--t_max_diff",
+            str(args.max_time_diff),
+            "--save_results",
+            str(results_zip),
+            "--no_warnings",
+        ]
+        if args.align:
+            command.append("--align")
+        if args.align_origin:
+            command.append("--align_origin")
+        if args.correct_scale:
+            command.append("--correct_scale")
+
+        completed = subprocess.run(command, capture_output=True, text=True, check=False)
+        if completed.returncode != 0:
+            raise RuntimeError(
+                "evo_ape failed:\n"
+                f"command: {' '.join(command)}\n"
+                f"stdout:\n{completed.stdout}\n"
+                f"stderr:\n{completed.stderr}"
+            )
+
+        info_json = load_zip_json(results_zip, "info.json")
+        stats_json = load_zip_json(results_zip, "stats.json")
+        matched_sample_count = maybe_load_matched_sample_count(results_zip)
+
+        saved_results_zip = None
+        if args.save_results_zip:
+            saved_results_zip = Path(args.save_results_zip).expanduser().resolve()
+            saved_results_zip.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(results_zip, saved_results_zip)
+
+    result = {
+        "estimated_csv": str(estimated_csv),
+        "reference_csv": str(reference_csv),
+        "estimated_sample_count": count_csv_rows(estimated_csv),
+        "reference_sample_count": count_csv_rows(reference_csv),
+        "matched_sample_count": matched_sample_count,
+        "pose_relation": args.pose_relation,
+        "max_time_diff": args.max_time_diff,
+        "align": args.align,
+        "align_origin": args.align_origin,
+        "correct_scale": args.correct_scale,
+        "evo_binary": str(evo_binary),
+        "evo_command": command,
+        "evo_stdout": completed.stdout,
+        "evo_stderr": completed.stderr,
+        "info": info_json,
+        "stats": stats_json,
+        "rmse": stats_json.get("rmse"),
+        "saved_results_zip": str(saved_results_zip) if saved_results_zip else None,
+        "saved_estimated_tum": str(save_estimated_tum) if save_estimated_tum else None,
+        "saved_reference_tum": str(save_reference_tum) if save_reference_tum else None,
+    }
+
+    with output_json.open("w", encoding="utf-8") as stream:
+        json.dump(result, stream, indent=2, sort_keys=True)
+        stream.write("\n")
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_gt_aligned_map_from_reference_csv.py
+++ b/scripts/build_gt_aligned_map_from_reference_csv.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+
+"""Build a GT-aligned point cloud map from a rosbag2 PointCloud2 topic."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+import numpy as np
+import open3d as o3d
+from rosbags.rosbag2 import Reader
+from rosbags.typesys import Stores
+from rosbags.typesys import get_typestore
+
+
+TYPESTORE = get_typestore(Stores.ROS2_HUMBLE)
+SUPPORTED_OUTPUT_SUFFIXES = {".ply", ".pcd"}
+
+
+@dataclass
+class BuildStats:
+    scan_count_seen: int = 0
+    used_scans: int = 0
+    skipped_no_pose: int = 0
+    raw_points: int = 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a GT-aligned map by transforming PointCloud2 scans with reference poses."
+    )
+    parser.add_argument("--bag-path", required=True, help="Path to the rosbag2 directory")
+    parser.add_argument("--reference-csv", required=True, help="Reference CSV with pose rows in map frame")
+    parser.add_argument(
+        "--output-map",
+        required=True,
+        help=(
+            "Destination .ply/.pcd path. Prefer .ply for benchmark/runtime use; this helper writes "
+            "float32 binary PLY instead of Open3D's default double-precision PLY fields."
+        ),
+    )
+    parser.add_argument("--cloud-topic", default="/velodyne_points", help="PointCloud2 topic name")
+    parser.add_argument("--point-stride", type=int, default=10, help="Keep every Nth scan")
+    parser.add_argument("--voxel-size", type=float, default=0.5, help="Voxel downsample size in meters")
+    parser.add_argument("--min-range", type=float, default=1.0, help="Minimum sensor-frame range")
+    parser.add_argument("--max-range", type=float, default=100.0, help="Maximum sensor-frame range")
+    parser.add_argument("--max-time-diff", type=float, default=0.05, help="Pose matching tolerance")
+    parser.add_argument("--print-every", type=int, default=20, help="Print progress every N used scans")
+    return parser.parse_args()
+
+
+def load_reference_csv(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    stamps = []
+    positions = []
+    quaternions = []
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        reader = csv.DictReader(stream)
+        for row in reader:
+            stamps.append(float(row["stamp_sec"]))
+            positions.append(
+                [float(row["position_x"]), float(row["position_y"]), float(row["position_z"])]
+            )
+            quaternions.append(
+                [
+                    float(row["orientation_x"]),
+                    float(row["orientation_y"]),
+                    float(row["orientation_z"]),
+                    float(row["orientation_w"]),
+                ]
+            )
+    if not stamps:
+        raise RuntimeError(f"No rows found in reference CSV: {path}")
+    return (
+        np.asarray(stamps, dtype=np.float64),
+        np.asarray(positions, dtype=np.float64),
+        np.asarray(quaternions, dtype=np.float64),
+    )
+
+
+def quaternion_to_rotation_matrix(quaternion: np.ndarray) -> np.ndarray:
+    x, y, z, w = quaternion
+    return np.array(
+        [
+            [1.0 - 2.0 * (y * y + z * z), 2.0 * (x * y - z * w), 2.0 * (x * z + y * w)],
+            [2.0 * (x * y + z * w), 1.0 - 2.0 * (x * x + z * z), 2.0 * (y * z - x * w)],
+            [2.0 * (x * z - y * w), 2.0 * (y * z + x * w), 1.0 - 2.0 * (x * x + y * y)],
+        ],
+        dtype=np.float64,
+    )
+
+
+def nearest_pose(
+    stamp_sec: float,
+    reference_stamps: np.ndarray,
+    reference_positions: np.ndarray,
+    reference_quaternions: np.ndarray,
+    max_time_diff: float,
+) -> tuple[np.ndarray, np.ndarray] | None:
+    index = int(np.searchsorted(reference_stamps, stamp_sec))
+    candidates = []
+    if index < len(reference_stamps):
+        candidates.append(index)
+    if index > 0:
+        candidates.append(index - 1)
+    if not candidates:
+        return None
+    best_index = min(candidates, key=lambda idx: abs(reference_stamps[idx] - stamp_sec))
+    if abs(reference_stamps[best_index] - stamp_sec) > max_time_diff:
+        return None
+    return reference_positions[best_index], reference_quaternions[best_index]
+
+
+def pointcloud2_xyz_array(message) -> np.ndarray:
+    field_offsets = {field.name: int(field.offset) for field in message.fields}
+    for field_name in ("x", "y", "z"):
+        if field_name not in field_offsets:
+            raise RuntimeError(f"PointCloud2 is missing required field: {field_name}")
+
+    endian = ">" if bool(message.is_bigendian) else "<"
+    dtype = np.dtype(
+        {
+            "names": ["x", "y", "z"],
+            "formats": [f"{endian}f4", f"{endian}f4", f"{endian}f4"],
+            "offsets": [field_offsets["x"], field_offsets["y"], field_offsets["z"]],
+            "itemsize": int(message.point_step),
+        }
+    )
+    array = np.frombuffer(bytes(message.data), dtype=dtype, count=int(message.width * message.height))
+    return np.column_stack([array["x"], array["y"], array["z"]]).astype(np.float32, copy=False)
+
+
+def voxel_downsample(points: np.ndarray, voxel_size: float) -> np.ndarray:
+    if voxel_size <= 0.0 or len(points) == 0:
+        return points
+    quantized = np.floor(points / voxel_size).astype(np.int64)
+    _, keep_indices = np.unique(quantized, axis=0, return_index=True)
+    keep_indices.sort()
+    return points[keep_indices]
+
+
+def filter_sensor_points(xyz_sensor: np.ndarray, min_range: float, max_range: float) -> np.ndarray:
+    if len(xyz_sensor) == 0:
+        return xyz_sensor
+    ranges = np.linalg.norm(xyz_sensor, axis=1)
+    valid = np.isfinite(xyz_sensor).all(axis=1)
+    valid &= ranges >= min_range
+    valid &= ranges <= max_range
+    return xyz_sensor[valid]
+
+
+def write_binary_float32_ply(path: Path, points: np.ndarray) -> None:
+    xyz = np.asarray(points, dtype=np.float32, order="C")
+    header = (
+        "ply\n"
+        "format binary_little_endian 1.0\n"
+        "comment Generated by build_gt_aligned_map_from_reference_csv.py\n"
+        f"element vertex {xyz.shape[0]}\n"
+        "property float x\n"
+        "property float y\n"
+        "property float z\n"
+        "end_header\n"
+    ).encode("ascii")
+    with path.open("wb") as stream:
+        stream.write(header)
+        stream.write(xyz.astype("<f4", copy=False).tobytes())
+
+
+def write_output_map(path: Path, points: np.ndarray) -> None:
+    suffix = path.suffix.lower()
+    if suffix not in SUPPORTED_OUTPUT_SUFFIXES:
+        supported = ", ".join(sorted(SUPPORTED_OUTPUT_SUFFIXES))
+        raise RuntimeError(f"Unsupported output suffix {suffix!r}; expected one of: {supported}")
+
+    if suffix == ".ply":
+        # Open3D writes x/y/z as double-precision PLY properties, but this stack's PCL loader only
+        # behaves reliably with float32 PLY fields (`property float x/y/z`), like the CloudCompare
+        # maps already used elsewhere in the repo.
+        write_binary_float32_ply(path, points)
+        return
+
+    print(
+        "warning: .pcd output is kept for inspection tools, but current benchmark/runtime validation "
+        "in this repo prefers float32 .ply maps",
+        file=sys.stderr,
+    )
+    point_cloud = o3d.geometry.PointCloud()
+    point_cloud.points = o3d.utility.Vector3dVector(points.astype(np.float64, copy=False))
+    if not o3d.io.write_point_cloud(str(path), point_cloud):
+        raise RuntimeError(f"Failed to write point cloud: {path}")
+
+
+def print_summary(
+    bag_path: Path,
+    reference_csv: Path,
+    cloud_topic: str,
+    voxel_size: float,
+    output_map: Path,
+    points: np.ndarray,
+    stats: BuildStats,
+) -> None:
+    print(f"bag_path: {bag_path}")
+    print(f"reference_csv: {reference_csv}")
+    print(f"cloud_topic: {cloud_topic}")
+    print(f"scan_count_seen: {stats.scan_count_seen}")
+    print(f"used_scans: {stats.used_scans}")
+    print(f"skipped_no_pose: {stats.skipped_no_pose}")
+    print(f"raw_points: {stats.raw_points}")
+    print(f"voxel_size: {voxel_size}")
+    print(f"points_after_voxel: {int(points.shape[0])}")
+    print(f"map_bounds_min: {points.min(axis=0).tolist()}")
+    print(f"map_bounds_max: {points.max(axis=0).tolist()}")
+    print(f"output_map: {output_map}")
+
+
+def main() -> int:
+    args = parse_args()
+    bag_path = Path(args.bag_path).expanduser().resolve()
+    reference_csv = Path(args.reference_csv).expanduser().resolve()
+    output_map = Path(args.output_map).expanduser().resolve()
+
+    reference_stamps, reference_positions, reference_quaternions = load_reference_csv(reference_csv)
+
+    reader = Reader(str(bag_path))
+    reader.open()
+
+    stats = BuildStats()
+    chunks: list[np.ndarray] = []
+
+    for connection, _, rawdata in reader.messages():
+        if connection.topic != args.cloud_topic:
+            continue
+
+        stats.scan_count_seen += 1
+        if args.point_stride > 1 and (stats.scan_count_seen - 1) % args.point_stride != 0:
+            continue
+
+        message = TYPESTORE.deserialize_cdr(rawdata, connection.msgtype)
+        stamp_sec = float(message.header.stamp.sec) + float(message.header.stamp.nanosec) * 1e-9
+
+        pose = nearest_pose(
+            stamp_sec,
+            reference_stamps,
+            reference_positions,
+            reference_quaternions,
+            float(args.max_time_diff),
+        )
+        if pose is None:
+            stats.skipped_no_pose += 1
+            continue
+
+        xyz_sensor = pointcloud2_xyz_array(message)
+        xyz_sensor = filter_sensor_points(
+            xyz_sensor,
+            float(args.min_range),
+            float(args.max_range),
+        )
+        if len(xyz_sensor) == 0:
+            continue
+
+        position, quaternion = pose
+        rotation = quaternion_to_rotation_matrix(quaternion)
+        xyz_map = (xyz_sensor @ rotation.T) + position
+        xyz_map = xyz_map.astype(np.float32, copy=False)
+        chunks.append(xyz_map)
+        stats.used_scans += 1
+        stats.raw_points += int(xyz_map.shape[0])
+
+        if args.print_every > 0 and stats.used_scans % args.print_every == 0:
+            print(f"used_scans={stats.used_scans} raw_points={stats.raw_points}")
+
+    reader.close()
+
+    if not chunks:
+        raise RuntimeError("No scans were transformed into the map.")
+
+    points = np.vstack(chunks)
+    points = voxel_downsample(points, float(args.voxel_size))
+
+    output_map.parent.mkdir(parents=True, exist_ok=True)
+    write_output_map(output_map, points)
+    print_summary(
+        bag_path,
+        reference_csv,
+        args.cloud_topic,
+        float(args.voxel_size),
+        output_map,
+        points,
+        stats,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tum_trajectory_to_pose_reference_csv_for_rosbag2.py
+++ b/scripts/tum_trajectory_to_pose_reference_csv_for_rosbag2.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Crop a TUM trajectory to a rosbag2 time window and export benchmark reference CSV / initial pose YAML."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Iterator
+from typing import Optional
+from typing import Tuple
+
+import yaml
+
+
+def iter_tum_poses(path: Path) -> Iterator[Tuple[float, float, float, float, float, float, float, float]]:
+    with path.open("r", encoding="utf-8", errors="replace") as stream:
+        for line in stream:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if len(parts) < 8:
+                continue
+            yield tuple(float(part) for part in parts[:8])  # type: ignore[return-value]
+
+
+def resolve_bag_metadata_path(bag_path: Path) -> Path:
+    if bag_path.is_file():
+        if bag_path.name != "metadata.yaml":
+            raise FileNotFoundError(f"Expected a rosbag2 metadata.yaml or bag directory, got file: {bag_path}")
+        return bag_path
+
+    metadata_path = bag_path / "metadata.yaml"
+    if metadata_path.exists():
+        return metadata_path
+
+    candidates = sorted(bag_path.rglob("metadata.yaml"))
+    if len(candidates) == 1:
+        return candidates[0]
+    raise FileNotFoundError(f"Could not resolve rosbag2 metadata.yaml under {bag_path}")
+
+
+def load_bag_time_window(
+    metadata_path: Path,
+    bag_start_offset: float,
+    bag_duration: float,
+) -> Tuple[float, float]:
+    metadata = yaml.safe_load(metadata_path.read_text(encoding="utf-8")) or {}
+    info = metadata.get("rosbag2_bagfile_information", {})
+    starting_time = info.get("starting_time", {})
+    duration = info.get("duration", {})
+
+    start_ns = starting_time.get("nanoseconds_since_epoch")
+    duration_ns = duration.get("nanoseconds")
+    if not isinstance(start_ns, int) or not isinstance(duration_ns, int):
+        raise RuntimeError(f"Failed to read starting_time/duration from {metadata_path}")
+
+    bag_full_start = float(start_ns) * 1e-9
+    bag_full_end = bag_full_start + float(duration_ns) * 1e-9
+    start_sec = bag_full_start + bag_start_offset
+    end_sec = bag_full_end if bag_duration <= 0.0 else min(start_sec + bag_duration, bag_full_end)
+    return start_sec, end_sec
+
+
+def export_initial_pose_yaml(
+    path: Path,
+    position: Tuple[float, float, float],
+    quaternion: Tuple[float, float, float, float],
+) -> None:
+    data = {
+        "/**": {
+            "ros__parameters": {
+                "set_initial_pose": True,
+                "initial_pose_x": position[0],
+                "initial_pose_y": position[1],
+                "initial_pose_z": position[2],
+                "initial_pose_qx": quaternion[0],
+                "initial_pose_qy": quaternion[1],
+                "initial_pose_qz": quaternion[2],
+                "initial_pose_qw": quaternion[3],
+            }
+        }
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def write_reference_csv(
+    rows: list[Tuple[float, float, float, float, float, float, float, float]],
+    output_csv: Path,
+) -> None:
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+    with output_csv.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(
+            [
+                "message_index",
+                "stamp_sec",
+                "frame_id",
+                "position_x",
+                "position_y",
+                "position_z",
+                "orientation_x",
+                "orientation_y",
+                "orientation_z",
+                "orientation_w",
+                "covariance",
+            ]
+        )
+        for index, (t, x, y, z, qx, qy, qz, qw) in enumerate(rows):
+            writer.writerow(
+                [
+                    index,
+                    f"{t:.9f}",
+                    "map",
+                    f"{x:.10f}",
+                    f"{y:.10f}",
+                    f"{z:.10f}",
+                    f"{qx:.10f}",
+                    f"{qy:.10f}",
+                    f"{qz:.10f}",
+                    f"{qw:.10f}",
+                    "",
+                ]
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path, help="Input TUM trajectory text file")
+    parser.add_argument("--bag-path", required=True, type=Path, help="rosbag2 directory or metadata.yaml")
+    parser.add_argument("--output-csv", required=True, type=Path, help="Destination reference CSV")
+    parser.add_argument(
+        "--output-initial-pose-yaml",
+        default="",
+        type=Path,
+        help="Optional parameter YAML from the chosen initial row",
+    )
+    parser.add_argument(
+        "--initial-pose-skip-sec",
+        type=float,
+        default=0.05,
+        help="Choose the first row at least this many seconds after the cropped window start",
+    )
+    parser.add_argument(
+        "--bag-start-offset",
+        type=float,
+        default=0.0,
+        help="Seconds to skip from the bag start time when cropping the TUM trajectory",
+    )
+    parser.add_argument(
+        "--bag-duration",
+        type=float,
+        default=0.0,
+        help="Seconds of bag data to export. 0 means until bag end",
+    )
+    parser.add_argument(
+        "--time-padding",
+        type=float,
+        default=0.0,
+        help="Optional symmetric padding in seconds around the bag time window",
+    )
+    args = parser.parse_args()
+
+    metadata_path = resolve_bag_metadata_path(args.bag_path.expanduser().resolve())
+    start_sec, end_sec = load_bag_time_window(metadata_path, args.bag_start_offset, args.bag_duration)
+    start_sec -= args.time_padding
+    end_sec += args.time_padding
+
+    rows = [row for row in iter_tum_poses(args.input.expanduser().resolve()) if start_sec <= row[0] <= end_sec]
+    if not rows:
+        raise SystemExit(
+            f"No poses left after cropping to [{start_sec:.9f}, {end_sec:.9f}] from {args.input}"
+        )
+
+    write_reference_csv(rows, args.output_csv.expanduser().resolve())
+
+    chosen: Optional[Tuple[float, float, float, float, float, float, float, float]]
+    if args.output_initial_pose_yaml:
+        threshold = rows[0][0] + max(args.initial_pose_skip_sec, 0.0)
+        chosen = next((row for row in rows if row[0] >= threshold), None)
+        if chosen is None:
+            raise SystemExit(
+                f"No cropped row with t >= {threshold:.9f} for initial pose (window starts at {rows[0][0]:.9f})"
+            )
+        _, x, y, z, qx, qy, qz, qw = chosen
+        export_initial_pose_yaml(
+            args.output_initial_pose_yaml.expanduser().resolve(),
+            (x, y, z),
+            (qx, qy, qz, qw),
+        )
+        print(f"initial_pose_stamp_sec: {chosen[0]:.9f}")
+        print(f"output_initial_pose_yaml: {args.output_initial_pose_yaml.expanduser().resolve()}")
+
+    print(f"metadata_path: {metadata_path}")
+    print(f"crop_start_sec: {start_sec:.9f}")
+    print(f"crop_end_sec: {end_sec:.9f}")
+    print(f"rows_written: {len(rows)}")
+    print(f"output_csv: {args.output_csv.expanduser().resolve()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` and a README quick-start path so users and agents can find the main workflows quickly.
- Document runtime map-format guidance for PLY/PCD benchmark use.
- Add benchmark helper scripts for evo APE evaluation, rosbag2-windowed TUM reference export, and GT-aligned diagnostic map generation.
- Add Koide hard localization benchmark manifests while ignoring large downloaded public data and local Boreas manifests.

## Validation

- `python3 -m py_compile scripts/benchmark_eval_evo_ape scripts/build_gt_aligned_map_from_reference_csv.py scripts/tum_trajectory_to_pose_reference_csv_for_rosbag2.py`
- Parsed 44 Koide benchmark YAML/JSON files with Python `yaml.safe_load` / `json.loads`.
- `source scripts/setup_local_env.sh && cd ../build_ws && colcon build --symlink-install --packages-up-to lidar_localization_ros2`
- Confirmed the three new helper scripts are visible via `ros2 pkg executables lidar_localization_ros2`.

## Stack

- This PR is stacked on #79 (`feat/scan-throttle-and-public-benchmarks`) so the diff only covers the docs and benchmark-helper additions from this branch.
- #79 itself is stacked on #78.
