### PR TITLE
feat: preserve original point cloud fields and add optional downsampling for initial_map visualization

### DIFF
--- a/include/lidar_localization/lidar_localization_component.hpp
+++ b/include/lidar_localization/lidar_localization_component.hpp
@@ -207,6 +207,8 @@ public:
   bool use_gtsam_smoother_{false};
   bool enable_debug_{false};
   bool enable_map_odom_tf_{false};
+  bool viz_downsample_{false};
+  double viz_voxel_leaf_size_{0.5};
   bool predict_pose_from_previous_delta_{true};
   bool reject_above_score_threshold_{true};
   bool enable_consistency_recovery_gate_{false};

--- a/src/lidar_localization_component.cpp
+++ b/src/lidar_localization_component.cpp
@@ -322,6 +322,8 @@ PCLLocalization::PCLLocalization(const rclcpp::NodeOptions & options)
   declare_parameter("reinitialization_trigger_fitness_explosion_threshold", 1000.0);
   declare_parameter("enable_timer_publishing", false);
   declare_parameter("pose_publish_frequency", 10.0);
+  declare_parameter("viz_downsample", false);
+  declare_parameter("viz_voxel_leaf_size", 0.5);
 }
 
 PCLLocalization::~PCLLocalization()
@@ -420,7 +422,16 @@ CallbackReturn PCLLocalization::on_activate(const rclcpp_lifecycle::State &)
       map_bounds_valid_ = false;
     }
     sensor_msgs::msg::PointCloud2::SharedPtr map_msg_ptr(new sensor_msgs::msg::PointCloud2);
-    pcl::toROSMsg(*map_cloud_ptr, *map_msg_ptr);
+    if (viz_downsample_) {
+      pcl::PointCloud<pcl::PointXYZI>::Ptr map_viz_ptr(new pcl::PointCloud<pcl::PointXYZI>);
+      pcl::VoxelGrid<pcl::PointXYZI> voxel_viz;
+      voxel_viz.setInputCloud(map_cloud_ptr);
+      voxel_viz.setLeafSize(viz_voxel_leaf_size_, viz_voxel_leaf_size_, viz_voxel_leaf_size_);
+      voxel_viz.filter(*map_viz_ptr);
+      pcl::toROSMsg(*map_viz_ptr, *map_msg_ptr);
+    } else {
+      pcl::toROSMsg(*map_cloud_ptr, *map_msg_ptr);
+    }
     map_msg_ptr->header.frame_id = global_frame_id_;
     initial_map_pub_->publish(*map_msg_ptr);
     RCLCPP_INFO(get_logger(), "Initial Map Published");
@@ -697,6 +708,8 @@ void PCLLocalization::initializeParameters()
     RCLCPP_INFO(get_logger(), "IMU preintegration smoother enabled");
   }
   get_parameter("enable_debug", enable_debug_);
+  get_parameter("viz_downsample", viz_downsample_);
+  get_parameter("viz_voxel_leaf_size", viz_voxel_leaf_size_);
   get_parameter("predict_pose_from_previous_delta", predict_pose_from_previous_delta_);
   get_parameter("enable_local_map_crop", enable_local_map_crop_);
   get_parameter("local_map_radius", local_map_radius_);

--- a/src/lidar_localization_component.cpp
+++ b/src/lidar_localization_component.cpp
@@ -423,14 +423,14 @@ CallbackReturn PCLLocalization::on_activate(const rclcpp_lifecycle::State &)
     }
     sensor_msgs::msg::PointCloud2::SharedPtr map_msg_ptr(new sensor_msgs::msg::PointCloud2);
     if (viz_downsample_) {
-      pcl::PointCloud<pcl::PointXYZI>::Ptr map_viz_ptr(new pcl::PointCloud<pcl::PointXYZI>);
-      pcl::VoxelGrid<pcl::PointXYZI> voxel_viz;
-      voxel_viz.setInputCloud(map_cloud_ptr);
+      pcl::PCLPointCloud2 map_cloud_viz_filtered;
+      pcl::VoxelGrid<pcl::PCLPointCloud2> voxel_viz;
+      voxel_viz.setInputCloud(std::make_shared<pcl::PCLPointCloud2>(raw_map_cloud));
       voxel_viz.setLeafSize(viz_voxel_leaf_size_, viz_voxel_leaf_size_, viz_voxel_leaf_size_);
-      voxel_viz.filter(*map_viz_ptr);
-      pcl::toROSMsg(*map_viz_ptr, *map_msg_ptr);
+      voxel_viz.filter(map_cloud_viz_filtered);
+      pcl_conversions::moveFromPCL(map_cloud_viz_filtered, *map_msg_ptr);
     } else {
-      pcl::toROSMsg(*map_cloud_ptr, *map_msg_ptr);
+      pcl_conversions::moveFromPCL(raw_map_cloud, *map_msg_ptr);
     }
     map_msg_ptr->header.frame_id = global_frame_id_;
     initial_map_pub_->publish(*map_msg_ptr);

--- a/src/lidar_localization_component.cpp
+++ b/src/lidar_localization_component.cpp
@@ -1199,7 +1199,7 @@ void PCLLocalization::odomReceived(const nav_msgs::msg::Odometry::ConstSharedPtr
 {
   if (shutting_down_) {return;}
   if (!use_odom_) {return;}
-  RCLCPP_INFO(get_logger(), "odomReceived");
+  RCLCPP_DEBUG(get_logger(), "odomReceived");
 
   double current_odom_received_time = msg->header.stamp.sec +
     msg->header.stamp.nanosec * 1e-9;
@@ -1359,7 +1359,7 @@ void PCLLocalization::cloudReceived(const sensor_msgs::msg::PointCloud2::ConstSh
   }
   last_cloud_process_time_ = this->now();
 
-  RCLCPP_INFO(get_logger(), "cloudReceived");
+  RCLCPP_DEBUG(get_logger(), "cloudReceived");
   const double scan_stamp_sec = stamp_to_sec(msg->header.stamp);
   if (consecutive_crop_failures_ > 100) {
     if (!crop_failure_guard_active_) {


### PR DESCRIPTION
## Summary

- `initial_map` was previously published as `PointXYZI`, discarding all
  original fields (e.g. RGB) from the source PCD/PLY file. It now uses
  `raw_map_cloud` (`PCLPointCloud2`) directly, preserving all fields.
- Added two parameters to control visualization quality vs. performance:
  - `viz_downsample` (bool, default: `false`): enable voxel downsampling
    for the published `initial_map`
  - `viz_voxel_leaf_size` (double, default: `0.5`): leaf size used when
    `viz_downsample` is `true`

## Motivation

Maps with RGB fields (e.g. colorized LiDAR or photogrammetry-derived PCD)
were not renderable in color in RViz2 because the conversion to `PointXYZI`
stripped the color data. Additionally, large maps caused RViz2 performance
issues due to publishing at full resolution.