### PR TITLE
[codex] Add artifact-first relocalization MVP pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,17 @@ target_link_libraries(lidar_localization_node
   ${rclcpp_lifecycle_LIBRARIES}
   ${std_msgs_LIBRARIES}
 )
+
+add_executable(relocalization_ndt_score_jobs src/relocalization_ndt_score_jobs.cpp)
+ament_target_dependencies(relocalization_ndt_score_jobs
+  ndt_omp_ros2
+)
+target_link_libraries(relocalization_ndt_score_jobs
+  -Wl,--start-group
+  ${ndt_omp_ros2_LIBRARIES}
+  ${PCL_LIBRARIES}
+  -Wl,--end-group
+)
 link_directories(
   ${PCL_LIBRARY_DIRS}
 )
@@ -92,6 +103,7 @@ ament_export_libraries(lidar_localization_component)
 
 install(TARGETS
   lidar_localization_node
+  relocalization_ndt_score_jobs
   DESTINATION lib/${PROJECT_NAME})
 
 install(TARGETS
@@ -115,6 +127,10 @@ install(PROGRAMS
   scripts/benchmark_eval_trajectory
   scripts/benchmark_eval_evo_ape
   scripts/augment_pointcloud_intensity.py
+  scripts/make_disabled_relocalization_attempts.py
+  scripts/observe_relocalization_reset_execution.py
+  scripts/make_route_grid_relocalization_attempts.py
+  scripts/make_registration_relocalization_jobs.py
   scripts/scaffold_mapless_public_dataset_bundle.py
   scripts/fetch_official_autoware_istanbul_dataset.sh
   scripts/fetch_koide_hard_pointcloud_localization_dataset.sh
@@ -129,6 +145,7 @@ install(PROGRAMS
   scripts/publish_odom_from_localization.py
   scripts/publish_odom_from_twist.py
   scripts/publish_pose_from_odom.py
+  scripts/publish_relocalization_reset_commands.py
   scripts/republish_initialpose_on_reinit.py
   scripts/relay_localization_inputs_with_current_stamp.py
   scripts/record_hdl_localization_outputs.py
@@ -144,6 +161,17 @@ install(PROGRAMS
   scripts/run_nav2_demo_smoke
   scripts/run_nav2_replay_smoke
   scripts/send_nav2_goal.py
+  scripts/summarize_localization_health.py
+  scripts/summarize_relocalization_attempts.py
+  scripts/summarize_registration_relocalization_scores.py
+  scripts/compare_registration_relocalization_score_summaries.py
+  scripts/run_registration_ordering_comparison.py
+  scripts/make_relocalization_reset_commands.py
+  scripts/select_relocalization_reset_candidates.py
+  scripts/validate_relocalization_reset_commands.py
+  scripts/validate_relocalization_reset_candidate_plan.py
+  scripts/score_relocalization_candidates_with_reference.py
+  scripts/resolve_registration_relocalization_scans.py
   scripts/run_autoware_istanbul_60s_predictor_compare.sh
   scripts/run_hdl_localization_docker_benchmark.sh
   DESTINATION lib/${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Then choose the path that matches what you want to do:
 | Run a self-contained Nav2 smoke path | [Recommended entry points](docs/v1_status.md#recommended-entry-points) |
 | Run public replay/regression checks | [Benchmarking](#benchmarking) |
 | Evaluate a rosbag against reference poses | [Benchmarking guide](docs/benchmarking.md) |
+| Plan the next relocalization/recovery work | [v1.1 relocalization plan](docs/v1_1_relocalization.md) |
 | Develop or compare recovery behavior | [Experiment-First Development](#experiment-first-development) |
 | Check what `v1.0.0` does and does not claim | [v1 status](docs/v1_status.md) |
 
@@ -97,6 +98,15 @@ This aggregates:
 - `run_nav2_reinit_supervisor_regression.sh`
 
 and writes a combined summary under `artifacts/public/release_regression_suite/`.
+
+The v1.1 relocalization work is documented in
+[docs/v1_1_relocalization.md](docs/v1_1_relocalization.md). Its public endpoint is a validated
+dry-run `/initialpose` command artifact, not automatic reset publication. The guarded publisher and
+post-reset observation helpers are experimental controlled-test utilities and are outside the default
+public benchmark path.
+
+Detailed health, relocalization, registration-scoring, and dry-run reset artifact commands live in
+[docs/benchmarking.md](docs/benchmarking.md#run-a-manifest-with-health-summary).
 
 ## IO
 - input  

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -18,6 +18,79 @@ This repository now includes a small benchmark harness so that localization chan
   - Records `diagnostic_msgs/msg/DiagnosticArray` into CSV
 - `benchmark_eval_trajectory`
   - Compares an estimated trajectory CSV against a reference trajectory CSV
+- `summarize_localization_health.py`
+  - Summarizes `alignment_status.csv` into recovery/reinitialization health metrics
+  - Writes `health_summary.json` and `health_summary.md`
+  - Tracks ok rate, failure-like rows, request windows, recovered/unrecovered windows, max accepted gap, and reject streaks
+  - `benchmark_from_manifest` writes this automatically for single-run manifests unless `benchmark.write_health_summary: false`
+- `summarize_relocalization_attempts.py`
+  - Summarizes experimental `relocalization_attempts.csv` artifacts and matches them to request windows from `alignment_status.csv`
+  - Writes `relocalization_attempt_summary.json` and `relocalization_attempt_summary.md`
+  - Records request-window coverage, accepted/rejected attempt counts, candidate counts, runtime stats, and false-recovery observability
+  - Treats a missing attempts CSV as zero attempts when run through `benchmark_from_manifest`, which makes "no global relocalization yet" explicit in artifacts
+- `make_disabled_relocalization_attempts.py`
+  - Converts each reinitialization request window in `alignment_status.csv` into one rejected baseline attempt
+  - Writes `candidate_count=0`, `accepted=false`, and `rejection_reason=candidate_generator_disabled`
+  - Useful for v1.1 public artifacts before a real candidate generator is enabled
+- `make_route_grid_relocalization_attempts.py`
+  - Converts each request window into route-corridor candidate poses from a reference trajectory
+  - Writes `relocalization_attempts.csv` plus per-candidate `relocalization_candidates.csv`
+  - Does not score candidates, call registration, or reset pose; attempts remain rejected with `candidate_scoring_not_implemented`
+  - Useful as the first non-zero-candidate artifact for the v1.1 relocalization pipeline
+- `score_relocalization_candidates_with_reference.py`
+  - Scores candidate poses against a reference trajectory as an offline oracle
+  - Writes `relocalization_candidate_scores.csv` and fills attempt `best_score`, `second_score`, and `candidate_margin`
+  - Does not call registration or reset pose; attempts remain rejected with `offline_oracle_scored_no_reset`
+  - Useful for separating "candidate set contains a plausible pose" from "runtime relocalization works"
+- `make_registration_relocalization_jobs.py`
+  - Converts candidate artifacts into a fixed registration-scoring job CSV
+  - Writes bag path, cloud topic, map path, candidate pose, backend label, local-map radius, voxel size, and timeout per job
+  - Does not run registration or reset pose; it freezes the input contract for the next scorer implementation
+- `resolve_registration_relocalization_scans.py`
+  - Resolves the nearest PointCloud2 scan for each registration job
+  - Writes `relocalization_registration_scores.csv` with scan timestamps, time deltas, point counts, and scan bounds
+  - Does not run registration or reset pose; rows are marked `scan_resolved_no_registration` when scan lookup succeeds
+- `relocalization_ndt_score_jobs`
+  - Runs NDT_OMP for rows that already have resolved scan PCDs
+  - Fills registration score, convergence, refinement delta, final pose, source point count, and target crop point count
+  - Fills `registration_gate_passed` and `registration_gate_reason` from score/refinement thresholds
+  - Does not accept or reset pose; scored rows are marked `registration_scored_no_reset`
+- `summarize_registration_relocalization_scores.py`
+  - Summarizes `relocalization_registration_scores*.csv`
+  - Writes scored/converged/gate-passed coverage plus score, refinement, runtime, source-point, and target-point stats
+  - Keeps reset acceptance explicitly out of scope
+- `compare_registration_relocalization_score_summaries.py`
+  - Compares two or more registration score summary JSON files
+  - Useful for comparing candidate ordering strategies such as `candidate_index` versus `oracle_rank`
+  - Treats `oracle_rank` comparisons as offline upper-bound diagnostics only
+- `run_registration_ordering_comparison.py`
+  - Runs the bounded candidate-ordering diagnostic pipeline for `candidate_index` and `oracle_rank`
+  - Generates jobs, resolves scans, runs NDT_OMP scoring, summarizes each order, and writes one comparison artifact
+  - Still never accepts or resets pose; it is for top-K ordering diagnostics before any reset policy exists
+- `select_relocalization_reset_candidates.py`
+  - Selects one gate-passing registration-scored candidate per attempt for a dry-run reset plan
+  - Uses registration score/gate fields, not `oracle_rank`, in the default policy
+  - Writes `accepted=false`; it is still a reset-plan artifact, not runtime reset execution
+- `validate_relocalization_reset_candidate_plan.py`
+  - Validates reset-plan artifacts before they are used by any executor
+  - Fails by default if any row has `accepted=true` or uses `oracle_rank` selection
+  - Can cross-check selected job/candidate rows against the registration score CSV
+- `make_relocalization_reset_commands.py`
+  - Converts selected reset-plan rows into dry-run `/initialpose` command artifacts
+  - Uses `selected_final_pose_*` as the command pose; `selected_initial_pose_*` remains candidate-seed provenance
+  - Does not publish or execute resets
+- `validate_relocalization_reset_commands.py`
+  - Validates dry-run reset command artifacts
+  - Requires `dry_run=true`, finite pose fields, near-unit quaternion, and zero published count by default
+  - Rejects accepted source plans and `oracle_rank` provenance by default
+- `publish_relocalization_reset_commands.py`
+  - Experimental guarded utility for `geometry_msgs/PoseWithCovarianceStamped` reset commands
+  - Requires `--execute` for actual publishing
+  - Without `--execute`, writes only an execution report with `published_count=0`
+- `observe_relocalization_reset_execution.py`
+  - Observes post-reset recovery from reset execution CSV and `alignment_status.csv`
+  - Counts post-reset `ok` rows, stable ok streak, reject streak, and first-ok latency
+  - Sets `accepted=true` only when a published command is followed by enough stable `ok` rows
 - `benchmark_eval_evo_ape`
   - Converts the benchmark CSVs to TUM format and evaluates them with `evo_ape`
   - Useful when you need a paper-style `ATE` workflow instead of only the built-in RMSE JSON
@@ -97,6 +170,163 @@ Interpretation:
 
 - Istanbul has no accelerometer stream, so it is only a default-on no-IMU safety check, not an IMU benefit benchmark
 - HDL has no strong public ground truth and single-run pose-row ratios are noisy, so the suite uses broad smoke bounds there rather than a strict acceptance benchmark
+
+### Run a manifest with health summary
+
+Single-run manifests use `benchmark_from_manifest`. After replay and trajectory evaluation, the
+wrapper writes recovery diagnostics by default:
+
+- `health_summary.json`
+- `health_summary.md`
+
+Relevant manifest knobs:
+
+```yaml
+benchmark:
+  write_health_summary: true
+  health_stable_ok_rows: 5
+  health_recovery_window_sec: 10.0
+  health_false_recovery_rmse_threshold_m: 5.0
+  write_route_grid_relocalization_attempts: true
+  route_grid_time_radius_sec: 15.0
+  route_grid_min_spacing_m: 10.0
+  route_grid_yaw_offsets_deg: [-15, 0, 15]
+  route_grid_lateral_offsets_m: [-2.0, 0.0, 2.0]
+  route_grid_longitudinal_offsets_m: [0.0]
+  write_reference_oracle_relocalization_scores: true
+  reference_oracle_translation_threshold_m: 2.0
+  reference_oracle_yaw_threshold_deg: 15.0
+  reference_oracle_yaw_weight_m_per_rad: 1.0
+  write_registration_relocalization_jobs: true
+  registration_jobs_method: NDT_OMP
+  registration_jobs_max_candidates_per_attempt: 32
+  registration_jobs_selection_source: candidate_index
+  registration_jobs_voxel_leaf_size: 1.0
+  registration_jobs_local_map_radius: 150.0
+  registration_jobs_timeout_sec: 1.0
+  write_registration_relocalization_scan_scores: true
+  registration_scores_max_scan_time_diff: 0.25
+  registration_scores_min_range: 1.0
+  registration_scores_max_range: 120.0
+  registration_scores_max_jobs: 32
+  registration_scores_export_scan_pcd_dir: manifest://registration_scans
+  write_ndt_relocalization_scores: false
+  ndt_relocalization_max_jobs: 1
+  ndt_relocalization_score_gate_threshold: 6.0
+  ndt_relocalization_refinement_delta_gate_m: 2.0
+  ndt_relocalization_refinement_yaw_gate_rad: 0.7853981633974483
+  write_registration_relocalization_score_summary: true
+  write_registration_ordering_comparison: false
+  registration_ordering_top_k: 5
+  registration_ordering_output_dir: manifest://registration_ordering_comparison
+  write_relocalization_reset_candidate_plan: false
+  relocalization_reset_candidate_plan_csv: manifest://relocalization_reset_candidate_plan.csv
+  relocalization_reset_candidate_plan_min_score_margin: 0.0
+  validate_relocalization_reset_candidate_plan: false
+  relocalization_reset_candidate_plan_min_selected_count: 0
+  write_relocalization_reset_command_dry_run: false
+  relocalization_reset_commands_csv: manifest://relocalization_reset_commands.csv
+  relocalization_reset_publish_topic: /initialpose
+  relocalization_reset_frame_id: map
+  validate_relocalization_reset_commands: false
+  relocalization_reset_commands_min_generated_count: 0
+  write_disabled_relocalization_attempts: false
+  write_relocalization_attempt_summary: true
+  relocalization_request_match_window_sec: 10.0
+  relocalization_post_reset_stable_ok_rows: 5
+```
+
+Disable it with `write_health_summary: false` only when the run intentionally has no
+`/alignment_status` recording.
+
+Relocalization helpers write `relocalization_attempts.csv` into the output directory, and
+`benchmark_from_manifest` includes it in `relocalization_attempt_summary.json/md`.
+
+The v1.1 relocalization endpoint is a validated dry-run `/initialpose` command artifact. Actual
+publication is guarded, opt-in, and outside the default public benchmark path. The minimal CSV schema
+is:
+
+```csv
+attempt_id,trigger_stamp_sec,source,candidate_count,accepted,rejection_reason,runtime_sec
+```
+
+Recommended optional fields are:
+
+```csv
+start_stamp_sec,end_stamp_sec,mode,roi_type,accepted_candidate_rank,best_score,second_score,candidate_margin,overlap,converged,refinement_delta_m,refinement_delta_yaw_rad,post_reset_ok_rows,post_reset_window_sec,false_recovery
+```
+
+`write_disabled_relocalization_attempts: true` generates a baseline attempts CSV only when one does
+not already exist. This preserves real candidate-generator output once the experimental relocalizer
+starts writing the same file.
+
+`write_route_grid_relocalization_attempts: true` generates non-zero route-corridor candidates from
+`dataset.reference_csv` or `benchmark.route_grid_reference_csv`. The generated attempts still set
+`accepted=false`; the artifact only proves candidate coverage and keeps scoring/refinement/reset
+work separate from the public regression contract.
+
+`write_reference_oracle_relocalization_scores: true` scores those candidates against the same
+reference trajectory and writes `relocalization_candidate_scores.csv`. This is an offline upper-bound
+diagnostic, not a runtime relocalization claim; it leaves attempts rejected and only fills score and
+oracle coverage fields.
+
+`write_registration_relocalization_jobs: true` writes `relocalization_registration_jobs.csv` for the
+registration scorer. The default `registration_jobs_selection_source: candidate_index` avoids using
+oracle ordering in runtime-like jobs. Use `oracle_rank` only for offline upper-bound diagnostics.
+
+`write_registration_relocalization_scan_scores: true` reads those jobs and resolves the nearest scan
+from the rosbag2 input. The resulting `relocalization_registration_scores.csv` is still a pre-scorer
+artifact: it verifies scan availability and timing, but keeps `converged=false` and score fields
+empty until a real registration backend is wired in.
+
+The NDT scorer is intentionally explicit for now:
+
+```bash
+ros2 run lidar_localization_ros2 relocalization_ndt_score_jobs \
+  --input-csv /tmp/run/relocalization_registration_scores.csv \
+  --output-csv /tmp/run/relocalization_registration_scores_ndt.csv \
+  --max-jobs 1
+```
+
+Use small `--max-jobs` values first. The scorer loads map crops and scan PCDs and can be much heavier
+than the CSV-only artifact steps.
+
+In manifests, keep `write_ndt_relocalization_scores: false` for normal public replay artifacts and
+enable it only for bounded scorer smoke runs. Even when the gate passes, the row remains
+`registration_scored_no_reset`; accepted reset execution is outside the default public path.
+
+When NDT scoring is enabled, `benchmark_from_manifest` also writes
+`relocalization_registration_score_summary.json/md` by default.
+
+Set `write_registration_ordering_comparison: true` only for bounded diagnostic runs. It invokes
+`run_registration_ordering_comparison.py` after candidate artifacts exist and writes a separate
+`registration_ordering_comparison/` directory by default. This compares `candidate_index` and
+`oracle_rank` top-K ordering with NDT_OMP scoring, but still does not accept or reset pose.
+
+After a scored CSV exists, `select_relocalization_reset_candidates.py` can produce the next artifact
+boundary: `relocalization_reset_candidate_plan.csv/json/md`. The default policy selects the
+lowest-score candidate that converged and passed the registration gate for each attempt. The plan
+keeps `accepted=false`; it is the handoff contract for the dry-run reset command artifact.
+
+Set `write_relocalization_reset_candidate_plan: true` to emit that handoff artifact from a manifest.
+When ordering comparison is also enabled, the default input is the `candidate_index_topK` scored CSV,
+not the `oracle_rank` CSV. Otherwise the default input is `relocalization_registration_scores_ndt.csv`.
+
+Set `validate_relocalization_reset_candidate_plan: true` to write
+`relocalization_reset_candidate_plan_validation.json/md` and fail the manifest run if the plan breaks
+the artifact-only safety contract.
+
+Set `write_relocalization_reset_command_dry_run: true` to write
+`relocalization_reset_commands.csv/json/md`. These rows are publish-intent artifacts only:
+`published_count` remains zero, and the command pose is taken from `selected_final_pose_*`.
+
+Set `validate_relocalization_reset_commands: true` to write
+`relocalization_reset_commands_validation.json/md` and fail if a command artifact is not dry-run safe.
+
+The v1.1 example manifests are starter manifests. They stop before NDT scoring and reset-command
+generation by default so a normal public replay remains lightweight and cannot publish. To exercise
+the full v1.1 endpoint, run a bounded scorer smoke first, then explicitly enable reset-plan,
+dry-run command, and command-validation artifacts.
 
 ### Fetch a real benchmark dataset from hdl_localization
 

--- a/docs/v1_1_relocalization.md
+++ b/docs/v1_1_relocalization.md
@@ -1,0 +1,167 @@
+# v1.1 Relocalization MVP
+
+This document fixes the v1.1 endpoint for the experimental relocalization work.
+
+The v1.1 target is not automatic runtime recovery. The target is an artifact-first,
+publicly reproducible pipeline that turns relocalization request windows into a
+validated dry-run `/initialpose` command artifact without publishing a reset in the
+default benchmark path.
+
+## Decision
+
+Freeze new relocalization helper work for v1.1 and consolidate the existing chain around one
+public endpoint:
+
+> A validated dry-run `/initialpose` command artifact derived from NDT_OMP-scored
+> route-grid relocalization candidates, with no publish in the default benchmark path.
+
+This endpoint is strong enough to show that candidate generation, scan resolution,
+registration scoring, reset candidate selection, and command validation are connected.
+It is also narrow enough to avoid claiming autonomous or production-grade recovery.
+
+## Public Stage Boundary
+
+| Stage | Runtime-like? | Offline diagnostic? | Dry-run only? | Can publish? | Public v1.1 claim? | Main artifacts |
+| --- | --- | --- | --- | --- | --- | --- |
+| Health summary | No | Yes | Yes | No | Yes | `health_summary.json/md` |
+| Route-grid candidates | Partly | Yes | Yes | No | Yes | `relocalization_attempts.csv`, `relocalization_candidates.csv` |
+| Reference-oracle scoring | No | Yes | Yes | No | Diagnostic only | `relocalization_candidate_scores.csv` |
+| NDT_OMP registration scoring | Partly | Yes | Yes | No | Yes | `relocalization_registration_scores_ndt.csv` |
+| Ordering comparison | No | Yes | Yes | No | Diagnostic only | `ordering_comparison/*` |
+| Reset candidate plan | Partly | Yes | Yes | No | Yes | `relocalization_reset_candidate_plan.csv/json/md` |
+| Plan validation | No | Yes | Yes | No | Yes | `relocalization_reset_candidate_plan_validation.json/md` |
+| Dry-run reset command | Partly | Yes | Yes | No | MVP endpoint | `relocalization_reset_commands.csv/json/md` |
+| Command validation | No | Yes | Yes | No | MVP endpoint | `relocalization_reset_commands_validation.json/md` |
+| Guarded publisher | Yes | No | Default yes | Yes with `--execute` | No | `relocalization_reset_command_execution.csv/json/md` |
+| Post-reset observation | Evaluation only | Yes | No | No | Future controlled test | `relocalization_reset_execution_observation.csv/json/md` |
+
+## Public Pipeline
+
+The public-facing story is four stages.
+
+1. Candidate generation
+
+   Route-corridor candidates are generated for request windows. The route corridor is an
+   offline public-regression artifact, not a runtime claim.
+
+2. Registration scoring
+
+   Candidate rows are converted into registration jobs, nearest scans are resolved from the
+   bag, and NDT_OMP scores the candidate initial poses. A gate pass is a scorer artifact, not
+   an accepted reset.
+
+3. Reset candidate selection
+
+   A dry-run reset candidate plan is selected from registration-derived fields only:
+   convergence, score, refinement delta, yaw delta, and optional score margin. Runtime-like
+   selection must not depend on `oracle_rank`.
+
+4. Safe reset artifact
+
+   The selected refined pose is converted into a dry-run `/initialpose` command artifact and
+   validated for topic, frame, finite pose values, near-unit quaternion, non-oracle provenance,
+   `dry_run=true`, and `published_count=0`.
+
+## Diagnostic And Experimental Utilities
+
+The following pieces remain useful, but they are not the v1.1 public endpoint.
+
+- Reference-oracle scoring measures whether the candidate set contains a plausible pose. It is an
+  offline upper-bound diagnostic, not a runtime relocalization score.
+- Ordering comparison contrasts runtime-like `candidate_index` ordering with diagnostic
+  `oracle_rank` ordering. It should stay bounded and off the default public path.
+- `publish_relocalization_reset_commands.py` is an experimental guarded execution utility. It
+  does not publish unless `--execute` is passed, and it is not required for the v1.1 MVP claim.
+- `observe_relocalization_reset_execution.py` is the acceptance evaluator for future controlled
+  execution tests. It is not the v1.1 public MVP endpoint.
+
+## Current Evidence
+
+The current Boreas localizer-only artifact chain exercises the v1.1 endpoint without publishing:
+
+- `candidate_index_top1` produced one scored row with NDT score `2.158257` and a passed local gate.
+- `oracle_rank_top1` produced one scored row with NDT score `13.994764` and no gate pass.
+- `candidate_index_top5` scored five rows, all with passed local gates, with median score
+  `2.175548`.
+- `oracle_rank_top5` scored five rows, with zero passed gates and median score `15.483539`.
+- The reset candidate plan selected candidate `2` with score `1.331940` and kept
+  `accepted=false`.
+- The dry-run command artifact targeted `/initialpose`, frame `map`, pose
+  `x=75.816933`, `y=11.294861`, `z=0.653252`, `yaw=0.248475`, and kept
+  `published_count=0`.
+- Command validation passed for the valid artifact and rejected an altered non-dry-run artifact.
+- The guarded publisher, when run without `--execute`, reported `published_count=0` with
+  `execute_flag_required`.
+
+This is evidence for a guarded artifact chain. It is not evidence for autonomous relocalization or
+post-reset recovery success.
+
+## Dataset Roles
+
+### Istanbul
+
+Use as the daily regression and Nav2 replay stability guard.
+
+Safe claim:
+
+- short public regression and controlled Nav2 recovery regression pass
+
+Unsafe claim:
+
+- long-horizon urban replay is solved
+
+### Boreas
+
+Use as the next public dataset coverage target.
+
+The first Boreas target is localizer-only artifact reproducibility: health summary, route-grid
+candidates, registration scoring, reset candidate selection, and validated dry-run reset command
+artifacts. Do not turn this into a broad robustness claim yet.
+
+### Koide Outdoor01
+
+Use as a public-map failure-boundary diagnostic.
+
+Keep original public-map results separate from diagnostic-map results. The useful claim is boundary
+characterization, not robust full-route tracking on the original public map.
+
+### GLIL
+
+Treat as competitor context or plumbing smoke unless a clearly public dataset target is defined.
+
+## Safe Claim Language
+
+Safe v1.1 wording:
+
+> v1.1 adds an experimental artifact-first relocalization evaluation pipeline. It can generate
+> route-corridor reset candidates, resolve scans, score candidates with NDT_OMP registration, select
+> and validate a reset candidate, and produce a validated dry-run `/initialpose` command artifact.
+> Actual reset publication is guarded, opt-in only, and not part of the default public benchmark
+> path.
+
+Safe shorter wording:
+
+> experimental artifact-first relocalization evaluation with validated dry-run reset command
+> artifacts
+
+## Do Not Claim
+
+- global relocalization solved
+- automatic recovery
+- robust relocalization
+- runtime relocalization
+- production-ready reset
+- Boreas relocalization success
+- oracle-based candidate ordering works at runtime
+- `SMALL_GICP` is default-ready
+- reliable covariance estimation
+
+## v1.1 Closeout
+
+For v1.1, stop adding scoring, selection, or recovery heuristics. The remaining work is closeout:
+
+1. Keep release regression green.
+2. Keep the v1.1 public story centered on the dry-run command validation endpoint.
+3. Treat guarded publication and post-reset observation as controlled follow-up work.
+4. Add a no-publish smoke runner only if it is a thin wrapper around existing artifacts and adds no
+   new scoring or selection behavior.

--- a/docs/v1_status.md
+++ b/docs/v1_status.md
@@ -61,6 +61,66 @@ The following paths were validated in this workspace before the `v1.0.0` packagi
   - `ros2 run lidar_localization_ros2 run_borderline_gate_experiments.py`
   - `ros2 run lidar_localization_ros2 run_recovery_action_experiments.py`
   - `ros2 run lidar_localization_ros2 run_reinit_trigger_experiments.py`
+- localization health summary:
+  - `ros2 run lidar_localization_ros2 summarize_localization_health.py --alignment-csv /absolute/path/to/alignment_status.csv --trajectory-eval-json /absolute/path/to/trajectory_eval.json`
+  - current role: artifact-first recovery/reinitialization metrics for v1.1 dataset expansion
+  - next target: [v1.1 relocalization plan](v1_1_relocalization.md)
+- relocalization attempt summary:
+  - `ros2 run lidar_localization_ros2 summarize_relocalization_attempts.py --alignment-csv /absolute/path/to/alignment_status.csv --attempts-csv /absolute/path/to/relocalization_attempts.csv --allow-missing-attempts`
+  - current role: fixed artifact schema for candidate generation, dry-run reset artifacts, and explicit zero-attempt baselines
+- disabled relocalization attempt baseline:
+  - `ros2 run lidar_localization_ros2 make_disabled_relocalization_attempts.py --alignment-csv /absolute/path/to/alignment_status.csv --output-csv /absolute/path/to/relocalization_attempts.csv`
+  - current role: converts request windows into rejected `candidate_generator_disabled` attempts before a real candidate generator exists
+- route-grid relocalization candidate artifact:
+  - `ros2 run lidar_localization_ros2 make_route_grid_relocalization_attempts.py --alignment-csv /absolute/path/to/alignment_status.csv --reference-csv /absolute/path/to/reference.csv --output-csv /absolute/path/to/relocalization_attempts.csv`
+  - current role: converts request windows into non-zero route-corridor candidates while keeping attempts rejected until scoring/refinement/reset are implemented
+- reference-oracle candidate scoring:
+  - `ros2 run lidar_localization_ros2 score_relocalization_candidates_with_reference.py --attempts-csv /absolute/path/to/relocalization_attempts.csv --candidates-csv /absolute/path/to/relocalization_candidates.csv --reference-csv /absolute/path/to/reference.csv --output-attempts-csv /absolute/path/to/relocalization_attempts.csv`
+  - current role: fills candidate score fields from reference trajectory as an offline upper-bound diagnostic; still no registration scoring or pose reset
+- registration relocalization job artifact:
+  - `ros2 run lidar_localization_ros2 make_registration_relocalization_jobs.py --attempts-csv /absolute/path/to/relocalization_attempts.csv --candidates-csv /absolute/path/to/relocalization_candidate_scores.csv --bag-path /absolute/path/to/bag --map-path /absolute/path/to/map.pcd --cloud-topic /velodyne_points --output-csv /absolute/path/to/relocalization_registration_jobs.csv`
+  - current role: freezes the bag/map/topic/candidate-pose contract for the next registration scorer; still no registration execution or reset
+- registration scan-resolution artifact:
+  - `ros2 run lidar_localization_ros2 resolve_registration_relocalization_scans.py --jobs-csv /absolute/path/to/relocalization_registration_jobs.csv --output-csv /absolute/path/to/relocalization_registration_scores.csv`
+  - current role: resolves nearest PointCloud2 scan, timing delta, point counts, and scan bounds for each registration job; still no registration execution or reset
+- NDT relocalization job scoring:
+  - `ros2 run lidar_localization_ros2 relocalization_ndt_score_jobs --input-csv /absolute/path/to/relocalization_registration_scores.csv --output-csv /absolute/path/to/relocalization_registration_scores_ndt.csv --max-jobs 1`
+  - current role: first real NDT_OMP candidate scorer; fills registration score/convergence/refinement fields while keeping reset disabled
+- registration score summary:
+  - `ros2 run lidar_localization_ros2 summarize_registration_relocalization_scores.py --scores-csv /absolute/path/to/relocalization_registration_scores_ndt.csv --output-json /absolute/path/to/relocalization_registration_score_summary.json`
+  - current role: scorer coverage/gate diagnostics for NDT relocalization artifacts; still no reset acceptance
+- registration score comparison:
+  - `ros2 run lidar_localization_ros2 compare_registration_relocalization_score_summaries.py --summary candidate_index:/absolute/path/to/summary_a.json --summary oracle_rank:/absolute/path/to/summary_b.json`
+  - current role: compares candidate ordering diagnostics without promoting oracle order or reset acceptance
+- registration ordering comparison runner:
+  - `ros2 run lidar_localization_ros2 run_registration_ordering_comparison.py --attempts-csv /absolute/path/to/relocalization_attempts.csv --candidates-csv /absolute/path/to/relocalization_candidate_scores.csv --bag-path /absolute/path/to/bag --map-path /absolute/path/to/map.pcd --cloud-topic /velodyne_points --output-dir /absolute/path/to/ordering_comparison --top-k 5`
+  - current role: runs the bounded jobs -> scan resolution -> NDT scoring -> summary -> comparison path for `candidate_index` and `oracle_rank`; still no reset acceptance
+- manifest ordering comparison hook:
+  - `benchmark.write_registration_ordering_comparison: true`
+  - current role: opt-in wrapper around the ordering comparison runner for bounded public artifacts; default examples keep it disabled because it runs NDT scoring
+- dry-run reset candidate plan:
+  - `ros2 run lidar_localization_ros2 select_relocalization_reset_candidates.py --scores-csv /absolute/path/to/relocalization_registration_scores_ndt.csv --output-csv /absolute/path/to/relocalization_reset_candidate_plan.csv`
+  - current role: selects one registration-gate-passing candidate per attempt for a dry-run reset plan; still writes `accepted=false`
+- manifest reset candidate plan hook:
+  - `benchmark.write_relocalization_reset_candidate_plan: true`
+  - current role: opt-in reset-plan artifact generation from either explicit NDT score CSV or `candidate_index_topK` ordering-comparison scores
+- reset candidate plan validation:
+  - `ros2 run lidar_localization_ros2 validate_relocalization_reset_candidate_plan.py --plan-csv /absolute/path/to/relocalization_reset_candidate_plan.csv --scores-csv /absolute/path/to/relocalization_registration_scores_ndt.csv`
+  - current role: contract check that keeps dry-run plans from silently claiming accepted resets or oracle-based runtime selection
+- reset command dry-run artifact:
+  - `ros2 run lidar_localization_ros2 make_relocalization_reset_commands.py --plan-csv /absolute/path/to/relocalization_reset_candidate_plan.csv --output-csv /absolute/path/to/relocalization_reset_commands.csv`
+  - current role: converts selected reset-plan rows into `/initialpose` publish-intent artifacts without publishing
+- reset command validation:
+  - `ros2 run lidar_localization_ros2 validate_relocalization_reset_commands.py --commands-csv /absolute/path/to/relocalization_reset_commands.csv --summary-json /absolute/path/to/relocalization_reset_commands.json`
+  - current role: verifies the v1.1 MVP endpoint: a validated dry-run `/initialpose` command artifact
+- guarded reset command publisher:
+  - `ros2 run lidar_localization_ros2 publish_relocalization_reset_commands.py --commands-csv /absolute/path/to/relocalization_reset_commands.csv --validation-json /absolute/path/to/relocalization_reset_commands_validation.json --output-csv /absolute/path/to/relocalization_reset_command_execution.csv`
+  - current role: experimental guarded utility; writes a no-publish execution report by default, and actual `/initialpose` publish requires explicit `--execute`
+  - v1.1 claim status: not part of the default public benchmark path or MVP endpoint
+- post-reset execution observation:
+  - `ros2 run lidar_localization_ros2 observe_relocalization_reset_execution.py --execution-csv /absolute/path/to/relocalization_reset_command_execution.csv --commands-csv /absolute/path/to/relocalization_reset_commands.csv --alignment-csv /absolute/path/to/alignment_status.csv --output-csv /absolute/path/to/relocalization_reset_execution_observation.csv`
+  - current role: future controlled execution evaluator for published command rows and post-reset alignment status
+  - v1.1 claim status: not the public MVP endpoint
 
 ## Recommended preset
 
@@ -88,3 +148,4 @@ Current rationale:
 - claiming universal recovery from prolonged reject streaks
 - claiming production-grade performance for every dense urban replay segment
 - replacing a full SLAM or mapping stack
+- claiming production-grade global relocalization; v1.1 starts this as an experimental artifact-first path

--- a/param/benchmark/v1_1_boreas_localizer_only.example.yaml
+++ b/param/benchmark/v1_1_boreas_localizer_only.example.yaml
@@ -1,0 +1,110 @@
+# v1.1 Boreas localizer-only public regression starter.
+#
+# Copy this file to a non-.example.yaml path and replace /absolute/path/to values before running.
+# The benchmark_from_manifest wrapper intentionally refuses to execute .example.yaml manifests.
+#
+# Intended role:
+#   - add non-Istanbul public dataset coverage
+#   - record localization health/recovery metrics before adding global relocalization
+#   - keep Nav2 out of the first Boreas pass
+#   - stop before NDT relocalization scoring and dry-run reset command generation by default
+#
+# Suggested flow:
+#   ros2 run lidar_localization_ros2 convert_boreas_sequence_to_rosbag2.py ...
+#   ros2 run lidar_localization_ros2 benchmark_from_manifest --manifest /path/to/v1_1_boreas_localizer_only.yaml
+#   ros2 run lidar_localization_ros2 summarize_localization_health.py \
+#     --alignment-csv /tmp/lidarloc_v1_1_boreas_localizer_only/alignment_status.csv \
+#     --trajectory-eval-json /tmp/lidarloc_v1_1_boreas_localizer_only/trajectory_eval.json \
+#     --output-json /tmp/lidarloc_v1_1_boreas_localizer_only/health_summary.json \
+#     --output-md /tmp/lidarloc_v1_1_boreas_localizer_only/health_summary.md
+
+mode: run
+
+dataset:
+  bag_path: /absolute/path/to/data/boreas/localization_sequence_rosbag2
+  map_path: /absolute/path/to/data/boreas/mapping_sequence_map.pcd
+  reference_csv: /absolute/path/to/data/boreas/localization_sequence_reference.csv
+  initial_pose_yaml: /absolute/path/to/data/boreas/localization_sequence_initial_pose.yaml
+  cloud_topic: /velodyne_points
+  imu_topic: /imu/data
+  twist_topic: /vehicle/twist
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: NDT_OMP
+    use_imu: false
+    use_imu_preintegration: false
+    use_twist_prediction: true
+    enable_scan_voxel_filter: true
+    enable_local_map_crop: true
+    voxel_leaf_size: 1.0
+    local_map_radius: 150.0
+    score_threshold: 6.0
+  launch_args:
+    - use_sim_time:=true
+
+benchmark:
+  output_dir: /tmp/lidarloc_v1_1_boreas_localizer_only
+  ros_domain_id: 170
+  bag_duration: 120
+  bag_start_offset: 0
+  settle_seconds: 10
+  post_roll_seconds: 3
+  max_time_diff: 0.5
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true
+  write_health_summary: true
+  health_stable_ok_rows: 5
+  health_recovery_window_sec: 10.0
+  health_false_recovery_rmse_threshold_m: 5.0
+  write_route_grid_relocalization_attempts: true
+  route_grid_time_radius_sec: 15.0
+  route_grid_min_spacing_m: 10.0
+  route_grid_max_route_poses: 32
+  route_grid_max_candidates: 256
+  route_grid_yaw_offsets_deg: [-15, 0, 15]
+  route_grid_lateral_offsets_m: [-2.0, 0.0, 2.0]
+  route_grid_longitudinal_offsets_m: [0.0]
+  write_reference_oracle_relocalization_scores: true
+  reference_oracle_translation_threshold_m: 2.0
+  reference_oracle_yaw_threshold_deg: 15.0
+  reference_oracle_yaw_weight_m_per_rad: 1.0
+  write_registration_relocalization_jobs: true
+  registration_jobs_method: NDT_OMP
+  registration_jobs_max_candidates_per_attempt: 32
+  registration_jobs_selection_source: candidate_index
+  registration_jobs_voxel_leaf_size: 1.0
+  registration_jobs_local_map_radius: 150.0
+  registration_jobs_timeout_sec: 1.0
+  write_registration_relocalization_scan_scores: true
+  registration_scores_max_scan_time_diff: 0.25
+  registration_scores_min_range: 1.0
+  registration_scores_max_range: 120.0
+  registration_scores_max_jobs: 32
+  registration_scores_export_scan_pcd_dir: manifest://registration_scans
+  write_ndt_relocalization_scores: false
+  ndt_relocalization_max_jobs: 1
+  ndt_relocalization_score_gate_threshold: 6.0
+  ndt_relocalization_refinement_delta_gate_m: 2.0
+  ndt_relocalization_refinement_yaw_gate_rad: 0.7853981633974483
+  write_registration_relocalization_score_summary: true
+  write_registration_ordering_comparison: false
+  registration_ordering_top_k: 5
+  registration_ordering_output_dir: manifest://registration_ordering_comparison
+  write_relocalization_reset_candidate_plan: false
+  relocalization_reset_candidate_plan_csv: manifest://relocalization_reset_candidate_plan.csv
+  relocalization_reset_candidate_plan_min_score_margin: 0.0
+  validate_relocalization_reset_candidate_plan: false
+  relocalization_reset_candidate_plan_min_selected_count: 0
+  write_relocalization_reset_command_dry_run: false
+  relocalization_reset_commands_csv: manifest://relocalization_reset_commands.csv
+  relocalization_reset_publish_topic: /initialpose
+  relocalization_reset_frame_id: map
+  validate_relocalization_reset_commands: false
+  relocalization_reset_commands_min_generated_count: 0
+  write_disabled_relocalization_attempts: false
+  write_relocalization_attempt_summary: true
+  relocalization_request_match_window_sec: 10.0
+  relocalization_post_reset_stable_ok_rows: 5

--- a/param/benchmark/v1_1_koide_outdoor01_public_map_failure_boundary.example.yaml
+++ b/param/benchmark/v1_1_koide_outdoor01_public_map_failure_boundary.example.yaml
@@ -1,0 +1,125 @@
+# v1.1 Koide Outdoor01 public-map failure-boundary diagnostic starter.
+#
+# Copy this file to a non-.example.yaml path and replace /absolute/path/to values before running.
+# This manifest intentionally uses the original public map, not the GT-aligned diagnostic map.
+#
+# Intended role:
+#   - diagnose map coverage/alignment and recovery behavior on a public map
+#   - record request/recovery/lost-window artifacts
+#   - avoid claiming robust full-route tracking until the original public-map path supports it
+#   - stop before NDT relocalization scoring and dry-run reset command generation by default
+#
+# Suggested flow:
+#   ros2 run lidar_localization_ros2 fetch_koide_hard_pointcloud_localization_dataset.sh \
+#     --with-maps --with-gt --sequence outdoor_hard_01a --sequence outdoor_hard_01b \
+#     --output-dir data/public/koide_hard_localization
+#
+#   # Generate reference and initial pose for the merged Outdoor01 rosbag2.
+#   ros2 run lidar_localization_ros2 tum_trajectory_to_pose_reference_csv_for_rosbag2.py \
+#     --input data/public/koide_hard_localization/gt/traj_lidar_outdoor_hard_01.txt \
+#     --bag-path data/public/koide_hard_localization/sequences/outdoor_hard_01 \
+#     --output-csv data/public/koide_hard_localization/benchmark/outdoor_hard_01/reference.csv \
+#     --output-initial-pose-yaml data/public/koide_hard_localization/benchmark/outdoor_hard_01/initial_pose.yaml \
+#     --initial-pose-skip-sec 0.05
+#
+#   ros2 run lidar_localization_ros2 benchmark_from_manifest \
+#     --manifest /path/to/v1_1_koide_outdoor01_public_map_failure_boundary.yaml
+#
+#   ros2 run lidar_localization_ros2 summarize_localization_health.py \
+#     --alignment-csv /tmp/lidarloc_v1_1_koide_outdoor01_public_map_failure_boundary/alignment_status.csv \
+#     --trajectory-eval-json /tmp/lidarloc_v1_1_koide_outdoor01_public_map_failure_boundary/trajectory_eval.json \
+#     --output-json /tmp/lidarloc_v1_1_koide_outdoor01_public_map_failure_boundary/health_summary.json \
+#     --output-md /tmp/lidarloc_v1_1_koide_outdoor01_public_map_failure_boundary/health_summary.md
+
+mode: run
+
+dataset:
+  bag_path: /absolute/path/to/data/public/koide_hard_localization/sequences/outdoor_hard_01
+  map_path: /absolute/path/to/data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: /absolute/path/to/data/public/koide_hard_localization/benchmark/outdoor_hard_01/reference.csv
+  initial_pose_yaml: /absolute/path/to/data/public/koide_hard_localization/benchmark/outdoor_hard_01/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    registration_method: NDT_OMP
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    enable_local_map_crop: true
+    voxel_leaf_size: 0.5
+    local_map_radius: 150.0
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+  launch_args:
+    - use_sim_time:=true
+    - lidar_frame_id:=livox_frame
+
+benchmark:
+  output_dir: /tmp/lidarloc_v1_1_koide_outdoor01_public_map_failure_boundary
+  ros_domain_id: 172
+  bag_duration: 0
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true
+  write_health_summary: true
+  health_stable_ok_rows: 5
+  health_recovery_window_sec: 10.0
+  health_false_recovery_rmse_threshold_m: 5.0
+  write_route_grid_relocalization_attempts: true
+  route_grid_time_radius_sec: 15.0
+  route_grid_min_spacing_m: 5.0
+  route_grid_max_route_poses: 32
+  route_grid_max_candidates: 256
+  route_grid_yaw_offsets_deg: [-15, 0, 15]
+  route_grid_lateral_offsets_m: [-1.0, 0.0, 1.0]
+  route_grid_longitudinal_offsets_m: [0.0]
+  write_reference_oracle_relocalization_scores: true
+  reference_oracle_translation_threshold_m: 2.0
+  reference_oracle_yaw_threshold_deg: 15.0
+  reference_oracle_yaw_weight_m_per_rad: 1.0
+  write_registration_relocalization_jobs: true
+  registration_jobs_method: NDT_OMP
+  registration_jobs_max_candidates_per_attempt: 32
+  registration_jobs_selection_source: candidate_index
+  registration_jobs_voxel_leaf_size: 1.0
+  registration_jobs_local_map_radius: 120.0
+  registration_jobs_timeout_sec: 1.0
+  write_registration_relocalization_scan_scores: true
+  registration_scores_max_scan_time_diff: 0.25
+  registration_scores_min_range: 1.0
+  registration_scores_max_range: 120.0
+  registration_scores_max_jobs: 32
+  registration_scores_export_scan_pcd_dir: manifest://registration_scans
+  write_ndt_relocalization_scores: false
+  ndt_relocalization_max_jobs: 1
+  ndt_relocalization_score_gate_threshold: 6.0
+  ndt_relocalization_refinement_delta_gate_m: 2.0
+  ndt_relocalization_refinement_yaw_gate_rad: 0.7853981633974483
+  write_registration_relocalization_score_summary: true
+  write_registration_ordering_comparison: false
+  registration_ordering_top_k: 5
+  registration_ordering_output_dir: manifest://registration_ordering_comparison
+  write_relocalization_reset_candidate_plan: false
+  relocalization_reset_candidate_plan_csv: manifest://relocalization_reset_candidate_plan.csv
+  relocalization_reset_candidate_plan_min_score_margin: 0.0
+  validate_relocalization_reset_candidate_plan: false
+  relocalization_reset_candidate_plan_min_selected_count: 0
+  write_relocalization_reset_command_dry_run: false
+  relocalization_reset_commands_csv: manifest://relocalization_reset_commands.csv
+  relocalization_reset_publish_topic: /initialpose
+  relocalization_reset_frame_id: map
+  validate_relocalization_reset_commands: false
+  relocalization_reset_commands_min_generated_count: 0
+  write_disabled_relocalization_attempts: false
+  write_relocalization_attempt_summary: true
+  relocalization_request_match_window_sec: 10.0
+  relocalization_post_reset_stable_ok_rows: 5

--- a/scripts/benchmark_from_manifest
+++ b/scripts/benchmark_from_manifest
@@ -118,10 +118,959 @@ def validate_manifest_for_execution(manifest_path: Path, manifest: Dict[str, Any
 
 
 def run_command(command: list[str], print_only: bool) -> None:
-    print(" ".join(quote(part) for part in command))
+    print(" ".join(quote(part) for part in command), flush=True)
     if print_only:
         return
     subprocess.run(command, check=True)
+
+
+def csv_arg(value: Any) -> str:
+    if isinstance(value, (list, tuple)):
+        return ",".join(str(item) for item in value)
+    return str(value)
+
+
+def run_health_summary(
+    benchmark: Dict[str, Any],
+    output_dir: Path,
+    eval_json: Optional[Path],
+    print_only: bool,
+) -> None:
+    if not bool(benchmark.get("write_health_summary", True)):
+        return
+
+    alignment_csv = output_dir / "alignment_status.csv"
+    if not print_only and not alignment_csv.exists():
+        raise RuntimeError(f"alignment_status.csv does not exist: {alignment_csv}")
+
+    health_script = _script_sibling("summarize_localization_health.py")
+    health_cmd = [
+        str(health_script),
+        "--alignment-csv",
+        str(alignment_csv),
+        "--output-json",
+        str(output_dir / "health_summary.json"),
+        "--output-md",
+        str(output_dir / "health_summary.md"),
+        "--stable-ok-rows",
+        str(int(benchmark.get("health_stable_ok_rows", 5))),
+        "--recovery-window-sec",
+        str(float(benchmark.get("health_recovery_window_sec", 10.0))),
+        "--false-recovery-rmse-threshold-m",
+        str(float(benchmark.get("health_false_recovery_rmse_threshold_m", 5.0))),
+    ]
+    if eval_json is not None:
+        health_cmd.extend(["--trajectory-eval-json", str(eval_json)])
+    run_command(health_cmd, print_only)
+
+
+def resolve_relocalization_attempts_csv(
+    benchmark: Dict[str, Any],
+    output_dir: Path,
+) -> Path:
+    attempts_csv_raw = benchmark.get("relocalization_attempts_csv")
+    attempts_csv = (
+        resolve_path(str(attempts_csv_raw), output_dir)
+        if attempts_csv_raw
+        else output_dir / "relocalization_attempts.csv"
+    )
+    assert attempts_csv is not None
+    return attempts_csv
+
+
+def resolve_relocalization_candidates_csv(
+    benchmark: Dict[str, Any],
+    output_dir: Path,
+) -> Path:
+    candidates_csv_raw = benchmark.get("relocalization_candidates_csv")
+    candidates_csv = (
+        resolve_path(str(candidates_csv_raw), output_dir)
+        if candidates_csv_raw
+        else output_dir / "relocalization_candidates.csv"
+    )
+    assert candidates_csv is not None
+    return candidates_csv
+
+
+def run_disabled_relocalization_attempt_baseline(
+    benchmark: Dict[str, Any],
+    output_dir: Path,
+    print_only: bool,
+) -> None:
+    if not bool(benchmark.get("write_disabled_relocalization_attempts", False)):
+        return
+
+    alignment_csv = output_dir / "alignment_status.csv"
+    if not print_only and not alignment_csv.exists():
+        raise RuntimeError(f"alignment_status.csv does not exist: {alignment_csv}")
+
+    attempts_csv = resolve_relocalization_attempts_csv(benchmark, output_dir)
+    if attempts_csv.exists() and not bool(
+        benchmark.get("overwrite_relocalization_attempts_csv", False)
+    ):
+        print(f"relocalization_attempts_csv_exists: {attempts_csv}")
+        return
+
+    baseline_script = _script_sibling("make_disabled_relocalization_attempts.py")
+    baseline_cmd = [
+        str(baseline_script),
+        "--alignment-csv",
+        str(alignment_csv),
+        "--output-csv",
+        str(attempts_csv),
+        "--source",
+        str(benchmark.get("disabled_relocalization_attempt_source", "disabled")),
+        "--mode",
+        str(benchmark.get("disabled_relocalization_attempt_mode", "diagnostic_request")),
+        "--roi-type",
+        str(benchmark.get("disabled_relocalization_attempt_roi_type", "none")),
+        "--rejection-reason",
+        str(
+            benchmark.get(
+                "disabled_relocalization_attempt_rejection_reason",
+                "candidate_generator_disabled",
+            )
+        ),
+    ]
+    if bool(benchmark.get("overwrite_relocalization_attempts_csv", False)):
+        baseline_cmd.append("--overwrite")
+    run_command(baseline_cmd, print_only)
+
+
+def run_route_grid_relocalization_attempts(
+    benchmark: Dict[str, Any],
+    dataset: Dict[str, Any],
+    manifest_dir: Path,
+    output_dir: Path,
+    print_only: bool,
+) -> None:
+    if not bool(benchmark.get("write_route_grid_relocalization_attempts", False)):
+        return
+
+    alignment_csv = output_dir / "alignment_status.csv"
+    if not print_only and not alignment_csv.exists():
+        raise RuntimeError(f"alignment_status.csv does not exist: {alignment_csv}")
+
+    reference_csv_raw = benchmark.get("route_grid_reference_csv") or dataset.get("reference_csv")
+    if not reference_csv_raw:
+        raise RuntimeError(
+            "write_route_grid_relocalization_attempts requires dataset.reference_csv "
+            "or benchmark.route_grid_reference_csv"
+        )
+    reference_csv = resolve_path(str(reference_csv_raw), manifest_dir)
+    assert reference_csv is not None
+    if not print_only and not reference_csv.exists():
+        raise RuntimeError(f"reference CSV does not exist: {reference_csv}")
+
+    attempts_csv = resolve_relocalization_attempts_csv(benchmark, output_dir)
+    if attempts_csv.exists() and not bool(
+        benchmark.get("overwrite_relocalization_attempts_csv", False)
+    ):
+        print(f"relocalization_attempts_csv_exists: {attempts_csv}")
+        return
+
+    candidates_csv = resolve_relocalization_candidates_csv(benchmark, output_dir)
+
+    route_script = _script_sibling("make_route_grid_relocalization_attempts.py")
+    route_cmd = [
+        str(route_script),
+        "--alignment-csv",
+        str(alignment_csv),
+        "--reference-csv",
+        str(reference_csv),
+        "--output-csv",
+        str(attempts_csv),
+        "--output-candidates-csv",
+        str(candidates_csv),
+        "--source",
+        str(benchmark.get("route_grid_relocalization_attempt_source", "route_grid")),
+        "--mode",
+        str(benchmark.get("route_grid_relocalization_attempt_mode", "offline_route_roi")),
+        "--roi-type",
+        str(benchmark.get("route_grid_relocalization_attempt_roi_type", "route_corridor")),
+        "--route-time-radius-sec",
+        str(float(benchmark.get("route_grid_time_radius_sec", 15.0))),
+        "--route-min-spacing-m",
+        str(float(benchmark.get("route_grid_min_spacing_m", 10.0))),
+        "--max-route-poses",
+        str(int(benchmark.get("route_grid_max_route_poses", 32))),
+        "--max-candidates",
+        str(int(benchmark.get("route_grid_max_candidates", 256))),
+        "--yaw-offsets-deg="
+        + csv_arg(benchmark.get("route_grid_yaw_offsets_deg", [0])),
+        "--lateral-offsets-m="
+        + csv_arg(benchmark.get("route_grid_lateral_offsets_m", [0])),
+        "--longitudinal-offsets-m="
+        + csv_arg(benchmark.get("route_grid_longitudinal_offsets_m", [0])),
+        "--rejection-reason",
+        str(
+            benchmark.get(
+                "route_grid_relocalization_attempt_rejection_reason",
+                "candidate_scoring_not_implemented",
+            )
+        ),
+    ]
+    if bool(benchmark.get("overwrite_relocalization_attempts_csv", False)):
+        route_cmd.append("--overwrite")
+    run_command(route_cmd, print_only)
+
+
+def run_reference_oracle_relocalization_scoring(
+    benchmark: Dict[str, Any],
+    dataset: Dict[str, Any],
+    manifest_dir: Path,
+    output_dir: Path,
+    print_only: bool,
+) -> None:
+    if not bool(benchmark.get("write_reference_oracle_relocalization_scores", False)):
+        return
+
+    reference_csv_raw = (
+        benchmark.get("reference_oracle_reference_csv")
+        or benchmark.get("route_grid_reference_csv")
+        or dataset.get("reference_csv")
+    )
+    if not reference_csv_raw:
+        raise RuntimeError(
+            "write_reference_oracle_relocalization_scores requires dataset.reference_csv "
+            "or benchmark.reference_oracle_reference_csv"
+        )
+    reference_csv = resolve_path(str(reference_csv_raw), manifest_dir)
+    assert reference_csv is not None
+    if not print_only and not reference_csv.exists():
+        raise RuntimeError(f"reference CSV does not exist: {reference_csv}")
+
+    attempts_csv = resolve_relocalization_attempts_csv(benchmark, output_dir)
+    candidates_csv = resolve_relocalization_candidates_csv(benchmark, output_dir)
+    if not print_only:
+        if not attempts_csv.exists():
+            raise RuntimeError(f"relocalization attempts CSV does not exist: {attempts_csv}")
+        if not candidates_csv.exists():
+            raise RuntimeError(f"relocalization candidates CSV does not exist: {candidates_csv}")
+
+    scored_candidates_raw = benchmark.get("relocalization_candidate_scores_csv")
+    scored_candidates_csv = (
+        resolve_path(str(scored_candidates_raw), output_dir)
+        if scored_candidates_raw
+        else output_dir / "relocalization_candidate_scores.csv"
+    )
+    assert scored_candidates_csv is not None
+
+    scorer_script = _script_sibling("score_relocalization_candidates_with_reference.py")
+    scorer_cmd = [
+        str(scorer_script),
+        "--attempts-csv",
+        str(attempts_csv),
+        "--candidates-csv",
+        str(candidates_csv),
+        "--reference-csv",
+        str(reference_csv),
+        "--output-attempts-csv",
+        str(attempts_csv),
+        "--output-scored-candidates-csv",
+        str(scored_candidates_csv),
+        "--translation-threshold-m",
+        str(float(benchmark.get("reference_oracle_translation_threshold_m", 2.0))),
+        "--yaw-threshold-deg",
+        str(float(benchmark.get("reference_oracle_yaw_threshold_deg", 15.0))),
+        "--yaw-weight-m-per-rad",
+        str(float(benchmark.get("reference_oracle_yaw_weight_m_per_rad", 1.0))),
+        "--rejection-reason",
+        str(
+            benchmark.get(
+                "reference_oracle_relocalization_attempt_rejection_reason",
+                "offline_oracle_scored_no_reset",
+            )
+        ),
+    ]
+    if bool(benchmark.get("overwrite_relocalization_attempts_csv", False)):
+        scorer_cmd.append("--overwrite")
+    run_command(scorer_cmd, print_only)
+
+
+def run_registration_relocalization_jobs(
+    benchmark: Dict[str, Any],
+    dataset: Dict[str, Any],
+    manifest_dir: Path,
+    output_dir: Path,
+    print_only: bool,
+) -> None:
+    if not bool(benchmark.get("write_registration_relocalization_jobs", False)):
+        return
+
+    bag_path = resolve_required_path(dataset, "bag_path", manifest_dir)
+    map_path = resolve_required_path(dataset, "map_path", manifest_dir)
+    cloud_topic = str(dataset.get("cloud_topic", "/velodyne_points"))
+    attempts_csv = resolve_relocalization_attempts_csv(benchmark, output_dir)
+
+    scored_candidates = output_dir / "relocalization_candidate_scores.csv"
+    if benchmark.get("registration_jobs_candidates_csv"):
+        candidates_csv = resolve_path(
+            str(benchmark.get("registration_jobs_candidates_csv")), output_dir
+        )
+        assert candidates_csv is not None
+    elif scored_candidates.exists() or bool(
+        benchmark.get("write_reference_oracle_relocalization_scores", False)
+    ):
+        candidates_csv = scored_candidates
+    else:
+        candidates_csv = resolve_relocalization_candidates_csv(benchmark, output_dir)
+
+    if not print_only:
+        if not attempts_csv.exists():
+            raise RuntimeError(f"relocalization attempts CSV does not exist: {attempts_csv}")
+        if not candidates_csv.exists():
+            raise RuntimeError(f"relocalization candidates CSV does not exist: {candidates_csv}")
+
+    jobs_csv_raw = benchmark.get("registration_relocalization_jobs_csv")
+    jobs_csv = (
+        resolve_path(str(jobs_csv_raw), output_dir)
+        if jobs_csv_raw
+        else output_dir / "relocalization_registration_jobs.csv"
+    )
+    assert jobs_csv is not None
+
+    jobs_script = _script_sibling("make_registration_relocalization_jobs.py")
+    jobs_cmd = [
+        str(jobs_script),
+        "--attempts-csv",
+        str(attempts_csv),
+        "--candidates-csv",
+        str(candidates_csv),
+        "--bag-path",
+        str(bag_path),
+        "--map-path",
+        str(map_path),
+        "--cloud-topic",
+        cloud_topic,
+        "--output-csv",
+        str(jobs_csv),
+        "--registration-method",
+        str(benchmark.get("registration_jobs_method", "NDT_OMP")),
+        "--max-candidates-per-attempt",
+        str(int(benchmark.get("registration_jobs_max_candidates_per_attempt", 32))),
+        "--selection-source",
+        str(benchmark.get("registration_jobs_selection_source", "candidate_index")),
+        "--voxel-leaf-size",
+        str(float(benchmark.get("registration_jobs_voxel_leaf_size", 1.0))),
+        "--local-map-radius",
+        str(float(benchmark.get("registration_jobs_local_map_radius", 150.0))),
+        "--timeout-sec",
+        str(float(benchmark.get("registration_jobs_timeout_sec", 1.0))),
+    ]
+    if bool(benchmark.get("overwrite_relocalization_attempts_csv", False)):
+        jobs_cmd.append("--overwrite")
+    run_command(jobs_cmd, print_only)
+
+
+def run_registration_relocalization_scan_resolution(
+    benchmark: Dict[str, Any],
+    output_dir: Path,
+    print_only: bool,
+) -> None:
+    if not bool(benchmark.get("write_registration_relocalization_scan_scores", False)):
+        return
+
+    jobs_csv_raw = benchmark.get("registration_relocalization_jobs_csv")
+    jobs_csv = (
+        resolve_path(str(jobs_csv_raw), output_dir)
+        if jobs_csv_raw
+        else output_dir / "relocalization_registration_jobs.csv"
+    )
+    assert jobs_csv is not None
+    if not print_only and not jobs_csv.exists():
+        raise RuntimeError(f"relocalization registration jobs CSV does not exist: {jobs_csv}")
+
+    scores_csv_raw = benchmark.get("registration_relocalization_scores_csv")
+    scores_csv = (
+        resolve_path(str(scores_csv_raw), output_dir)
+        if scores_csv_raw
+        else output_dir / "relocalization_registration_scores.csv"
+    )
+    assert scores_csv is not None
+
+    resolver_script = _script_sibling("resolve_registration_relocalization_scans.py")
+    resolver_cmd = [
+        str(resolver_script),
+        "--jobs-csv",
+        str(jobs_csv),
+        "--output-csv",
+        str(scores_csv),
+        "--max-scan-time-diff",
+        str(float(benchmark.get("registration_scores_max_scan_time_diff", 0.25))),
+        "--min-range",
+        str(float(benchmark.get("registration_scores_min_range", 1.0))),
+        "--max-range",
+        str(float(benchmark.get("registration_scores_max_range", 120.0))),
+        "--max-jobs",
+        str(int(benchmark.get("registration_scores_max_jobs", 0))),
+    ]
+    export_scan_pcd_dir = benchmark.get("registration_scores_export_scan_pcd_dir")
+    if export_scan_pcd_dir:
+        resolved_export_dir = resolve_path(str(export_scan_pcd_dir), output_dir)
+        assert resolved_export_dir is not None
+        resolver_cmd.extend(["--export-scan-pcd-dir", str(resolved_export_dir)])
+    if bool(benchmark.get("overwrite_relocalization_attempts_csv", False)):
+        resolver_cmd.append("--overwrite")
+    run_command(resolver_cmd, print_only)
+
+
+def run_ndt_relocalization_scoring(
+    benchmark: Dict[str, Any],
+    output_dir: Path,
+    print_only: bool,
+) -> None:
+    if not bool(benchmark.get("write_ndt_relocalization_scores", False)):
+        return
+
+    input_scores_raw = benchmark.get("ndt_relocalization_input_scores_csv")
+    input_scores_csv = (
+        resolve_path(str(input_scores_raw), output_dir)
+        if input_scores_raw
+        else output_dir / "relocalization_registration_scores.csv"
+    )
+    assert input_scores_csv is not None
+    if not print_only and not input_scores_csv.exists():
+        raise RuntimeError(
+            f"relocalization registration scores CSV does not exist: {input_scores_csv}"
+        )
+
+    output_scores_raw = benchmark.get("ndt_relocalization_output_scores_csv")
+    output_scores_csv = (
+        resolve_path(str(output_scores_raw), output_dir)
+        if output_scores_raw
+        else output_dir / "relocalization_registration_scores_ndt.csv"
+    )
+    assert output_scores_csv is not None
+
+    ndt_cmd = [
+        "ros2",
+        "run",
+        "lidar_localization_ros2",
+        "relocalization_ndt_score_jobs",
+        "--input-csv",
+        str(input_scores_csv),
+        "--output-csv",
+        str(output_scores_csv),
+        "--max-jobs",
+        str(int(benchmark.get("ndt_relocalization_max_jobs", 1))),
+        "--ndt-resolution",
+        str(float(benchmark.get("ndt_relocalization_resolution", 1.0))),
+        "--ndt-step-size",
+        str(float(benchmark.get("ndt_relocalization_step_size", 0.1))),
+        "--transform-epsilon",
+        str(float(benchmark.get("ndt_relocalization_transform_epsilon", 0.01))),
+        "--max-iterations",
+        str(int(benchmark.get("ndt_relocalization_max_iterations", 30))),
+        "--num-threads",
+        str(int(benchmark.get("ndt_relocalization_num_threads", 1))),
+        "--scan-voxel-leaf-size",
+        str(float(benchmark.get("ndt_relocalization_scan_voxel_leaf_size", 1.0))),
+        "--target-voxel-leaf-size",
+        str(float(benchmark.get("ndt_relocalization_target_voxel_leaf_size", 1.0))),
+        "--local-map-radius",
+        str(float(benchmark.get("ndt_relocalization_local_map_radius", 150.0))),
+        "--min-target-points",
+        str(int(benchmark.get("ndt_relocalization_min_target_points", 100))),
+        "--score-gate-threshold",
+        str(float(benchmark.get("ndt_relocalization_score_gate_threshold", 6.0))),
+        "--refinement-delta-gate-m",
+        str(float(benchmark.get("ndt_relocalization_refinement_delta_gate_m", 2.0))),
+        "--refinement-yaw-gate-rad",
+        str(float(benchmark.get("ndt_relocalization_refinement_yaw_gate_rad", 0.7853981633974483))),
+    ]
+    run_command(ndt_cmd, print_only)
+
+
+def run_registration_relocalization_score_summary(
+    benchmark: Dict[str, Any],
+    output_dir: Path,
+    print_only: bool,
+) -> None:
+    if not bool(benchmark.get("write_registration_relocalization_score_summary", True)):
+        return
+
+    if not bool(benchmark.get("write_ndt_relocalization_scores", False)):
+        return
+
+    scores_raw = benchmark.get("registration_score_summary_scores_csv")
+    if scores_raw:
+        scores_csv = resolve_path(str(scores_raw), output_dir)
+    elif benchmark.get("ndt_relocalization_output_scores_csv"):
+        scores_csv = resolve_path(
+            str(benchmark.get("ndt_relocalization_output_scores_csv")), output_dir
+        )
+    else:
+        scores_csv = output_dir / "relocalization_registration_scores_ndt.csv"
+    assert scores_csv is not None
+    if not print_only and not scores_csv.exists():
+        raise RuntimeError(f"registration score CSV does not exist: {scores_csv}")
+
+    summary_script = _script_sibling("summarize_registration_relocalization_scores.py")
+    summary_cmd = [
+        str(summary_script),
+        "--scores-csv",
+        str(scores_csv),
+        "--output-json",
+        str(output_dir / "relocalization_registration_score_summary.json"),
+        "--output-md",
+        str(output_dir / "relocalization_registration_score_summary.md"),
+    ]
+    run_command(summary_cmd, print_only)
+
+
+def run_registration_ordering_comparison(
+    benchmark: Dict[str, Any],
+    dataset: Dict[str, Any],
+    manifest_dir: Path,
+    output_dir: Path,
+    print_only: bool,
+) -> None:
+    if not bool(benchmark.get("write_registration_ordering_comparison", False)):
+        return
+
+    bag_path = resolve_required_path(dataset, "bag_path", manifest_dir)
+    map_path = resolve_required_path(dataset, "map_path", manifest_dir)
+    cloud_topic = str(dataset.get("cloud_topic", "/velodyne_points"))
+    attempts_csv = resolve_relocalization_attempts_csv(benchmark, output_dir)
+
+    candidates_raw = benchmark.get("registration_ordering_candidates_csv")
+    if candidates_raw:
+        candidates_csv = resolve_path(str(candidates_raw), output_dir)
+    elif (output_dir / "relocalization_candidate_scores.csv").exists() or bool(
+        benchmark.get("write_reference_oracle_relocalization_scores", False)
+    ):
+        candidates_csv = output_dir / "relocalization_candidate_scores.csv"
+    else:
+        candidates_csv = resolve_relocalization_candidates_csv(benchmark, output_dir)
+    assert candidates_csv is not None
+
+    if not print_only:
+        if not attempts_csv.exists():
+            raise RuntimeError(f"relocalization attempts CSV does not exist: {attempts_csv}")
+        if not candidates_csv.exists():
+            raise RuntimeError(f"relocalization candidates CSV does not exist: {candidates_csv}")
+
+    ordering_output_raw = benchmark.get("registration_ordering_output_dir")
+    ordering_output_dir = (
+        resolve_path(str(ordering_output_raw), output_dir)
+        if ordering_output_raw
+        else output_dir / "registration_ordering_comparison"
+    )
+    assert ordering_output_dir is not None
+
+    runner_script = _script_sibling("run_registration_ordering_comparison.py")
+    runner_cmd = [
+        str(runner_script),
+        "--attempts-csv",
+        str(attempts_csv),
+        "--candidates-csv",
+        str(candidates_csv),
+        "--bag-path",
+        str(bag_path),
+        "--map-path",
+        str(map_path),
+        "--cloud-topic",
+        cloud_topic,
+        "--output-dir",
+        str(ordering_output_dir),
+        "--top-k",
+        str(int(benchmark.get("registration_ordering_top_k", 5))),
+        "--registration-method",
+        str(benchmark.get("registration_jobs_method", "NDT_OMP")),
+        "--local-map-radius",
+        str(
+            float(
+                benchmark.get(
+                    "registration_ordering_local_map_radius",
+                    benchmark.get("registration_jobs_local_map_radius", 150.0),
+                )
+            )
+        ),
+        "--voxel-leaf-size",
+        str(
+            float(
+                benchmark.get(
+                    "registration_ordering_voxel_leaf_size",
+                    benchmark.get("registration_jobs_voxel_leaf_size", 1.0),
+                )
+            )
+        ),
+        "--scan-min-range",
+        str(float(benchmark.get("registration_scores_min_range", 1.0))),
+        "--scan-max-range",
+        str(float(benchmark.get("registration_scores_max_range", 120.0))),
+        "--max-scan-time-diff",
+        str(float(benchmark.get("registration_scores_max_scan_time_diff", 0.25))),
+        "--ndt-resolution",
+        str(float(benchmark.get("ndt_relocalization_resolution", 1.0))),
+        "--ndt-step-size",
+        str(float(benchmark.get("ndt_relocalization_step_size", 0.1))),
+        "--transform-epsilon",
+        str(float(benchmark.get("ndt_relocalization_transform_epsilon", 0.01))),
+        "--max-iterations",
+        str(int(benchmark.get("ndt_relocalization_max_iterations", 30))),
+        "--num-threads",
+        str(int(benchmark.get("ndt_relocalization_num_threads", 1))),
+        "--score-gate-threshold",
+        str(float(benchmark.get("ndt_relocalization_score_gate_threshold", 6.0))),
+        "--refinement-delta-gate-m",
+        str(float(benchmark.get("ndt_relocalization_refinement_delta_gate_m", 2.0))),
+        "--refinement-yaw-gate-rad",
+        str(float(benchmark.get("ndt_relocalization_refinement_yaw_gate_rad", 0.7853981633974483))),
+    ]
+    if bool(benchmark.get("registration_ordering_overwrite", True)):
+        runner_cmd.append("--overwrite")
+    run_command(runner_cmd, print_only)
+
+
+def run_relocalization_reset_candidate_plan(
+    benchmark: Dict[str, Any],
+    output_dir: Path,
+    print_only: bool,
+) -> None:
+    if not bool(benchmark.get("write_relocalization_reset_candidate_plan", False)):
+        return
+
+    scores_raw = benchmark.get("relocalization_reset_candidate_plan_scores_csv")
+    if scores_raw:
+        scores_csv = resolve_path(str(scores_raw), output_dir)
+    elif bool(benchmark.get("write_registration_ordering_comparison", False)):
+        ordering_output_raw = benchmark.get("registration_ordering_output_dir")
+        ordering_output_dir = (
+            resolve_path(str(ordering_output_raw), output_dir)
+            if ordering_output_raw
+            else output_dir / "registration_ordering_comparison"
+        )
+        assert ordering_output_dir is not None
+        top_k = int(benchmark.get("registration_ordering_top_k", 5))
+        scores_csv = (
+            ordering_output_dir
+            / f"relocalization_registration_scores_ndt_candidate_index_top{top_k}.csv"
+        )
+    elif benchmark.get("ndt_relocalization_output_scores_csv"):
+        scores_csv = resolve_path(
+            str(benchmark.get("ndt_relocalization_output_scores_csv")), output_dir
+        )
+    else:
+        scores_csv = output_dir / "relocalization_registration_scores_ndt.csv"
+    assert scores_csv is not None
+    if not print_only and not scores_csv.exists():
+        raise RuntimeError(f"reset candidate plan scores CSV does not exist: {scores_csv}")
+
+    output_csv_raw = benchmark.get("relocalization_reset_candidate_plan_csv")
+    output_csv = (
+        resolve_path(str(output_csv_raw), output_dir)
+        if output_csv_raw
+        else output_dir / "relocalization_reset_candidate_plan.csv"
+    )
+    assert output_csv is not None
+    output_json = output_csv.with_suffix(".json")
+    output_md = output_csv.with_suffix(".md")
+
+    selector_script = _script_sibling("select_relocalization_reset_candidates.py")
+    selector_cmd = [
+        str(selector_script),
+        "--scores-csv",
+        str(scores_csv),
+        "--output-csv",
+        str(output_csv),
+        "--output-json",
+        str(output_json),
+        "--output-md",
+        str(output_md),
+        "--policy-name",
+        str(
+            benchmark.get(
+                "relocalization_reset_candidate_plan_policy",
+                "lowest_registration_score_with_gate",
+            )
+        ),
+        "--max-score",
+        str(
+            float(
+                benchmark.get(
+                    "relocalization_reset_candidate_plan_max_score",
+                    benchmark.get("ndt_relocalization_score_gate_threshold", 6.0),
+                )
+            )
+        ),
+        "--max-refinement-delta-m",
+        str(
+            float(
+                benchmark.get(
+                    "relocalization_reset_candidate_plan_max_refinement_delta_m",
+                    benchmark.get("ndt_relocalization_refinement_delta_gate_m", 2.0),
+                )
+            )
+        ),
+        "--max-refinement-yaw-rad",
+        str(
+            float(
+                benchmark.get(
+                    "relocalization_reset_candidate_plan_max_refinement_yaw_rad",
+                    benchmark.get(
+                        "ndt_relocalization_refinement_yaw_gate_rad",
+                        0.7853981633974483,
+                    ),
+                )
+            )
+        ),
+        "--min-score-margin",
+        str(float(benchmark.get("relocalization_reset_candidate_plan_min_score_margin", 0.0))),
+    ]
+    if not bool(benchmark.get("relocalization_reset_candidate_plan_require_gate", True)):
+        selector_cmd.append("--no-require-registration-gate")
+    if bool(benchmark.get("relocalization_reset_candidate_plan_overwrite", True)):
+        selector_cmd.append("--overwrite")
+    run_command(selector_cmd, print_only)
+
+
+def run_relocalization_reset_candidate_plan_validation(
+    benchmark: Dict[str, Any],
+    output_dir: Path,
+    print_only: bool,
+) -> None:
+    if not bool(benchmark.get("validate_relocalization_reset_candidate_plan", False)):
+        return
+
+    plan_raw = benchmark.get("relocalization_reset_candidate_plan_csv")
+    plan_csv = (
+        resolve_path(str(plan_raw), output_dir)
+        if plan_raw
+        else output_dir / "relocalization_reset_candidate_plan.csv"
+    )
+    assert plan_csv is not None
+    if not print_only and not plan_csv.exists():
+        raise RuntimeError(f"reset candidate plan CSV does not exist: {plan_csv}")
+
+    scores_raw = benchmark.get("relocalization_reset_candidate_plan_scores_csv")
+    if scores_raw:
+        scores_csv = resolve_path(str(scores_raw), output_dir)
+    elif bool(benchmark.get("write_registration_ordering_comparison", False)):
+        ordering_output_raw = benchmark.get("registration_ordering_output_dir")
+        ordering_output_dir = (
+            resolve_path(str(ordering_output_raw), output_dir)
+            if ordering_output_raw
+            else output_dir / "registration_ordering_comparison"
+        )
+        assert ordering_output_dir is not None
+        top_k = int(benchmark.get("registration_ordering_top_k", 5))
+        scores_csv = (
+            ordering_output_dir
+            / f"relocalization_registration_scores_ndt_candidate_index_top{top_k}.csv"
+        )
+    elif benchmark.get("ndt_relocalization_output_scores_csv"):
+        scores_csv = resolve_path(
+            str(benchmark.get("ndt_relocalization_output_scores_csv")), output_dir
+        )
+    else:
+        scores_csv = output_dir / "relocalization_registration_scores_ndt.csv"
+    assert scores_csv is not None
+    if not print_only and not scores_csv.exists():
+        raise RuntimeError(f"reset candidate plan scores CSV does not exist: {scores_csv}")
+
+    validator_script = _script_sibling("validate_relocalization_reset_candidate_plan.py")
+    validation_json = output_dir / "relocalization_reset_candidate_plan_validation.json"
+    validation_md = output_dir / "relocalization_reset_candidate_plan_validation.md"
+    validator_cmd = [
+        str(validator_script),
+        "--plan-csv",
+        str(plan_csv),
+        "--scores-csv",
+        str(scores_csv),
+        "--output-json",
+        str(validation_json),
+        "--output-md",
+        str(validation_md),
+        "--max-score",
+        str(
+            float(
+                benchmark.get(
+                    "relocalization_reset_candidate_plan_max_score",
+                    benchmark.get("ndt_relocalization_score_gate_threshold", 6.0),
+                )
+            )
+        ),
+        "--max-refinement-delta-m",
+        str(
+            float(
+                benchmark.get(
+                    "relocalization_reset_candidate_plan_max_refinement_delta_m",
+                    benchmark.get("ndt_relocalization_refinement_delta_gate_m", 2.0),
+                )
+            )
+        ),
+        "--max-refinement-yaw-rad",
+        str(
+            float(
+                benchmark.get(
+                    "relocalization_reset_candidate_plan_max_refinement_yaw_rad",
+                    benchmark.get(
+                        "ndt_relocalization_refinement_yaw_gate_rad",
+                        0.7853981633974483,
+                    ),
+                )
+            )
+        ),
+        "--min-selected-count",
+        str(int(benchmark.get("relocalization_reset_candidate_plan_min_selected_count", 0))),
+        "--max-selected-count",
+        str(int(benchmark.get("relocalization_reset_candidate_plan_max_selected_count", -1))),
+        "--overwrite",
+    ]
+    if bool(benchmark.get("relocalization_reset_candidate_plan_allow_accepted", False)):
+        validator_cmd.append("--allow-accepted")
+    if bool(benchmark.get("relocalization_reset_candidate_plan_allow_oracle_selection", False)):
+        validator_cmd.append("--allow-oracle-selection")
+    run_command(validator_cmd, print_only)
+
+
+def run_relocalization_reset_command_dry_run(
+    benchmark: Dict[str, Any],
+    output_dir: Path,
+    print_only: bool,
+) -> None:
+    if not bool(benchmark.get("write_relocalization_reset_command_dry_run", False)):
+        return
+
+    plan_raw = benchmark.get("relocalization_reset_candidate_plan_csv")
+    plan_csv = (
+        resolve_path(str(plan_raw), output_dir)
+        if plan_raw
+        else output_dir / "relocalization_reset_candidate_plan.csv"
+    )
+    assert plan_csv is not None
+    if not print_only and not plan_csv.exists():
+        raise RuntimeError(f"reset candidate plan CSV does not exist: {plan_csv}")
+
+    commands_raw = benchmark.get("relocalization_reset_commands_csv")
+    commands_csv = (
+        resolve_path(str(commands_raw), output_dir)
+        if commands_raw
+        else output_dir / "relocalization_reset_commands.csv"
+    )
+    assert commands_csv is not None
+    commands_json = commands_csv.with_suffix(".json")
+    commands_md = commands_csv.with_suffix(".md")
+
+    command_script = _script_sibling("make_relocalization_reset_commands.py")
+    command_cmd = [
+        str(command_script),
+        "--plan-csv",
+        str(plan_csv),
+        "--output-csv",
+        str(commands_csv),
+        "--output-json",
+        str(commands_json),
+        "--output-md",
+        str(commands_md),
+        "--publish-topic",
+        str(benchmark.get("relocalization_reset_publish_topic", "/initialpose")),
+        "--frame-id",
+        str(benchmark.get("relocalization_reset_frame_id", "map")),
+        "--stamp-source",
+        str(benchmark.get("relocalization_reset_stamp_source", "trigger")),
+    ]
+    if bool(benchmark.get("relocalization_reset_allow_accepted_plan", False)):
+        command_cmd.append("--allow-accepted-plan")
+    if bool(benchmark.get("relocalization_reset_commands_overwrite", True)):
+        command_cmd.append("--overwrite")
+    run_command(command_cmd, print_only)
+
+
+def run_relocalization_reset_command_validation(
+    benchmark: Dict[str, Any],
+    output_dir: Path,
+    print_only: bool,
+) -> None:
+    if not bool(benchmark.get("validate_relocalization_reset_commands", False)):
+        return
+
+    commands_raw = benchmark.get("relocalization_reset_commands_csv")
+    commands_csv = (
+        resolve_path(str(commands_raw), output_dir)
+        if commands_raw
+        else output_dir / "relocalization_reset_commands.csv"
+    )
+    assert commands_csv is not None
+    summary_json = commands_csv.with_suffix(".json")
+    if not print_only and not commands_csv.exists():
+        raise RuntimeError(f"reset commands CSV does not exist: {commands_csv}")
+    if not print_only and not summary_json.exists():
+        raise RuntimeError(f"reset commands summary JSON does not exist: {summary_json}")
+
+    validation_json = output_dir / "relocalization_reset_commands_validation.json"
+    validation_md = output_dir / "relocalization_reset_commands_validation.md"
+    validator_script = _script_sibling("validate_relocalization_reset_commands.py")
+    validator_cmd = [
+        str(validator_script),
+        "--commands-csv",
+        str(commands_csv),
+        "--summary-json",
+        str(summary_json),
+        "--output-json",
+        str(validation_json),
+        "--output-md",
+        str(validation_md),
+        "--expected-topic",
+        str(benchmark.get("relocalization_reset_publish_topic", "/initialpose")),
+        "--expected-frame-id",
+        str(benchmark.get("relocalization_reset_frame_id", "map")),
+        "--quaternion-norm-tolerance",
+        str(float(benchmark.get("relocalization_reset_quaternion_norm_tolerance", 1e-3))),
+        "--min-generated-count",
+        str(int(benchmark.get("relocalization_reset_commands_min_generated_count", 0))),
+        "--max-generated-count",
+        str(int(benchmark.get("relocalization_reset_commands_max_generated_count", -1))),
+        "--overwrite",
+    ]
+    if bool(benchmark.get("relocalization_reset_commands_allow_published", False)):
+        validator_cmd.append("--allow-published")
+    if bool(benchmark.get("relocalization_reset_commands_allow_accepted_source_plan", False)):
+        validator_cmd.append("--allow-accepted-source-plan")
+    if bool(benchmark.get("relocalization_reset_commands_allow_oracle_selection", False)):
+        validator_cmd.append("--allow-oracle-selection")
+    run_command(validator_cmd, print_only)
+
+
+def run_relocalization_attempt_summary(
+    benchmark: Dict[str, Any],
+    output_dir: Path,
+    eval_json: Optional[Path],
+    print_only: bool,
+) -> None:
+    if not bool(benchmark.get("write_relocalization_attempt_summary", True)):
+        return
+
+    alignment_csv = output_dir / "alignment_status.csv"
+    if not print_only and not alignment_csv.exists():
+        raise RuntimeError(f"alignment_status.csv does not exist: {alignment_csv}")
+
+    attempts_csv = resolve_relocalization_attempts_csv(benchmark, output_dir)
+
+    summary_script = _script_sibling("summarize_relocalization_attempts.py")
+    summary_cmd = [
+        str(summary_script),
+        "--alignment-csv",
+        str(alignment_csv),
+        "--attempts-csv",
+        str(attempts_csv),
+        "--allow-missing-attempts",
+        "--output-json",
+        str(output_dir / "relocalization_attempt_summary.json"),
+        "--output-md",
+        str(output_dir / "relocalization_attempt_summary.md"),
+        "--request-match-window-sec",
+        str(float(benchmark.get("relocalization_request_match_window_sec", 10.0))),
+        "--post-reset-stable-ok-rows",
+        str(int(benchmark.get("relocalization_post_reset_stable_ok_rows", 5))),
+        "--false-recovery-rmse-threshold-m",
+        str(float(benchmark.get("health_false_recovery_rmse_threshold_m", 5.0))),
+    ]
+    if eval_json is not None:
+        summary_cmd.extend(["--trajectory-eval-json", str(eval_json)])
+    run_command(summary_cmd, print_only)
 
 
 def infer_mode(manifest: Dict[str, Any], mode_override: str) -> str:
@@ -290,6 +1239,7 @@ def run_single_benchmark(
     run_command(runner_cmd, print_only)
 
     reference_csv_raw = dataset.get("reference_csv")
+    eval_json: Optional[Path] = None
     if reference_csv_raw:
         reference_csv = resolve_path(str(reference_csv_raw), manifest_dir)
         assert reference_csv is not None
@@ -309,6 +1259,30 @@ def run_single_benchmark(
         run_command(eval_cmd, print_only)
         if not print_only:
             (output_dir / "eval.json").write_text(eval_json.read_text(encoding="utf-8"), encoding="utf-8")
+
+    run_health_summary(benchmark, output_dir, eval_json, print_only)
+    if not bool(benchmark.get("write_route_grid_relocalization_attempts", False)):
+        run_disabled_relocalization_attempt_baseline(benchmark, output_dir, print_only)
+    run_route_grid_relocalization_attempts(
+        benchmark, dataset, manifest_dir, output_dir, print_only
+    )
+    run_reference_oracle_relocalization_scoring(
+        benchmark, dataset, manifest_dir, output_dir, print_only
+    )
+    run_registration_relocalization_jobs(
+        benchmark, dataset, manifest_dir, output_dir, print_only
+    )
+    run_registration_relocalization_scan_resolution(benchmark, output_dir, print_only)
+    run_ndt_relocalization_scoring(benchmark, output_dir, print_only)
+    run_registration_relocalization_score_summary(benchmark, output_dir, print_only)
+    run_registration_ordering_comparison(
+        benchmark, dataset, manifest_dir, output_dir, print_only
+    )
+    run_relocalization_reset_candidate_plan(benchmark, output_dir, print_only)
+    run_relocalization_reset_candidate_plan_validation(benchmark, output_dir, print_only)
+    run_relocalization_reset_command_dry_run(benchmark, output_dir, print_only)
+    run_relocalization_reset_command_validation(benchmark, output_dir, print_only)
+    run_relocalization_attempt_summary(benchmark, output_dir, eval_json, print_only)
 
     print(f"manifest_copy: {manifest_copy_path}")
     print(f"generated_param_yaml: {generated_yaml}")

--- a/scripts/compare_registration_relocalization_score_summaries.py
+++ b/scripts/compare_registration_relocalization_score_summaries.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare registration relocalization score summaries, for example "
+            "candidate_index order versus oracle_rank diagnostic order."
+        )
+    )
+    parser.add_argument(
+        "--summary",
+        action="append",
+        required=True,
+        metavar="LABEL:PATH",
+        help="Summary JSON with a label, e.g. candidate_index:path/to/summary.json",
+    )
+    parser.add_argument("--output-json", default="", help="Optional comparison JSON")
+    parser.add_argument("--output-md", default="", help="Optional comparison Markdown")
+    return parser.parse_args()
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def parse_summary_arg(raw: str) -> Tuple[str, Path]:
+    if ":" not in raw:
+        raise ValueError(f"expected LABEL:PATH, got {raw!r}")
+    label, path = raw.split(":", 1)
+    if not label:
+        raise ValueError(f"summary label is empty in {raw!r}")
+    return label, Path(path).expanduser().resolve()
+
+
+def load_summary(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"summary JSON does not exist: {path}")
+    with path.open("r", encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def stat_value(summary: Dict[str, Any], group: str, metric: str, key: str) -> Optional[float]:
+    value = summary.get(group, {}).get(metric, {}).get(key)
+    return value if isinstance(value, (int, float)) else None
+
+
+def scored_stat_value(summary: Dict[str, Any], metric: str, key: str) -> Optional[float]:
+    value = stat_value(summary, "scored_stats", metric, key)
+    if value is not None:
+        return value
+    return stat_value(summary, "stats", metric, key)
+
+
+def compact_row(label: str, path: Path, summary: Dict[str, Any]) -> Dict[str, Any]:
+    rows = summary.get("rows", {})
+    attempts = summary.get("attempts", {})
+    return {
+        "label": label,
+        "summary_json": str(path),
+        "scores_csv": summary.get("scores_csv"),
+        "row_count": rows.get("count"),
+        "scored_count": rows.get("scored_count"),
+        "scored_rate_percent": rows.get("scored_rate_percent"),
+        "converged_count": rows.get("converged_count"),
+        "gate_passed_count": rows.get("gate_passed_count"),
+        "gate_passed_rate_percent": rows.get("gate_passed_rate_percent"),
+        "attempt_count": attempts.get("count"),
+        "attempt_gate_passed_count": attempts.get("gate_passed_count"),
+        "score_median": scored_stat_value(summary, "score", "median"),
+        "score_min": scored_stat_value(summary, "score", "min"),
+        "score_max": scored_stat_value(summary, "score", "max"),
+        "refinement_delta_m_median": scored_stat_value(
+            summary, "refinement_delta_m", "median"
+        ),
+        "runtime_sec_median": scored_stat_value(summary, "runtime_sec", "median"),
+        "runtime_sec_max": scored_stat_value(summary, "runtime_sec", "max"),
+        "status_counts": summary.get("counts", {}).get("status", {}),
+        "gate_reason_counts": summary.get("counts", {}).get("registration_gate_reason", {}),
+    }
+
+
+def build_comparison(summary_args: List[str]) -> Dict[str, Any]:
+    rows = []
+    for raw in summary_args:
+        label, path = parse_summary_arg(raw)
+        rows.append(compact_row(label, path, load_summary(path)))
+    best_by_gate = sorted(
+        rows,
+        key=lambda row: (
+            row["gate_passed_count"] or 0,
+            row["gate_passed_rate_percent"] or 0.0,
+            -(row["score_median"] or float("inf")),
+        ),
+        reverse=True,
+    )
+    return {
+        "generated_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "rows": rows,
+        "best_by_gate_passed": best_by_gate[0]["label"] if best_by_gate else None,
+        "notes": [
+            "oracle_rank comparisons are diagnostic upper bounds, not runtime candidate selection claims",
+            "registration gate pass does not mean pose reset was accepted",
+        ],
+    }
+
+
+def build_markdown(comparison: Dict[str, Any]) -> str:
+    lines = [
+        "# Registration Relocalization Score Comparison",
+        "",
+        f"Generated at: {comparison['generated_at']}",
+        "",
+        f"- best_by_gate_passed: `{comparison['best_by_gate_passed']}`",
+        "",
+        "| Label | Rows | Scored | Gate Passed | Score Median | Runtime Median [s] | Status Counts |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for row in comparison["rows"]:
+        lines.append(
+            "| "
+            f"{row['label']} | "
+            f"{_fmt(row['row_count'])} | "
+            f"{_fmt(row['scored_count'])} ({_fmt(row['scored_rate_percent'])}%) | "
+            f"{_fmt(row['gate_passed_count'])} ({_fmt(row['gate_passed_rate_percent'])}%) | "
+            f"{_fmt(row['score_median'])} | "
+            f"{_fmt(row['runtime_sec_median'])} | "
+            f"`{json.dumps(row['status_counts'], sort_keys=True)}` |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Caveat",
+            "",
+            "- `oracle_rank` ordering is an offline upper-bound diagnostic. It must not be described as runtime relocalization behavior.",
+            "- A passed registration gate is not an accepted reset.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    args = parse_args()
+    comparison = build_comparison(args.summary)
+    if args.output_json:
+        output_json = Path(args.output_json).expanduser().resolve()
+        output_json.parent.mkdir(parents=True, exist_ok=True)
+        output_json.write_text(
+            json.dumps(comparison, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.output_md:
+        output_md = Path(args.output_md).expanduser().resolve()
+        output_md.parent.mkdir(parents=True, exist_ok=True)
+        output_md.write_text(build_markdown(comparison) + "\n", encoding="utf-8")
+    if not args.output_json and not args.output_md:
+        print(json.dumps(comparison, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/make_disabled_relocalization_attempts.py
+++ b/scripts/make_disabled_relocalization_attempts.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+
+FIELDNAMES = [
+    "attempt_id",
+    "trigger_stamp_sec",
+    "start_stamp_sec",
+    "end_stamp_sec",
+    "source",
+    "mode",
+    "roi_type",
+    "candidate_count",
+    "accepted",
+    "accepted_candidate_rank",
+    "rejection_reason",
+    "best_score",
+    "second_score",
+    "candidate_margin",
+    "overlap",
+    "converged",
+    "refinement_delta_m",
+    "refinement_delta_yaw_rad",
+    "runtime_sec",
+    "post_reset_ok_rows",
+    "post_reset_window_sec",
+    "false_recovery",
+    "request_reason",
+    "request_score",
+    "request_window_rows",
+    "request_window_duration_sec",
+    "generated_at",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create a disabled relocalization-attempt baseline CSV from alignment_status.csv. "
+            "Each reinitialization request window becomes one rejected attempt with "
+            "candidate_count=0."
+        )
+    )
+    parser.add_argument("--alignment-csv", required=True, help="Input alignment_status.csv")
+    parser.add_argument("--output-csv", required=True, help="Output relocalization_attempts.csv")
+    parser.add_argument(
+        "--source",
+        default="disabled",
+        help="Attempt source label to write into the CSV.",
+    )
+    parser.add_argument(
+        "--mode",
+        default="diagnostic_request",
+        help="Attempt mode label to write into the CSV.",
+    )
+    parser.add_argument(
+        "--roi-type",
+        default="none",
+        help="ROI type label to write into the CSV.",
+    )
+    parser.add_argument(
+        "--rejection-reason",
+        default="candidate_generator_disabled",
+        help="Rejection reason written for every generated attempt.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite output CSV when it already exists.",
+    )
+    return parser.parse_args()
+
+
+def _as_bool(value: Any) -> bool:
+    return str(value).strip().lower() in {"true", "1", "yes", "y"}
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def load_alignment_rows(path: Path) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        for record in csv.DictReader(stream):
+            values = json.loads(record["values_json"])
+            rows.append(
+                {
+                    "stamp_sec": float(record["stamp_sec"]),
+                    "message": str(record.get("message", "")),
+                    "requested": _as_bool(values.get("reinitialization_requested")),
+                    "reason": values.get("reinitialization_request_reason"),
+                    "score": _as_float(values.get("reinitialization_request_score")),
+                }
+            )
+    return rows
+
+
+def build_attempt_rows(
+    rows: List[Dict[str, Any]],
+    source: str,
+    mode: str,
+    roi_type: str,
+    rejection_reason: str,
+) -> List[Dict[str, Any]]:
+    attempts: List[Dict[str, Any]] = []
+    generated_at = datetime.now().astimezone().isoformat(timespec="seconds")
+    index = 0
+    while index < len(rows):
+        if not rows[index]["requested"]:
+            index += 1
+            continue
+
+        start = index
+        while index < len(rows) and rows[index]["requested"]:
+            index += 1
+        end = index - 1
+
+        attempts.append(
+            {
+                "attempt_id": f"disabled_{len(attempts) + 1:04d}",
+                "trigger_stamp_sec": f"{rows[start]['stamp_sec']:.9f}",
+                "start_stamp_sec": f"{rows[start]['stamp_sec']:.9f}",
+                "end_stamp_sec": f"{rows[start]['stamp_sec']:.9f}",
+                "source": source,
+                "mode": mode,
+                "roi_type": roi_type,
+                "candidate_count": "0",
+                "accepted": "false",
+                "accepted_candidate_rank": "",
+                "rejection_reason": rejection_reason,
+                "best_score": "",
+                "second_score": "",
+                "candidate_margin": "",
+                "overlap": "",
+                "converged": "false",
+                "refinement_delta_m": "",
+                "refinement_delta_yaw_rad": "",
+                "runtime_sec": "0.0",
+                "post_reset_ok_rows": "0",
+                "post_reset_window_sec": "",
+                "false_recovery": "",
+                "request_reason": rows[start]["reason"] or "",
+                "request_score": (
+                    "" if rows[start]["score"] is None else f"{rows[start]['score']:.10g}"
+                ),
+                "request_window_rows": str(end - start + 1),
+                "request_window_duration_sec": f"{max(0.0, rows[end]['stamp_sec'] - rows[start]['stamp_sec']):.9f}",
+                "generated_at": generated_at,
+            }
+        )
+    return attempts
+
+
+def write_attempts(path: Path, attempts: List[Dict[str, Any]], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output CSV already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(attempts)
+
+
+def main() -> None:
+    args = parse_args()
+    alignment_csv = Path(args.alignment_csv).expanduser().resolve()
+    output_csv = Path(args.output_csv).expanduser().resolve()
+    if not alignment_csv.exists():
+        raise FileNotFoundError(f"alignment CSV does not exist: {alignment_csv}")
+
+    attempts = build_attempt_rows(
+        load_alignment_rows(alignment_csv),
+        source=args.source,
+        mode=args.mode,
+        roi_type=args.roi_type,
+        rejection_reason=args.rejection_reason,
+    )
+    write_attempts(output_csv, attempts, overwrite=args.overwrite)
+    print(json.dumps({"output_csv": str(output_csv), "attempt_count": len(attempts)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/make_registration_relocalization_jobs.py
+++ b/scripts/make_registration_relocalization_jobs.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+
+JOB_FIELDNAMES = [
+    "job_id",
+    "attempt_id",
+    "candidate_index",
+    "trigger_stamp_sec",
+    "bag_path",
+    "cloud_topic",
+    "map_path",
+    "registration_method",
+    "initial_pose_x",
+    "initial_pose_y",
+    "initial_pose_z",
+    "initial_yaw_rad",
+    "route_stamp_sec",
+    "route_time_delta_sec",
+    "candidate_source",
+    "selection_source",
+    "selection_rank",
+    "oracle_rank",
+    "oracle_score",
+    "oracle_translation_error_m",
+    "oracle_yaw_error_deg",
+    "voxel_leaf_size",
+    "local_map_radius",
+    "timeout_sec",
+    "generated_at",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create registration-scoring job rows from relocalization candidate artifacts. "
+            "This is a contract artifact only; it does not run registration or reset pose."
+        )
+    )
+    parser.add_argument("--attempts-csv", required=True, help="Input relocalization_attempts.csv")
+    parser.add_argument(
+        "--candidates-csv",
+        required=True,
+        help="Input relocalization_candidates.csv or relocalization_candidate_scores.csv",
+    )
+    parser.add_argument("--bag-path", required=True, help="Rosbag2 directory used by the run")
+    parser.add_argument("--map-path", required=True, help="Point cloud map path used by the run")
+    parser.add_argument("--cloud-topic", required=True, help="PointCloud2 topic to score")
+    parser.add_argument("--output-csv", required=True, help="Output registration jobs CSV")
+    parser.add_argument(
+        "--registration-method",
+        default="NDT_OMP",
+        help="Registration backend label for the future scorer.",
+    )
+    parser.add_argument(
+        "--max-candidates-per-attempt",
+        type=int,
+        default=32,
+        help="Maximum candidates to emit per attempt. 0 means all candidates.",
+    )
+    parser.add_argument(
+        "--selection-source",
+        choices=["candidate_index", "oracle_rank"],
+        default="candidate_index",
+        help=(
+            "How to order candidates before truncation. oracle_rank is an offline diagnostic "
+            "mode and must not be used as a runtime claim."
+        ),
+    )
+    parser.add_argument("--voxel-leaf-size", type=float, default=1.0)
+    parser.add_argument("--local-map-radius", type=float, default=150.0)
+    parser.add_argument("--timeout-sec", type=float, default=1.0)
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite output CSV.")
+    return parser.parse_args()
+
+
+def _read_csv_rows(path: Path) -> Tuple[List[str], List[Dict[str, Any]]]:
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        reader = csv.DictReader(stream)
+        return list(reader.fieldnames or []), list(reader)
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_int(value: Any) -> Optional[int]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        return int(float(str(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _candidate_sort_key(row: Dict[str, Any], selection_source: str) -> Tuple[int, int]:
+    candidate_index = _as_int(row.get("candidate_index"))
+    if candidate_index is None:
+        candidate_index = 10**9
+    if selection_source == "oracle_rank":
+        oracle_rank = _as_int(row.get("oracle_rank"))
+        if oracle_rank is not None:
+            return (oracle_rank, candidate_index)
+    return (candidate_index, candidate_index)
+
+
+def build_jobs(
+    attempts: List[Dict[str, Any]],
+    candidates: List[Dict[str, Any]],
+    bag_path: Path,
+    map_path: Path,
+    cloud_topic: str,
+    registration_method: str,
+    max_candidates_per_attempt: int,
+    selection_source: str,
+    voxel_leaf_size: float,
+    local_map_radius: float,
+    timeout_sec: float,
+) -> List[Dict[str, Any]]:
+    generated_at = datetime.now().astimezone().isoformat(timespec="seconds")
+    attempts_by_id = {str(row.get("attempt_id", "")): row for row in attempts}
+    candidates_by_attempt: Dict[str, List[Dict[str, Any]]] = {}
+    for candidate in candidates:
+        candidates_by_attempt.setdefault(str(candidate.get("attempt_id", "")), []).append(
+            candidate
+        )
+
+    jobs: List[Dict[str, Any]] = []
+    for attempt_id, attempt in attempts_by_id.items():
+        attempt_candidates = sorted(
+            candidates_by_attempt.get(attempt_id, []),
+            key=lambda row: _candidate_sort_key(row, selection_source),
+        )
+        if max_candidates_per_attempt > 0:
+            attempt_candidates = attempt_candidates[:max_candidates_per_attempt]
+        trigger_stamp_sec = str(attempt.get("trigger_stamp_sec", ""))
+        for selection_index, candidate in enumerate(attempt_candidates):
+            candidate_index = str(candidate.get("candidate_index", ""))
+            jobs.append(
+                {
+                    "job_id": f"registration_job_{len(jobs) + 1:06d}",
+                    "attempt_id": attempt_id,
+                    "candidate_index": candidate_index,
+                    "trigger_stamp_sec": trigger_stamp_sec,
+                    "bag_path": str(bag_path),
+                    "cloud_topic": cloud_topic,
+                    "map_path": str(map_path),
+                    "registration_method": registration_method,
+                    "initial_pose_x": str(candidate.get("pose_x", "")),
+                    "initial_pose_y": str(candidate.get("pose_y", "")),
+                    "initial_pose_z": str(candidate.get("pose_z", "")),
+                    "initial_yaw_rad": str(candidate.get("yaw_rad", "")),
+                    "route_stamp_sec": str(candidate.get("route_stamp_sec", "")),
+                    "route_time_delta_sec": str(candidate.get("route_time_delta_sec", "")),
+                    "candidate_source": str(candidate.get("source", "")),
+                    "selection_source": selection_source,
+                    "selection_rank": str(selection_index + 1),
+                    "oracle_rank": str(candidate.get("oracle_rank", "")),
+                    "oracle_score": str(candidate.get("oracle_score", "")),
+                    "oracle_translation_error_m": str(
+                        candidate.get("oracle_translation_error_m", "")
+                    ),
+                    "oracle_yaw_error_deg": str(candidate.get("oracle_yaw_error_deg", "")),
+                    "voxel_leaf_size": f"{voxel_leaf_size:.9f}",
+                    "local_map_radius": f"{local_map_radius:.9f}",
+                    "timeout_sec": f"{timeout_sec:.9f}",
+                    "generated_at": generated_at,
+                }
+            )
+    return jobs
+
+
+def write_jobs(path: Path, jobs: List[Dict[str, Any]], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output CSV already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=JOB_FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(jobs)
+
+
+def main() -> None:
+    args = parse_args()
+    attempts_csv = Path(args.attempts_csv).expanduser().resolve()
+    candidates_csv = Path(args.candidates_csv).expanduser().resolve()
+    bag_path = Path(args.bag_path).expanduser().resolve()
+    map_path = Path(args.map_path).expanduser().resolve()
+    output_csv = Path(args.output_csv).expanduser().resolve()
+    for path, label in [
+        (attempts_csv, "attempts CSV"),
+        (candidates_csv, "candidates CSV"),
+        (bag_path, "bag path"),
+        (map_path, "map path"),
+    ]:
+        if not path.exists():
+            raise FileNotFoundError(f"{label} does not exist: {path}")
+
+    _, attempts = _read_csv_rows(attempts_csv)
+    _, candidates = _read_csv_rows(candidates_csv)
+    jobs = build_jobs(
+        attempts=attempts,
+        candidates=candidates,
+        bag_path=bag_path,
+        map_path=map_path,
+        cloud_topic=args.cloud_topic,
+        registration_method=args.registration_method,
+        max_candidates_per_attempt=args.max_candidates_per_attempt,
+        selection_source=args.selection_source,
+        voxel_leaf_size=args.voxel_leaf_size,
+        local_map_radius=args.local_map_radius,
+        timeout_sec=args.timeout_sec,
+    )
+    write_jobs(output_csv, jobs, overwrite=args.overwrite)
+    print(
+        json.dumps(
+            {
+                "output_csv": str(output_csv),
+                "attempt_count": len(attempts),
+                "candidate_count": len(candidates),
+                "job_count": len(jobs),
+                "selection_source": args.selection_source,
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/make_relocalization_reset_commands.py
+++ b/scripts/make_relocalization_reset_commands.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import math
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+
+
+COMMAND_FIELDNAMES = [
+    "command_id",
+    "attempt_id",
+    "trigger_stamp_sec",
+    "command_type",
+    "dry_run",
+    "publish_topic",
+    "frame_id",
+    "stamp_sec",
+    "position_x",
+    "position_y",
+    "position_z",
+    "orientation_x",
+    "orientation_y",
+    "orientation_z",
+    "orientation_w",
+    "yaw_rad",
+    "source_plan_row_selected",
+    "source_plan_row_accepted",
+    "source_job_id",
+    "source_candidate_index",
+    "source_selection_source",
+    "source_selection_rank",
+    "source_score",
+    "source_registration_gate_reason",
+    "status",
+    "rejection_reason",
+    "generated_at",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert a relocalization reset candidate plan into dry-run reset command artifacts. "
+            "This does not publish /initialpose and does not execute a reset."
+        )
+    )
+    parser.add_argument("--plan-csv", required=True)
+    parser.add_argument("--output-csv", required=True)
+    parser.add_argument("--output-json", default="")
+    parser.add_argument("--output-md", default="")
+    parser.add_argument("--publish-topic", default="/initialpose")
+    parser.add_argument("--frame-id", default="map")
+    parser.add_argument(
+        "--stamp-source",
+        choices=["trigger", "zero"],
+        default="trigger",
+        help="Stamp to write into the dry-run command artifact.",
+    )
+    parser.add_argument("--allow-accepted-plan", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def _read_csv(path: Path) -> List[Dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        return list(csv.DictReader(stream))
+
+
+def _as_bool(value: Any) -> Optional[bool]:
+    if value is None or str(value).strip() == "":
+        return None
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "y"}:
+        return True
+    if normalized in {"0", "false", "no", "n"}:
+        return False
+    return None
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        number = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _fmt(value: Optional[float]) -> str:
+    return "" if value is None else f"{value:.9f}"
+
+
+def _yaw_to_quaternion(yaw: float) -> Dict[str, float]:
+    half = 0.5 * yaw
+    return {
+        "x": 0.0,
+        "y": 0.0,
+        "z": math.sin(half),
+        "w": math.cos(half),
+    }
+
+
+def _counts(values: Iterable[str]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for value in values:
+        key = str(value)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _rejected_command(
+    command_id: str,
+    row: Dict[str, str],
+    publish_topic: str,
+    frame_id: str,
+    reason: str,
+    generated_at: str,
+) -> Dict[str, str]:
+    command = {field: "" for field in COMMAND_FIELDNAMES}
+    command.update(
+        {
+            "command_id": command_id,
+            "attempt_id": str(row.get("attempt_id", "")),
+            "trigger_stamp_sec": str(row.get("trigger_stamp_sec", "")),
+            "command_type": "initialpose",
+            "dry_run": "true",
+            "publish_topic": publish_topic,
+            "frame_id": frame_id,
+            "source_plan_row_selected": str(row.get("selected", "")),
+            "source_plan_row_accepted": str(row.get("accepted", "")),
+            "source_job_id": str(row.get("selected_job_id", "")),
+            "source_candidate_index": str(row.get("selected_candidate_index", "")),
+            "source_selection_source": str(row.get("selected_selection_source", "")),
+            "source_selection_rank": str(row.get("selected_selection_rank", "")),
+            "source_score": str(row.get("selected_score", "")),
+            "source_registration_gate_reason": str(
+                row.get("selected_registration_gate_reason", "")
+            ),
+            "status": "rejected",
+            "rejection_reason": reason,
+            "generated_at": generated_at,
+        }
+    )
+    return command
+
+
+def build_commands(
+    plan_rows: List[Dict[str, str]],
+    publish_topic: str,
+    frame_id: str,
+    stamp_source: str,
+    allow_accepted_plan: bool,
+) -> List[Dict[str, str]]:
+    generated_at = datetime.now().astimezone().isoformat(timespec="seconds")
+    commands: List[Dict[str, str]] = []
+    for index, row in enumerate(plan_rows, start=1):
+        command_id = f"reset_command_{index:06d}"
+        selected = _as_bool(row.get("selected"))
+        accepted = _as_bool(row.get("accepted"))
+        if selected is not True:
+            commands.append(
+                _rejected_command(
+                    command_id,
+                    row,
+                    publish_topic,
+                    frame_id,
+                    "plan_row_not_selected",
+                    generated_at,
+                )
+            )
+            continue
+        if accepted is True and not allow_accepted_plan:
+            commands.append(
+                _rejected_command(
+                    command_id,
+                    row,
+                    publish_topic,
+                    frame_id,
+                    "accepted_plan_rows_not_allowed",
+                    generated_at,
+                )
+            )
+            continue
+
+        x = _as_float(row.get("selected_final_pose_x"))
+        y = _as_float(row.get("selected_final_pose_y"))
+        z = _as_float(row.get("selected_final_pose_z"))
+        yaw = _as_float(row.get("selected_final_yaw_rad"))
+        if x is None or y is None or z is None or yaw is None:
+            commands.append(
+                _rejected_command(
+                    command_id,
+                    row,
+                    publish_topic,
+                    frame_id,
+                    "selected_final_pose_missing",
+                    generated_at,
+                )
+            )
+            continue
+
+        quat = _yaw_to_quaternion(yaw)
+        stamp = _as_float(row.get("trigger_stamp_sec")) if stamp_source == "trigger" else 0.0
+        commands.append(
+            {
+                "command_id": command_id,
+                "attempt_id": str(row.get("attempt_id", "")),
+                "trigger_stamp_sec": str(row.get("trigger_stamp_sec", "")),
+                "command_type": "initialpose",
+                "dry_run": "true",
+                "publish_topic": publish_topic,
+                "frame_id": frame_id,
+                "stamp_sec": _fmt(stamp),
+                "position_x": _fmt(x),
+                "position_y": _fmt(y),
+                "position_z": _fmt(z),
+                "orientation_x": _fmt(quat["x"]),
+                "orientation_y": _fmt(quat["y"]),
+                "orientation_z": _fmt(quat["z"]),
+                "orientation_w": _fmt(quat["w"]),
+                "yaw_rad": _fmt(yaw),
+                "source_plan_row_selected": str(row.get("selected", "")),
+                "source_plan_row_accepted": str(row.get("accepted", "")),
+                "source_job_id": str(row.get("selected_job_id", "")),
+                "source_candidate_index": str(row.get("selected_candidate_index", "")),
+                "source_selection_source": str(row.get("selected_selection_source", "")),
+                "source_selection_rank": str(row.get("selected_selection_rank", "")),
+                "source_score": str(row.get("selected_score", "")),
+                "source_registration_gate_reason": str(
+                    row.get("selected_registration_gate_reason", "")
+                ),
+                "status": "dry_run_command_generated",
+                "rejection_reason": "publish_disabled",
+                "generated_at": generated_at,
+            }
+        )
+    return commands
+
+
+def write_csv(path: Path, rows: List[Dict[str, str]], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output CSV already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=COMMAND_FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def build_summary(plan_csv: Path, output_csv: Path, commands: List[Dict[str, str]]) -> Dict[str, Any]:
+    generated = [row for row in commands if row.get("status") == "dry_run_command_generated"]
+    return {
+        "plan_csv": str(plan_csv),
+        "output_csv": str(output_csv),
+        "command_count": len(commands),
+        "dry_run_generated_count": len(generated),
+        "published_count": 0,
+        "status_counts": _counts(row.get("status", "") for row in commands),
+        "rejection_reason_counts": _counts(row.get("rejection_reason", "") for row in commands),
+        "notes": [
+            "this helper never publishes /initialpose",
+            "commands use selected_final_pose_* from the reset candidate plan",
+            "selected_initial_pose_* remains candidate seed provenance, not the reset command pose",
+        ],
+    }
+
+
+def write_json(path: Path, data: Dict[str, Any], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output JSON already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_md(path: Path, data: Dict[str, Any], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output Markdown already exists: {path}")
+    lines = [
+        "# Relocalization Reset Commands",
+        "",
+        f"- plan CSV: `{data['plan_csv']}`",
+        f"- output CSV: `{data['output_csv']}`",
+        f"- commands: `{data['command_count']}`",
+        f"- dry-run generated: `{data['dry_run_generated_count']}`",
+        f"- published: `{data['published_count']}`",
+        f"- status counts: `{json.dumps(data['status_counts'], sort_keys=True)}`",
+        f"- rejection reasons: `{json.dumps(data['rejection_reason_counts'], sort_keys=True)}`",
+        "",
+        "## Notes",
+        "",
+    ]
+    lines.extend(f"- {note}" for note in data["notes"])
+    lines.append("")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    plan_csv = Path(args.plan_csv).expanduser().resolve()
+    output_csv = Path(args.output_csv).expanduser().resolve()
+    if not plan_csv.exists():
+        raise FileNotFoundError(f"plan CSV does not exist: {plan_csv}")
+
+    plan_rows = _read_csv(plan_csv)
+    commands = build_commands(
+        plan_rows=plan_rows,
+        publish_topic=args.publish_topic,
+        frame_id=args.frame_id,
+        stamp_source=args.stamp_source,
+        allow_accepted_plan=args.allow_accepted_plan,
+    )
+    write_csv(output_csv, commands, args.overwrite)
+    summary = build_summary(plan_csv, output_csv, commands)
+    if args.output_json:
+        write_json(Path(args.output_json).expanduser().resolve(), summary, args.overwrite)
+    if args.output_md:
+        write_md(Path(args.output_md).expanduser().resolve(), summary, args.overwrite)
+    print(json.dumps(summary, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/make_route_grid_relocalization_attempts.py
+++ b/scripts/make_route_grid_relocalization_attempts.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import math
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+
+ATTEMPT_FIELDNAMES = [
+    "attempt_id",
+    "trigger_stamp_sec",
+    "start_stamp_sec",
+    "end_stamp_sec",
+    "source",
+    "mode",
+    "roi_type",
+    "candidate_count",
+    "accepted",
+    "accepted_candidate_rank",
+    "rejection_reason",
+    "best_score",
+    "second_score",
+    "candidate_margin",
+    "overlap",
+    "converged",
+    "refinement_delta_m",
+    "refinement_delta_yaw_rad",
+    "runtime_sec",
+    "post_reset_ok_rows",
+    "post_reset_window_sec",
+    "false_recovery",
+    "request_reason",
+    "request_score",
+    "request_window_rows",
+    "request_window_duration_sec",
+    "generated_at",
+    "reference_pose_count",
+    "route_time_radius_sec",
+    "route_min_spacing_m",
+    "route_window_start_stamp_sec",
+    "route_window_end_stamp_sec",
+    "nearest_reference_stamp_sec",
+    "nearest_reference_time_delta_sec",
+    "yaw_offsets_deg",
+    "lateral_offsets_m",
+    "longitudinal_offsets_m",
+    "candidates_csv",
+]
+
+
+CANDIDATE_FIELDNAMES = [
+    "attempt_id",
+    "candidate_index",
+    "source",
+    "pose_x",
+    "pose_y",
+    "pose_z",
+    "yaw_rad",
+    "route_stamp_sec",
+    "route_time_delta_sec",
+    "route_position_x",
+    "route_position_y",
+    "route_position_z",
+    "route_yaw_rad",
+    "longitudinal_offset_m",
+    "lateral_offset_m",
+    "yaw_offset_deg",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create a route-grid relocalization candidate artifact from "
+            "alignment_status.csv and a reference trajectory. This helper does not "
+            "score candidates or reset pose; it records candidate coverage so global "
+            "relocalization can be developed against a stable CSV contract."
+        )
+    )
+    parser.add_argument("--alignment-csv", required=True, help="Input alignment_status.csv")
+    parser.add_argument("--reference-csv", required=True, help="Reference trajectory CSV")
+    parser.add_argument("--output-csv", required=True, help="Output relocalization_attempts.csv")
+    parser.add_argument(
+        "--output-candidates-csv",
+        default="",
+        help="Optional per-candidate CSV. Defaults to relocalization_candidates.csv next to output CSV.",
+    )
+    parser.add_argument("--source", default="route_grid", help="Attempt source label.")
+    parser.add_argument(
+        "--mode",
+        default="offline_route_roi",
+        help="Attempt mode label.",
+    )
+    parser.add_argument(
+        "--roi-type",
+        default="route_corridor",
+        help="ROI type label.",
+    )
+    parser.add_argument(
+        "--route-time-radius-sec",
+        type=float,
+        default=15.0,
+        help="Reference poses within +/- this many seconds around the trigger become route seeds.",
+    )
+    parser.add_argument(
+        "--route-min-spacing-m",
+        type=float,
+        default=10.0,
+        help="Minimum XY spacing between route seed poses after time-window selection.",
+    )
+    parser.add_argument(
+        "--max-route-poses",
+        type=int,
+        default=32,
+        help="Maximum route seed poses per request window after spacing.",
+    )
+    parser.add_argument(
+        "--max-candidates",
+        type=int,
+        default=256,
+        help="Maximum generated candidate poses per request window.",
+    )
+    parser.add_argument(
+        "--yaw-offsets-deg",
+        default="0",
+        help="Comma-separated yaw offsets in degrees, for example '-15,0,15'.",
+    )
+    parser.add_argument(
+        "--lateral-offsets-m",
+        default="0",
+        help="Comma-separated lateral offsets in meters.",
+    )
+    parser.add_argument(
+        "--longitudinal-offsets-m",
+        default="0",
+        help="Comma-separated longitudinal offsets in meters.",
+    )
+    parser.add_argument(
+        "--rejection-reason",
+        default="candidate_scoring_not_implemented",
+        help="Rejection reason written for every generated attempt.",
+    )
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite output CSV files.")
+    return parser.parse_args()
+
+
+def _as_bool(value: Any) -> bool:
+    return str(value).strip().lower() in {"true", "1", "yes", "y"}
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        number = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _parse_float_list(raw: str) -> List[float]:
+    values: List[float] = []
+    for token in str(raw).split(","):
+        token = token.strip()
+        if not token:
+            continue
+        values.append(float(token))
+    if not values:
+        raise ValueError(f"expected at least one numeric value in {raw!r}")
+    return values
+
+
+def _yaw_from_quaternion(x: float, y: float, z: float, w: float) -> float:
+    siny_cosp = 2.0 * (w * z + x * y)
+    cosy_cosp = 1.0 - 2.0 * (y * y + z * z)
+    return math.atan2(siny_cosp, cosy_cosp)
+
+
+def _wrap_angle(angle: float) -> float:
+    return math.atan2(math.sin(angle), math.cos(angle))
+
+
+def load_alignment_rows(path: Path) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        for record in csv.DictReader(stream):
+            values = json.loads(record["values_json"])
+            rows.append(
+                {
+                    "stamp_sec": float(record["stamp_sec"]),
+                    "requested": _as_bool(values.get("reinitialization_requested")),
+                    "reason": values.get("reinitialization_request_reason"),
+                    "score": _as_float(values.get("reinitialization_request_score")),
+                }
+            )
+    return rows
+
+
+def load_reference_rows(path: Path) -> List[Dict[str, float]]:
+    rows: List[Dict[str, float]] = []
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        for record in csv.DictReader(stream):
+            qx = float(record["orientation_x"])
+            qy = float(record["orientation_y"])
+            qz = float(record["orientation_z"])
+            qw = float(record["orientation_w"])
+            rows.append(
+                {
+                    "stamp_sec": float(record["stamp_sec"]),
+                    "x": float(record["position_x"]),
+                    "y": float(record["position_y"]),
+                    "z": float(record["position_z"]),
+                    "yaw": _yaw_from_quaternion(qx, qy, qz, qw),
+                }
+            )
+    if not rows:
+        raise RuntimeError(f"reference CSV has no rows: {path}")
+    rows.sort(key=lambda row: row["stamp_sec"])
+    return rows
+
+
+def request_windows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    windows: List[Dict[str, Any]] = []
+    index = 0
+    while index < len(rows):
+        if not rows[index]["requested"]:
+            index += 1
+            continue
+        start = index
+        while index < len(rows) and rows[index]["requested"]:
+            index += 1
+        end = index - 1
+        windows.append(
+            {
+                "start_index": start,
+                "end_index": end,
+                "start_stamp_sec": rows[start]["stamp_sec"],
+                "end_stamp_sec": rows[end]["stamp_sec"],
+                "row_count": end - start + 1,
+                "reason": rows[start]["reason"],
+                "score": rows[start]["score"],
+            }
+        )
+    return windows
+
+
+def _distance_xy(a: Dict[str, float], b: Dict[str, float]) -> float:
+    return math.hypot(a["x"] - b["x"], a["y"] - b["y"])
+
+
+def _spaced_reference_rows(
+    rows: Iterable[Dict[str, float]],
+    min_spacing_m: float,
+    max_rows: int,
+) -> List[Dict[str, float]]:
+    selected: List[Dict[str, float]] = []
+    for row in rows:
+        if selected and min_spacing_m > 0.0 and _distance_xy(row, selected[-1]) < min_spacing_m:
+            continue
+        selected.append(row)
+        if max_rows > 0 and len(selected) >= max_rows:
+            break
+    return selected
+
+
+def select_route_rows(
+    reference_rows: List[Dict[str, float]],
+    trigger_stamp_sec: float,
+    time_radius_sec: float,
+    min_spacing_m: float,
+    max_route_poses: int,
+) -> Tuple[List[Dict[str, float]], Dict[str, float]]:
+    nearest = min(
+        reference_rows,
+        key=lambda row: abs(row["stamp_sec"] - trigger_stamp_sec),
+    )
+    start_stamp = trigger_stamp_sec - time_radius_sec
+    end_stamp = trigger_stamp_sec + time_radius_sec
+    window_rows = [
+        row for row in reference_rows if start_stamp <= row["stamp_sec"] <= end_stamp
+    ]
+    if not window_rows:
+        window_rows = [nearest]
+    selected = _spaced_reference_rows(window_rows, min_spacing_m, max_route_poses)
+    if not selected:
+        selected = [nearest]
+    if all(row["stamp_sec"] != nearest["stamp_sec"] for row in selected):
+        selected.append(nearest)
+        selected.sort(key=lambda row: row["stamp_sec"])
+        if max_route_poses > 0 and len(selected) > max_route_poses:
+            selected = sorted(
+                selected,
+                key=lambda row: (row["stamp_sec"] != nearest["stamp_sec"], abs(row["stamp_sec"] - nearest["stamp_sec"])),
+            )[:max_route_poses]
+            selected.sort(key=lambda row: row["stamp_sec"])
+    return selected, nearest
+
+
+def build_candidates(
+    attempt_id: str,
+    route_rows: List[Dict[str, float]],
+    trigger_stamp_sec: float,
+    source: str,
+    longitudinal_offsets_m: List[float],
+    lateral_offsets_m: List[float],
+    yaw_offsets_deg: List[float],
+    max_candidates: int,
+) -> List[Dict[str, Any]]:
+    candidates: List[Dict[str, Any]] = []
+    for route_row in route_rows:
+        cos_yaw = math.cos(route_row["yaw"])
+        sin_yaw = math.sin(route_row["yaw"])
+        for longitudinal in longitudinal_offsets_m:
+            for lateral in lateral_offsets_m:
+                for yaw_offset_deg in yaw_offsets_deg:
+                    x = route_row["x"] + longitudinal * cos_yaw - lateral * sin_yaw
+                    y = route_row["y"] + longitudinal * sin_yaw + lateral * cos_yaw
+                    yaw = _wrap_angle(route_row["yaw"] + math.radians(yaw_offset_deg))
+                    candidates.append(
+                        {
+                            "attempt_id": attempt_id,
+                            "candidate_index": str(len(candidates)),
+                            "source": source,
+                            "pose_x": f"{x:.9f}",
+                            "pose_y": f"{y:.9f}",
+                            "pose_z": f"{route_row['z']:.9f}",
+                            "yaw_rad": f"{yaw:.9f}",
+                            "route_stamp_sec": f"{route_row['stamp_sec']:.9f}",
+                            "route_time_delta_sec": f"{route_row['stamp_sec'] - trigger_stamp_sec:.9f}",
+                            "route_position_x": f"{route_row['x']:.9f}",
+                            "route_position_y": f"{route_row['y']:.9f}",
+                            "route_position_z": f"{route_row['z']:.9f}",
+                            "route_yaw_rad": f"{route_row['yaw']:.9f}",
+                            "longitudinal_offset_m": f"{longitudinal:.9f}",
+                            "lateral_offset_m": f"{lateral:.9f}",
+                            "yaw_offset_deg": f"{yaw_offset_deg:.9f}",
+                        }
+                    )
+                    if max_candidates > 0 and len(candidates) >= max_candidates:
+                        return candidates
+    return candidates
+
+
+def build_attempt_artifacts(
+    alignment_rows: List[Dict[str, Any]],
+    reference_rows: List[Dict[str, float]],
+    candidates_csv: Path,
+    source: str,
+    mode: str,
+    roi_type: str,
+    route_time_radius_sec: float,
+    route_min_spacing_m: float,
+    max_route_poses: int,
+    max_candidates: int,
+    yaw_offsets_deg: List[float],
+    lateral_offsets_m: List[float],
+    longitudinal_offsets_m: List[float],
+    rejection_reason: str,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    generated_at = datetime.now().astimezone().isoformat(timespec="seconds")
+    attempts: List[Dict[str, Any]] = []
+    candidate_rows: List[Dict[str, Any]] = []
+    for window in request_windows(alignment_rows):
+        started = time.monotonic()
+        attempt_id = f"{source}_{len(attempts) + 1:04d}"
+        trigger_stamp_sec = float(window["start_stamp_sec"])
+        route_rows, nearest = select_route_rows(
+            reference_rows,
+            trigger_stamp_sec=trigger_stamp_sec,
+            time_radius_sec=route_time_radius_sec,
+            min_spacing_m=route_min_spacing_m,
+            max_route_poses=max_route_poses,
+        )
+        candidates = build_candidates(
+            attempt_id=attempt_id,
+            route_rows=route_rows,
+            trigger_stamp_sec=trigger_stamp_sec,
+            source=source,
+            longitudinal_offsets_m=longitudinal_offsets_m,
+            lateral_offsets_m=lateral_offsets_m,
+            yaw_offsets_deg=yaw_offsets_deg,
+            max_candidates=max_candidates,
+        )
+        candidate_rows.extend(candidates)
+        route_start = min(row["stamp_sec"] for row in route_rows)
+        route_end = max(row["stamp_sec"] for row in route_rows)
+        attempts.append(
+            {
+                "attempt_id": attempt_id,
+                "trigger_stamp_sec": f"{trigger_stamp_sec:.9f}",
+                "start_stamp_sec": f"{trigger_stamp_sec:.9f}",
+                "end_stamp_sec": f"{trigger_stamp_sec:.9f}",
+                "source": source,
+                "mode": mode,
+                "roi_type": roi_type,
+                "candidate_count": str(len(candidates)),
+                "accepted": "false",
+                "accepted_candidate_rank": "",
+                "rejection_reason": rejection_reason,
+                "best_score": "",
+                "second_score": "",
+                "candidate_margin": "",
+                "overlap": "",
+                "converged": "false",
+                "refinement_delta_m": "",
+                "refinement_delta_yaw_rad": "",
+                "runtime_sec": f"{time.monotonic() - started:.6f}",
+                "post_reset_ok_rows": "0",
+                "post_reset_window_sec": "",
+                "false_recovery": "false",
+                "request_reason": window["reason"] or "",
+                "request_score": "" if window["score"] is None else f"{window['score']:.10g}",
+                "request_window_rows": str(window["row_count"]),
+                "request_window_duration_sec": f"{max(0.0, window['end_stamp_sec'] - window['start_stamp_sec']):.9f}",
+                "generated_at": generated_at,
+                "reference_pose_count": str(len(route_rows)),
+                "route_time_radius_sec": f"{route_time_radius_sec:.9f}",
+                "route_min_spacing_m": f"{route_min_spacing_m:.9f}",
+                "route_window_start_stamp_sec": f"{route_start:.9f}",
+                "route_window_end_stamp_sec": f"{route_end:.9f}",
+                "nearest_reference_stamp_sec": f"{nearest['stamp_sec']:.9f}",
+                "nearest_reference_time_delta_sec": f"{nearest['stamp_sec'] - trigger_stamp_sec:.9f}",
+                "yaw_offsets_deg": ",".join(f"{value:.9f}" for value in yaw_offsets_deg),
+                "lateral_offsets_m": ",".join(f"{value:.9f}" for value in lateral_offsets_m),
+                "longitudinal_offsets_m": ",".join(
+                    f"{value:.9f}" for value in longitudinal_offsets_m
+                ),
+                "candidates_csv": str(candidates_csv),
+            }
+        )
+    return attempts, candidate_rows
+
+
+def write_csv(
+    path: Path,
+    rows: List[Dict[str, Any]],
+    fieldnames: List[str],
+    overwrite: bool,
+) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output CSV already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    args = parse_args()
+    alignment_csv = Path(args.alignment_csv).expanduser().resolve()
+    reference_csv = Path(args.reference_csv).expanduser().resolve()
+    output_csv = Path(args.output_csv).expanduser().resolve()
+    candidates_csv = (
+        Path(args.output_candidates_csv).expanduser().resolve()
+        if args.output_candidates_csv
+        else output_csv.with_name("relocalization_candidates.csv")
+    )
+    if not alignment_csv.exists():
+        raise FileNotFoundError(f"alignment CSV does not exist: {alignment_csv}")
+    if not reference_csv.exists():
+        raise FileNotFoundError(f"reference CSV does not exist: {reference_csv}")
+
+    attempts, candidates = build_attempt_artifacts(
+        alignment_rows=load_alignment_rows(alignment_csv),
+        reference_rows=load_reference_rows(reference_csv),
+        candidates_csv=candidates_csv,
+        source=args.source,
+        mode=args.mode,
+        roi_type=args.roi_type,
+        route_time_radius_sec=args.route_time_radius_sec,
+        route_min_spacing_m=args.route_min_spacing_m,
+        max_route_poses=args.max_route_poses,
+        max_candidates=args.max_candidates,
+        yaw_offsets_deg=_parse_float_list(args.yaw_offsets_deg),
+        lateral_offsets_m=_parse_float_list(args.lateral_offsets_m),
+        longitudinal_offsets_m=_parse_float_list(args.longitudinal_offsets_m),
+        rejection_reason=args.rejection_reason,
+    )
+    write_csv(output_csv, attempts, ATTEMPT_FIELDNAMES, overwrite=args.overwrite)
+    write_csv(candidates_csv, candidates, CANDIDATE_FIELDNAMES, overwrite=args.overwrite)
+    print(
+        json.dumps(
+            {
+                "output_csv": str(output_csv),
+                "output_candidates_csv": str(candidates_csv),
+                "attempt_count": len(attempts),
+                "candidate_count": len(candidates),
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/observe_relocalization_reset_execution.py
+++ b/scripts/observe_relocalization_reset_execution.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import math
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+
+
+OBSERVATION_FIELDNAMES = [
+    "command_id",
+    "attempt_id",
+    "published_count",
+    "execution_status",
+    "command_stamp_sec",
+    "observation_window_sec",
+    "alignment_rows_in_window",
+    "ok_rows_in_window",
+    "failure_like_rows_in_window",
+    "first_ok_latency_sec",
+    "stable_ok_rows_after_reset",
+    "max_reject_streak_after_reset",
+    "observed_recovered",
+    "accepted",
+    "false_recovery_observable",
+    "reference_risky",
+    "rejection_reason",
+    "generated_at",
+]
+
+
+FAILURE_MESSAGES = {
+    "local_map_crop_too_small",
+    "registration_not_converged",
+    "filtered_scan_empty",
+    "scan_missing_xyz_field",
+}
+
+FAILURE_STATES = {
+    "degraded",
+    "recovering",
+    "reinitialization_requested",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Observe post-reset localization health from reset execution and alignment_status "
+            "CSV artifacts. This is offline and does not subscribe to ROS topics."
+        )
+    )
+    parser.add_argument("--execution-csv", required=True)
+    parser.add_argument("--alignment-csv", required=True)
+    parser.add_argument(
+        "--commands-csv",
+        default="",
+        help="Optional reset commands CSV. Used to recover command stamp/trigger fields.",
+    )
+    parser.add_argument("--trajectory-eval-json", default="")
+    parser.add_argument("--output-csv", required=True)
+    parser.add_argument("--output-json", default="")
+    parser.add_argument("--output-md", default="")
+    parser.add_argument("--post-reset-window-sec", type=float, default=10.0)
+    parser.add_argument("--stable-ok-rows", type=int, default=5)
+    parser.add_argument("--false-recovery-rmse-threshold-m", type=float, default=5.0)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def _read_csv(path: Path) -> List[Dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        return list(csv.DictReader(stream))
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        number = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _as_int(value: Any) -> Optional[int]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        return int(float(str(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_bool(value: Any) -> Optional[bool]:
+    if value is None or str(value).strip() == "":
+        return None
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "y"}:
+        return True
+    if normalized in {"0", "false", "no", "n"}:
+        return False
+    return None
+
+
+def _fmt(value: Optional[float]) -> str:
+    return "" if value is None else f"{value:.9f}"
+
+
+def _counts(values: Iterable[str]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for value in values:
+        key = str(value)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def load_alignment_rows(path: Path) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for record in _read_csv(path):
+        values = json.loads(record["values_json"])
+        message = str(record.get("message", ""))
+        requested = _as_bool(values.get("reinitialization_requested")) is True
+        recovery_state = str(values.get("recovery_state", ""))
+        failure_like = (
+            message in FAILURE_MESSAGES
+            or message.startswith("fitness_score_over_")
+            or requested
+            or recovery_state in FAILURE_STATES
+        )
+        rows.append(
+            {
+                "stamp_sec": float(record["stamp_sec"]),
+                "message": message,
+                "failure_like": failure_like,
+                "consecutive_rejected_updates": _as_int(
+                    values.get("consecutive_rejected_updates")
+                )
+                or 0,
+            }
+        )
+    rows.sort(key=lambda row: row["stamp_sec"])
+    return rows
+
+
+def load_trajectory_risk(path: Optional[Path], threshold_m: float) -> Dict[str, Any]:
+    if path is None or not path.exists():
+        return {"available": False, "translation_rmse_m": None, "reference_risky": None}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    rmse = _as_float(
+        data.get("translation_rmse_m")
+        or data.get("rmse_m")
+        or data.get("translation", {}).get("rmse_m", "")
+    )
+    return {
+        "available": rmse is not None,
+        "translation_rmse_m": rmse,
+        "reference_risky": None if rmse is None else rmse > threshold_m,
+    }
+
+
+def _commands_by_id(commands_csv: Optional[Path]) -> Dict[str, Dict[str, str]]:
+    if commands_csv is None or not commands_csv.exists():
+        return {}
+    return {str(row.get("command_id", "")): row for row in _read_csv(commands_csv)}
+
+
+def _command_stamp(execution: Dict[str, str], command: Optional[Dict[str, str]]) -> Optional[float]:
+    for row in [execution, command or {}]:
+        for key in ["stamp_sec", "trigger_stamp_sec", "command_stamp_sec"]:
+            value = _as_float(row.get(key))
+            if value is not None:
+                return value
+    return None
+
+
+def _stable_ok_streak(rows: List[Dict[str, Any]]) -> int:
+    max_streak = 0
+    current = 0
+    for row in rows:
+        if row["message"] == "ok":
+            current += 1
+            max_streak = max(max_streak, current)
+        else:
+            current = 0
+    return max_streak
+
+
+def _first_ok_latency(rows: List[Dict[str, Any]], start_stamp: float) -> Optional[float]:
+    for row in rows:
+        if row["message"] == "ok":
+            return row["stamp_sec"] - start_stamp
+    return None
+
+
+def observe_execution(
+    execution_rows: List[Dict[str, str]],
+    alignment_rows: List[Dict[str, Any]],
+    commands_by_id: Dict[str, Dict[str, str]],
+    trajectory_risk: Dict[str, Any],
+    window_sec: float,
+    stable_ok_rows_required: int,
+) -> List[Dict[str, str]]:
+    generated_at = datetime.now().astimezone().isoformat(timespec="seconds")
+    observations: List[Dict[str, str]] = []
+    for execution in execution_rows:
+        command_id = str(execution.get("command_id", ""))
+        command = commands_by_id.get(command_id)
+        published_count = _as_int(execution.get("published_count")) or 0
+        execution_status = str(execution.get("status", ""))
+        command_stamp = _command_stamp(execution, command)
+        base = {
+            "command_id": command_id,
+            "attempt_id": str(execution.get("attempt_id", "")),
+            "published_count": str(published_count),
+            "execution_status": execution_status,
+            "command_stamp_sec": _fmt(command_stamp),
+            "observation_window_sec": f"{window_sec:.9f}",
+            "generated_at": generated_at,
+        }
+        if published_count <= 0:
+            observations.append(
+                {
+                    **base,
+                    "alignment_rows_in_window": "0",
+                    "ok_rows_in_window": "0",
+                    "failure_like_rows_in_window": "0",
+                    "first_ok_latency_sec": "",
+                    "stable_ok_rows_after_reset": "0",
+                    "max_reject_streak_after_reset": "0",
+                    "observed_recovered": "false",
+                    "accepted": "false",
+                    "false_recovery_observable": "false",
+                    "reference_risky": "",
+                    "rejection_reason": "reset_command_not_published",
+                }
+            )
+            continue
+        if command_stamp is None:
+            observations.append(
+                {
+                    **base,
+                    "alignment_rows_in_window": "0",
+                    "ok_rows_in_window": "0",
+                    "failure_like_rows_in_window": "0",
+                    "first_ok_latency_sec": "",
+                    "stable_ok_rows_after_reset": "0",
+                    "max_reject_streak_after_reset": "0",
+                    "observed_recovered": "false",
+                    "accepted": "false",
+                    "false_recovery_observable": "false",
+                    "reference_risky": "",
+                    "rejection_reason": "command_stamp_missing",
+                }
+            )
+            continue
+
+        deadline = command_stamp + window_sec
+        window_rows = [
+            row for row in alignment_rows if command_stamp <= row["stamp_sec"] <= deadline
+        ]
+        ok_rows = [row for row in window_rows if row["message"] == "ok"]
+        failure_like_rows = [row for row in window_rows if row["failure_like"]]
+        stable_ok = _stable_ok_streak(window_rows)
+        recovered = stable_ok >= stable_ok_rows_required
+        reference_risky = trajectory_risk.get("reference_risky")
+        observations.append(
+            {
+                **base,
+                "alignment_rows_in_window": str(len(window_rows)),
+                "ok_rows_in_window": str(len(ok_rows)),
+                "failure_like_rows_in_window": str(len(failure_like_rows)),
+                "first_ok_latency_sec": _fmt(_first_ok_latency(window_rows, command_stamp)),
+                "stable_ok_rows_after_reset": str(stable_ok),
+                "max_reject_streak_after_reset": str(
+                    max(
+                        [int(row["consecutive_rejected_updates"]) for row in window_rows],
+                        default=0,
+                    )
+                ),
+                "observed_recovered": "true" if recovered else "false",
+                "accepted": "true" if recovered else "false",
+                "false_recovery_observable": "true" if trajectory_risk["available"] else "false",
+                "reference_risky": ""
+                if reference_risky is None
+                else ("true" if reference_risky else "false"),
+                "rejection_reason": "" if recovered else "stable_ok_rows_below_threshold",
+            }
+        )
+    return observations
+
+
+def write_csv(path: Path, rows: List[Dict[str, str]], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output CSV already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=OBSERVATION_FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def build_summary(
+    execution_csv: Path,
+    alignment_csv: Path,
+    output_csv: Path,
+    observations: List[Dict[str, str]],
+    trajectory_risk: Dict[str, Any],
+) -> Dict[str, Any]:
+    recovered_rows = [row for row in observations if _as_bool(row.get("observed_recovered"))]
+    accepted_rows = [row for row in observations if _as_bool(row.get("accepted"))]
+    return {
+        "execution_csv": str(execution_csv),
+        "alignment_csv": str(alignment_csv),
+        "output_csv": str(output_csv),
+        "command_count": len(observations),
+        "observed_recovered_count": len(recovered_rows),
+        "accepted_count": len(accepted_rows),
+        "published_command_count": len(
+            [row for row in observations if (_as_int(row.get("published_count")) or 0) > 0]
+        ),
+        "rejection_reason_counts": _counts(row.get("rejection_reason", "") for row in observations),
+        "execution_status_counts": _counts(row.get("execution_status", "") for row in observations),
+        "trajectory_risk": trajectory_risk,
+        "notes": [
+            "accepted=true here means offline post-reset observation met stable-ok criteria",
+            "unpublished commands are not evaluated for recovery",
+            "false recovery is only observable when trajectory_eval_json is provided",
+        ],
+    }
+
+
+def write_json(path: Path, data: Dict[str, Any], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output JSON already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_md(path: Path, data: Dict[str, Any], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output Markdown already exists: {path}")
+    lines = [
+        "# Relocalization Reset Execution Observation",
+        "",
+        f"- execution CSV: `{data['execution_csv']}`",
+        f"- alignment CSV: `{data['alignment_csv']}`",
+        f"- output CSV: `{data['output_csv']}`",
+        f"- commands: `{data['command_count']}`",
+        f"- published commands: `{data['published_command_count']}`",
+        f"- observed recovered: `{data['observed_recovered_count']}`",
+        f"- accepted: `{data['accepted_count']}`",
+        f"- rejection reasons: `{json.dumps(data['rejection_reason_counts'], sort_keys=True)}`",
+        f"- execution statuses: `{json.dumps(data['execution_status_counts'], sort_keys=True)}`",
+        "",
+        "## Notes",
+        "",
+    ]
+    lines.extend(f"- {note}" for note in data["notes"])
+    lines.append("")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    execution_csv = Path(args.execution_csv).expanduser().resolve()
+    alignment_csv = Path(args.alignment_csv).expanduser().resolve()
+    commands_csv = Path(args.commands_csv).expanduser().resolve() if args.commands_csv else None
+    trajectory_eval = (
+        Path(args.trajectory_eval_json).expanduser().resolve()
+        if args.trajectory_eval_json
+        else None
+    )
+    output_csv = Path(args.output_csv).expanduser().resolve()
+    if not execution_csv.exists():
+        raise FileNotFoundError(f"execution CSV does not exist: {execution_csv}")
+    if not alignment_csv.exists():
+        raise FileNotFoundError(f"alignment CSV does not exist: {alignment_csv}")
+    if commands_csv is not None and not commands_csv.exists():
+        raise FileNotFoundError(f"commands CSV does not exist: {commands_csv}")
+    if trajectory_eval is not None and not trajectory_eval.exists():
+        raise FileNotFoundError(f"trajectory eval JSON does not exist: {trajectory_eval}")
+
+    execution_rows = _read_csv(execution_csv)
+    alignment_rows = load_alignment_rows(alignment_csv)
+    command_rows = _commands_by_id(commands_csv)
+    trajectory_risk = load_trajectory_risk(trajectory_eval, args.false_recovery_rmse_threshold_m)
+    observations = observe_execution(
+        execution_rows=execution_rows,
+        alignment_rows=alignment_rows,
+        commands_by_id=command_rows,
+        trajectory_risk=trajectory_risk,
+        window_sec=args.post_reset_window_sec,
+        stable_ok_rows_required=args.stable_ok_rows,
+    )
+    write_csv(output_csv, observations, args.overwrite)
+    summary = build_summary(
+        execution_csv=execution_csv,
+        alignment_csv=alignment_csv,
+        output_csv=output_csv,
+        observations=observations,
+        trajectory_risk=trajectory_risk,
+    )
+    if args.output_json:
+        write_json(Path(args.output_json).expanduser().resolve(), summary, args.overwrite)
+    if args.output_md:
+        write_md(Path(args.output_md).expanduser().resolve(), summary, args.overwrite)
+    print(json.dumps(summary, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/publish_relocalization_reset_commands.py
+++ b/scripts/publish_relocalization_reset_commands.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import math
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+
+
+EXECUTION_FIELDNAMES = [
+    "command_id",
+    "attempt_id",
+    "execute",
+    "publish_topic",
+    "frame_id",
+    "position_x",
+    "position_y",
+    "position_z",
+    "orientation_x",
+    "orientation_y",
+    "orientation_z",
+    "orientation_w",
+    "yaw_rad",
+    "publish_repeat",
+    "published_count",
+    "status",
+    "rejection_reason",
+    "validation_json",
+    "validation_passed",
+    "generated_at",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Publish validated relocalization reset commands to /initialpose. By default this "
+            "only writes an execution report; actual publishing requires --execute."
+        )
+    )
+    parser.add_argument("--commands-csv", required=True)
+    parser.add_argument("--validation-json", required=True)
+    parser.add_argument("--output-csv", required=True)
+    parser.add_argument("--output-json", default="")
+    parser.add_argument("--output-md", default="")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--allow-unvalidated", action="store_true")
+    parser.add_argument("--allow-failed-validation", action="store_true")
+    parser.add_argument("--allow-accepted-source-plan", action="store_true")
+    parser.add_argument("--allow-oracle-selection", action="store_true")
+    parser.add_argument("--publish-repeat", type=int, default=1)
+    parser.add_argument("--publish-period-sec", type=float, default=0.1)
+    parser.add_argument("--spin-before-sec", type=float, default=0.2)
+    parser.add_argument("--node-name", default="relocalization_reset_command_publisher")
+    parser.add_argument("--xy-covariance", type=float, default=0.25)
+    parser.add_argument("--z-covariance", type=float, default=0.25)
+    parser.add_argument("--roll-pitch-covariance", type=float, default=0.06853892326654787)
+    parser.add_argument("--yaw-covariance", type=float, default=0.06853892326654787)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def _read_csv(path: Path) -> List[Dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        return list(csv.DictReader(stream))
+
+
+def _as_bool(value: Any) -> Optional[bool]:
+    if value is None or str(value).strip() == "":
+        return None
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "y"}:
+        return True
+    if normalized in {"0", "false", "no", "n"}:
+        return False
+    return None
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        number = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _counts(values: Iterable[str]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for value in values:
+        key = str(value)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _load_validation(path: Path, allow_unvalidated: bool) -> Dict[str, Any]:
+    if not path.exists():
+        if allow_unvalidated:
+            return {"validation_passed": False, "missing": True}
+        raise FileNotFoundError(f"validation JSON does not exist: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validation_ok(validation: Dict[str, Any], args: argparse.Namespace) -> bool:
+    if args.allow_unvalidated:
+        return True
+    if bool(validation.get("validation_passed")):
+        return True
+    return bool(args.allow_failed_validation)
+
+
+def _safe_float(row: Dict[str, str], key: str) -> Optional[float]:
+    return _as_float(row.get(key))
+
+
+def _command_rejection(row: Dict[str, str], args: argparse.Namespace) -> str:
+    if row.get("status") != "dry_run_command_generated":
+        return "command_status_not_generated"
+    if _as_bool(row.get("dry_run")) is not True:
+        return "command_not_marked_dry_run"
+    if _as_bool(row.get("source_plan_row_accepted")) is True and not args.allow_accepted_source_plan:
+        return "accepted_source_plan_not_allowed"
+    if row.get("source_selection_source") == "oracle_rank" and not args.allow_oracle_selection:
+        return "oracle_selection_not_allowed"
+    for field in [
+        "position_x",
+        "position_y",
+        "position_z",
+        "orientation_x",
+        "orientation_y",
+        "orientation_z",
+        "orientation_w",
+    ]:
+        if _safe_float(row, field) is None:
+            return f"{field}_missing"
+    return ""
+
+
+def _empty_execution(
+    row: Dict[str, str],
+    args: argparse.Namespace,
+    validation_json: Path,
+    validation_passed: bool,
+    status: str,
+    rejection_reason: str,
+    generated_at: str,
+) -> Dict[str, str]:
+    return {
+        "command_id": str(row.get("command_id", "")),
+        "attempt_id": str(row.get("attempt_id", "")),
+        "execute": "true" if args.execute else "false",
+        "publish_topic": str(row.get("publish_topic", "")),
+        "frame_id": str(row.get("frame_id", "")),
+        "position_x": str(row.get("position_x", "")),
+        "position_y": str(row.get("position_y", "")),
+        "position_z": str(row.get("position_z", "")),
+        "orientation_x": str(row.get("orientation_x", "")),
+        "orientation_y": str(row.get("orientation_y", "")),
+        "orientation_z": str(row.get("orientation_z", "")),
+        "orientation_w": str(row.get("orientation_w", "")),
+        "yaw_rad": str(row.get("yaw_rad", "")),
+        "publish_repeat": str(args.publish_repeat),
+        "published_count": "0",
+        "status": status,
+        "rejection_reason": rejection_reason,
+        "validation_json": str(validation_json),
+        "validation_passed": "true" if validation_passed else "false",
+        "generated_at": generated_at,
+    }
+
+
+def _covariance(args: argparse.Namespace) -> List[float]:
+    covariance = [0.0] * 36
+    covariance[0] = args.xy_covariance
+    covariance[7] = args.xy_covariance
+    covariance[14] = args.z_covariance
+    covariance[21] = args.roll_pitch_covariance
+    covariance[28] = args.roll_pitch_covariance
+    covariance[35] = args.yaw_covariance
+    return covariance
+
+
+def publish_rows(rows: List[Dict[str, str]], args: argparse.Namespace) -> Dict[str, int]:
+    import rclpy
+    from geometry_msgs.msg import PoseWithCovarianceStamped
+
+    rclpy.init()
+    node = rclpy.create_node(args.node_name)
+    publishers: Dict[str, Any] = {}
+    counts: Dict[str, int] = {}
+    try:
+        deadline = time.monotonic() + max(0.0, args.spin_before_sec)
+        while time.monotonic() < deadline:
+            rclpy.spin_once(node, timeout_sec=0.05)
+        covariance = _covariance(args)
+        for row in rows:
+            topic = row["publish_topic"]
+            if topic not in publishers:
+                publishers[topic] = node.create_publisher(PoseWithCovarianceStamped, topic, 10)
+            publisher = publishers[topic]
+            msg = PoseWithCovarianceStamped()
+            msg.header.frame_id = row["frame_id"]
+            msg.header.stamp = node.get_clock().now().to_msg()
+            msg.pose.pose.position.x = float(row["position_x"])
+            msg.pose.pose.position.y = float(row["position_y"])
+            msg.pose.pose.position.z = float(row["position_z"])
+            msg.pose.pose.orientation.x = float(row["orientation_x"])
+            msg.pose.pose.orientation.y = float(row["orientation_y"])
+            msg.pose.pose.orientation.z = float(row["orientation_z"])
+            msg.pose.pose.orientation.w = float(row["orientation_w"])
+            msg.pose.covariance = covariance
+            count = 0
+            for _ in range(max(1, args.publish_repeat)):
+                msg.header.stamp = node.get_clock().now().to_msg()
+                publisher.publish(msg)
+                rclpy.spin_once(node, timeout_sec=0.0)
+                count += 1
+                if args.publish_period_sec > 0:
+                    time.sleep(args.publish_period_sec)
+            counts[row["command_id"]] = count
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+    return counts
+
+
+def build_execution_rows(
+    command_rows: List[Dict[str, str]],
+    validation_json: Path,
+    validation_passed: bool,
+    args: argparse.Namespace,
+) -> List[Dict[str, str]]:
+    generated_at = datetime.now().astimezone().isoformat(timespec="seconds")
+    execution_rows: List[Dict[str, str]] = []
+    for row in command_rows:
+        reason = _command_rejection(row, args)
+        if reason:
+            execution_rows.append(
+                _empty_execution(
+                    row,
+                    args,
+                    validation_json,
+                    validation_passed,
+                    status="not_published",
+                    rejection_reason=reason,
+                    generated_at=generated_at,
+                )
+            )
+            continue
+        if not validation_passed:
+            execution_rows.append(
+                _empty_execution(
+                    row,
+                    args,
+                    validation_json,
+                    validation_passed,
+                    status="not_published",
+                    rejection_reason="validation_not_passed",
+                    generated_at=generated_at,
+                )
+            )
+            continue
+        if not args.execute:
+            execution_rows.append(
+                _empty_execution(
+                    row,
+                    args,
+                    validation_json,
+                    validation_passed,
+                    status="not_published",
+                    rejection_reason="execute_flag_required",
+                    generated_at=generated_at,
+                )
+            )
+            continue
+        execution_rows.append(
+            _empty_execution(
+                row,
+                args,
+                validation_json,
+                validation_passed,
+                status="pending_publish",
+                rejection_reason="",
+                generated_at=generated_at,
+            )
+        )
+    return execution_rows
+
+
+def write_csv(path: Path, rows: List[Dict[str, str]], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output CSV already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=EXECUTION_FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def build_summary(commands_csv: Path, output_csv: Path, rows: List[Dict[str, str]]) -> Dict[str, Any]:
+    published_count = sum(int(row.get("published_count", "0") or "0") for row in rows)
+    return {
+        "commands_csv": str(commands_csv),
+        "output_csv": str(output_csv),
+        "execution_row_count": len(rows),
+        "published_count": published_count,
+        "status_counts": _counts(row.get("status", "") for row in rows),
+        "rejection_reason_counts": _counts(row.get("rejection_reason", "") for row in rows),
+        "notes": [
+            "actual publishing requires --execute",
+            "validation_passed=true is required unless explicitly overridden",
+            "publishing uses geometry_msgs/PoseWithCovarianceStamped",
+        ],
+    }
+
+
+def write_json(path: Path, data: Dict[str, Any], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output JSON already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_md(path: Path, data: Dict[str, Any], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output Markdown already exists: {path}")
+    lines = [
+        "# Relocalization Reset Command Execution",
+        "",
+        f"- commands CSV: `{data['commands_csv']}`",
+        f"- output CSV: `{data['output_csv']}`",
+        f"- execution rows: `{data['execution_row_count']}`",
+        f"- published count: `{data['published_count']}`",
+        f"- status counts: `{json.dumps(data['status_counts'], sort_keys=True)}`",
+        f"- rejection reasons: `{json.dumps(data['rejection_reason_counts'], sort_keys=True)}`",
+        "",
+        "## Notes",
+        "",
+    ]
+    lines.extend(f"- {note}" for note in data["notes"])
+    lines.append("")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    commands_csv = Path(args.commands_csv).expanduser().resolve()
+    validation_json = Path(args.validation_json).expanduser().resolve()
+    output_csv = Path(args.output_csv).expanduser().resolve()
+    if not commands_csv.exists():
+        raise FileNotFoundError(f"commands CSV does not exist: {commands_csv}")
+    if args.publish_repeat < 1:
+        raise ValueError("--publish-repeat must be >= 1")
+
+    command_rows = _read_csv(commands_csv)
+    validation = _load_validation(validation_json, args.allow_unvalidated)
+    validation_passed = _validation_ok(validation, args)
+    execution_rows = build_execution_rows(command_rows, validation_json, validation_passed, args)
+    publishable = [row for row in execution_rows if row["status"] == "pending_publish"]
+    if publishable:
+        published = publish_rows(publishable, args)
+        for row in execution_rows:
+            if row["status"] == "pending_publish":
+                count = published.get(row["command_id"], 0)
+                row["published_count"] = str(count)
+                row["status"] = "published_initialpose" if count > 0 else "publish_failed"
+                row["rejection_reason"] = "" if count > 0 else "publisher_returned_zero"
+    write_csv(output_csv, execution_rows, args.overwrite)
+    summary = build_summary(commands_csv, output_csv, execution_rows)
+    if args.output_json:
+        write_json(Path(args.output_json).expanduser().resolve(), summary, args.overwrite)
+    if args.output_md:
+        write_md(Path(args.output_md).expanduser().resolve(), summary, args.overwrite)
+    print(json.dumps(summary, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/resolve_registration_relocalization_scans.py
+++ b/scripts/resolve_registration_relocalization_scans.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import math
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+import numpy as np
+from rosbags.rosbag2 import Reader
+from rosbags.typesys import Stores
+from rosbags.typesys import get_typestore
+
+
+TYPESTORE = get_typestore(Stores.ROS2_HUMBLE)
+
+SCORE_FIELDNAMES = [
+    "job_id",
+    "attempt_id",
+    "candidate_index",
+    "selection_source",
+    "selection_rank",
+    "oracle_rank",
+    "oracle_score",
+    "trigger_stamp_sec",
+    "scan_stamp_sec",
+    "scan_time_delta_sec",
+    "scan_point_count_raw",
+    "scan_point_count_valid",
+    "scan_nearest_range_m",
+    "scan_farthest_range_m",
+    "scan_bounds_min_x",
+    "scan_bounds_min_y",
+    "scan_bounds_min_z",
+    "scan_bounds_max_x",
+    "scan_bounds_max_y",
+    "scan_bounds_max_z",
+    "scan_pcd_path",
+    "map_path",
+    "registration_method",
+    "initial_pose_x",
+    "initial_pose_y",
+    "initial_pose_z",
+    "initial_yaw_rad",
+    "status",
+    "rejection_reason",
+    "converged",
+    "score",
+    "overlap",
+    "refinement_delta_m",
+    "refinement_delta_yaw_rad",
+    "runtime_sec",
+]
+
+
+@dataclass(frozen=True)
+class ScanSummary:
+    stamp_sec: float
+    raw_point_count: int
+    valid_point_count: int
+    nearest_range_m: Optional[float]
+    farthest_range_m: Optional[float]
+    bounds_min: Tuple[Optional[float], Optional[float], Optional[float]]
+    bounds_max: Tuple[Optional[float], Optional[float], Optional[float]]
+    valid_points: np.ndarray
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Resolve the nearest PointCloud2 scan for each relocalization registration job. "
+            "This validates scorer inputs and writes a score-shaped CSV, but does not run "
+            "registration or reset pose."
+        )
+    )
+    parser.add_argument("--jobs-csv", required=True, help="Input relocalization_registration_jobs.csv")
+    parser.add_argument(
+        "--output-csv",
+        required=True,
+        help="Output relocalization_registration_scores.csv",
+    )
+    parser.add_argument(
+        "--max-scan-time-diff",
+        type=float,
+        default=0.25,
+        help="Maximum allowed absolute trigger-to-scan time difference in seconds.",
+    )
+    parser.add_argument(
+        "--min-range",
+        type=float,
+        default=1.0,
+        help="Minimum range for valid point count and bounds.",
+    )
+    parser.add_argument(
+        "--max-range",
+        type=float,
+        default=120.0,
+        help="Maximum range for valid point count and bounds.",
+    )
+    parser.add_argument(
+        "--max-jobs",
+        type=int,
+        default=0,
+        help="Optional cap for smoke testing. 0 means all jobs.",
+    )
+    parser.add_argument(
+        "--export-scan-pcd-dir",
+        default="",
+        help="Optional directory for one PCD file per unique resolved scan.",
+    )
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite output CSV.")
+    return parser.parse_args()
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        number = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _fmt(value: Optional[float]) -> str:
+    return "" if value is None else f"{value:.9f}"
+
+
+def _read_csv_rows(path: Path) -> Tuple[List[str], List[Dict[str, Any]]]:
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        reader = csv.DictReader(stream)
+        return list(reader.fieldnames or []), list(reader)
+
+
+def pointcloud2_xyz_array(message: object) -> np.ndarray:
+    field_offsets = {field.name: int(field.offset) for field in message.fields}
+    for field_name in ("x", "y", "z"):
+        if field_name not in field_offsets:
+            raise RuntimeError(f"PointCloud2 is missing required field: {field_name}")
+
+    endian = ">" if bool(message.is_bigendian) else "<"
+    dtype = np.dtype(
+        {
+            "names": ["x", "y", "z"],
+            "formats": [f"{endian}f4", f"{endian}f4", f"{endian}f4"],
+            "offsets": [field_offsets["x"], field_offsets["y"], field_offsets["z"]],
+            "itemsize": int(message.point_step),
+        }
+    )
+    count = int(message.width * message.height)
+    array = np.frombuffer(bytes(message.data), dtype=dtype, count=count)
+    return np.column_stack([array["x"], array["y"], array["z"]]).astype(
+        np.float32, copy=False
+    )
+
+
+def scan_stamp_sec(message: object, fallback_record_time_ns: int) -> float:
+    if hasattr(message, "header") and hasattr(message.header, "stamp"):
+        stamp = message.header.stamp
+        return float(stamp.sec) + float(stamp.nanosec) * 1e-9
+    return float(fallback_record_time_ns) * 1e-9
+
+
+def summarize_scan(
+    message: object,
+    record_time_ns: int,
+    min_range: float,
+    max_range: float,
+) -> ScanSummary:
+    xyz = pointcloud2_xyz_array(message)
+    raw_count = int(xyz.shape[0])
+    finite = np.isfinite(xyz).all(axis=1)
+    ranges = np.linalg.norm(xyz, axis=1)
+    valid_mask = finite & (ranges >= min_range) & (ranges <= max_range)
+    valid = xyz[valid_mask]
+    valid_ranges = ranges[valid_mask]
+    if valid.shape[0] == 0:
+        bounds_min: Tuple[Optional[float], Optional[float], Optional[float]] = (
+            None,
+            None,
+            None,
+        )
+        bounds_max: Tuple[Optional[float], Optional[float], Optional[float]] = (
+            None,
+            None,
+            None,
+        )
+        nearest = None
+        farthest = None
+    else:
+        bounds_min_values = valid.min(axis=0)
+        bounds_max_values = valid.max(axis=0)
+        bounds_min = tuple(float(value) for value in bounds_min_values)
+        bounds_max = tuple(float(value) for value in bounds_max_values)
+        nearest = float(valid_ranges.min())
+        farthest = float(valid_ranges.max())
+    return ScanSummary(
+        stamp_sec=scan_stamp_sec(message, record_time_ns),
+        raw_point_count=raw_count,
+        valid_point_count=int(valid.shape[0]),
+        nearest_range_m=nearest,
+        farthest_range_m=farthest,
+        bounds_min=bounds_min,
+        bounds_max=bounds_max,
+        valid_points=valid.astype(np.float32, copy=False),
+    )
+
+
+def write_xyz_intensity_pcd(path: Path, points: np.ndarray) -> None:
+    xyz = np.asarray(points, dtype=np.float32, order="C")
+    if xyz.ndim != 2 or xyz.shape[1] != 3:
+        raise RuntimeError(f"expected Nx3 point array, got {xyz.shape}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header = (
+        "# .PCD v0.7 - Point Cloud Data file format\n"
+        "VERSION 0.7\n"
+        "FIELDS x y z intensity\n"
+        "SIZE 4 4 4 4\n"
+        "TYPE F F F F\n"
+        "COUNT 1 1 1 1\n"
+        f"WIDTH {xyz.shape[0]}\n"
+        "HEIGHT 1\n"
+        "VIEWPOINT 0 0 0 1 0 0 0\n"
+        f"POINTS {xyz.shape[0]}\n"
+        "DATA binary\n"
+    ).encode("ascii")
+    intensity = np.zeros((xyz.shape[0], 1), dtype=np.float32)
+    xyzi = np.hstack([xyz, intensity]).astype("<f4", copy=False)
+    with path.open("wb") as stream:
+        stream.write(header)
+        stream.write(xyzi.tobytes())
+
+
+def load_scan_summaries(
+    bag_path: Path,
+    cloud_topic: str,
+    min_range: float,
+    max_range: float,
+) -> List[ScanSummary]:
+    reader = Reader(str(bag_path))
+    reader.open()
+    summaries: List[ScanSummary] = []
+    try:
+        for connection, timestamp, rawdata in reader.messages():
+            if connection.topic != cloud_topic:
+                continue
+            message = TYPESTORE.deserialize_cdr(rawdata, connection.msgtype)
+            summaries.append(
+                summarize_scan(
+                    message,
+                    record_time_ns=int(timestamp),
+                    min_range=min_range,
+                    max_range=max_range,
+                )
+            )
+    finally:
+        reader.close()
+    if not summaries:
+        raise RuntimeError(f"no PointCloud2 scans found for topic {cloud_topic} in {bag_path}")
+    summaries.sort(key=lambda scan: scan.stamp_sec)
+    return summaries
+
+
+def nearest_scan(
+    scans: List[ScanSummary],
+    target_stamp_sec: float,
+) -> ScanSummary:
+    # A linear scan is acceptable here because this helper is an artifact validator; the bag
+    # is loaded once per unique bag/topic and job counts are intentionally capped.
+    return min(scans, key=lambda scan: abs(scan.stamp_sec - target_stamp_sec))
+
+
+def grouped_jobs(jobs: Iterable[Dict[str, Any]]) -> Dict[Tuple[str, str], List[Dict[str, Any]]]:
+    groups: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    for job in jobs:
+        groups.setdefault((str(job["bag_path"]), str(job["cloud_topic"])), []).append(job)
+    return groups
+
+
+def build_score_row(
+    job: Dict[str, Any],
+    scan: Optional[ScanSummary],
+    max_scan_time_diff: float,
+    scan_pcd_path: Optional[Path],
+    started: float,
+) -> Dict[str, Any]:
+    trigger_stamp = _as_float(job.get("trigger_stamp_sec"))
+    if scan is None or trigger_stamp is None:
+        status = "missing_scan"
+        rejection_reason = "scan_not_resolved"
+        scan_delta: Optional[float] = None
+    else:
+        scan_delta = scan.stamp_sec - trigger_stamp
+        if abs(scan_delta) > max_scan_time_diff:
+            status = "scan_time_mismatch"
+            rejection_reason = "scan_time_delta_exceeds_threshold"
+        else:
+            status = "scan_resolved_no_registration"
+            rejection_reason = "registration_not_implemented"
+
+    bounds_min = (None, None, None) if scan is None else scan.bounds_min
+    bounds_max = (None, None, None) if scan is None else scan.bounds_max
+    return {
+        "job_id": str(job.get("job_id", "")),
+        "attempt_id": str(job.get("attempt_id", "")),
+        "candidate_index": str(job.get("candidate_index", "")),
+        "selection_source": str(job.get("selection_source", "")),
+        "selection_rank": str(job.get("selection_rank", "")),
+        "oracle_rank": str(job.get("oracle_rank", "")),
+        "oracle_score": str(job.get("oracle_score", "")),
+        "trigger_stamp_sec": str(job.get("trigger_stamp_sec", "")),
+        "scan_stamp_sec": "" if scan is None else f"{scan.stamp_sec:.9f}",
+        "scan_time_delta_sec": _fmt(scan_delta),
+        "scan_point_count_raw": "" if scan is None else str(scan.raw_point_count),
+        "scan_point_count_valid": "" if scan is None else str(scan.valid_point_count),
+        "scan_nearest_range_m": "" if scan is None else _fmt(scan.nearest_range_m),
+        "scan_farthest_range_m": "" if scan is None else _fmt(scan.farthest_range_m),
+        "scan_bounds_min_x": _fmt(bounds_min[0]),
+        "scan_bounds_min_y": _fmt(bounds_min[1]),
+        "scan_bounds_min_z": _fmt(bounds_min[2]),
+        "scan_bounds_max_x": _fmt(bounds_max[0]),
+        "scan_bounds_max_y": _fmt(bounds_max[1]),
+        "scan_bounds_max_z": _fmt(bounds_max[2]),
+        "scan_pcd_path": "" if scan_pcd_path is None else str(scan_pcd_path),
+        "map_path": str(job.get("map_path", "")),
+        "registration_method": str(job.get("registration_method", "")),
+        "initial_pose_x": str(job.get("initial_pose_x", "")),
+        "initial_pose_y": str(job.get("initial_pose_y", "")),
+        "initial_pose_z": str(job.get("initial_pose_z", "")),
+        "initial_yaw_rad": str(job.get("initial_yaw_rad", "")),
+        "status": status,
+        "rejection_reason": rejection_reason,
+        "converged": "false",
+        "score": "",
+        "overlap": "",
+        "refinement_delta_m": "",
+        "refinement_delta_yaw_rad": "",
+        "runtime_sec": f"{time.monotonic() - started:.6f}",
+    }
+
+
+def resolve_jobs(
+    jobs: List[Dict[str, Any]],
+    max_scan_time_diff: float,
+    min_range: float,
+    max_range: float,
+    export_scan_pcd_dir: Optional[Path],
+) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    exported_scans: Dict[Tuple[str, str, str], Path] = {}
+    for (bag_path_raw, cloud_topic), group in grouped_jobs(jobs).items():
+        bag_path = Path(bag_path_raw)
+        scans = load_scan_summaries(
+            bag_path,
+            cloud_topic=cloud_topic,
+            min_range=min_range,
+            max_range=max_range,
+        )
+        for job in group:
+            started = time.monotonic()
+            trigger_stamp = _as_float(job.get("trigger_stamp_sec"))
+            scan = None if trigger_stamp is None else nearest_scan(scans, trigger_stamp)
+            scan_pcd_path = None
+            if scan is not None and export_scan_pcd_dir is not None:
+                key = (str(bag_path), cloud_topic, f"{scan.stamp_sec:.9f}")
+                scan_pcd_path = exported_scans.get(key)
+                if scan_pcd_path is None:
+                    safe_topic = cloud_topic.strip("/").replace("/", "_") or "cloud"
+                    scan_pcd_path = (
+                        export_scan_pcd_dir
+                        / f"{safe_topic}_{scan.stamp_sec:.9f}.pcd"
+                    )
+                    write_xyz_intensity_pcd(scan_pcd_path, scan.valid_points)
+                    exported_scans[key] = scan_pcd_path
+            rows.append(build_score_row(job, scan, max_scan_time_diff, scan_pcd_path, started))
+    return rows
+
+
+def write_scores(path: Path, rows: List[Dict[str, Any]], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output CSV already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=SCORE_FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    args = parse_args()
+    jobs_csv = Path(args.jobs_csv).expanduser().resolve()
+    output_csv = Path(args.output_csv).expanduser().resolve()
+    if not jobs_csv.exists():
+        raise FileNotFoundError(f"jobs CSV does not exist: {jobs_csv}")
+
+    _, jobs = _read_csv_rows(jobs_csv)
+    if args.max_jobs > 0:
+        jobs = jobs[: args.max_jobs]
+    rows = resolve_jobs(
+        jobs,
+        max_scan_time_diff=float(args.max_scan_time_diff),
+        min_range=float(args.min_range),
+        max_range=float(args.max_range),
+        export_scan_pcd_dir=(
+            Path(args.export_scan_pcd_dir).expanduser().resolve()
+            if args.export_scan_pcd_dir
+            else None
+        ),
+    )
+    write_scores(output_csv, rows, overwrite=args.overwrite)
+    status_counts: Dict[str, int] = {}
+    for row in rows:
+        status_counts[row["status"]] = status_counts.get(row["status"], 0) + 1
+    print(
+        json.dumps(
+            {
+                "output_csv": str(output_csv),
+                "job_count": len(jobs),
+                "score_row_count": len(rows),
+                "status_counts": status_counts,
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_public_regression_suite.sh
+++ b/scripts/run_public_regression_suite.sh
@@ -105,6 +105,7 @@ istanbul_pose_topic="/sensing/gnss/pose_with_covariance"
 istanbul_base_template="${repo_root}/param/public_istanbul_60s_benchmark.yaml"
 
 hdl_bag="${ws_root}/data/official/hdl_localization/hdl_400_ros2"
+hdl_map="${ws_root}/data/official/hdl_localization/map.pcd"
 hdl_cloud_topic="/velodyne_points"
 hdl_imu_topic="/gpsimu_driver/imu_data"
 
@@ -115,7 +116,7 @@ for required_dir in "${istanbul_bag}" "${hdl_bag}"; do
   fi
 done
 
-for required_file in "${istanbul_map}" "${istanbul_base_template}" "${repo_root}/param/hdl_imu_preint.yaml"; do
+for required_file in "${istanbul_map}" "${hdl_map}" "${istanbul_base_template}" "${repo_root}/param/hdl_imu_preint.yaml"; do
   if [[ ! -f "${required_file}" ]]; then
     echo "Required file not found: ${required_file}" >&2
     exit 1
@@ -142,6 +143,7 @@ istanbul_initial_pose_yaml="${inputs_dir}/autoware_istanbul_initial_pose_60s.yam
 istanbul_param_yaml="${inputs_dir}/autoware_istanbul_public_benchmark_60s.yaml"
 istanbul_run_dir="${istanbul_dir}/default_on_no_imu"
 hdl_no_imu_yaml="${inputs_dir}/hdl_imu_preint_false.yaml"
+hdl_imu_yaml="${inputs_dir}/hdl_imu_preint_true.yaml"
 summary_json="${report_dir}/summary.json"
 summary_md="${report_dir}/summary.md"
 
@@ -175,17 +177,22 @@ output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(yaml.safe_dump(base, sort_keys=False), encoding="utf-8")
 PY
 
-python3 - "${repo_root}/param/hdl_imu_preint.yaml" "${hdl_no_imu_yaml}" <<'PY'
+python3 - "${repo_root}/param/hdl_imu_preint.yaml" "${hdl_no_imu_yaml}" "${hdl_imu_yaml}" "${hdl_map}" <<'PY'
 import sys
 from pathlib import Path
 import yaml
 
 src = Path(sys.argv[1])
-dst = Path(sys.argv[2])
+false_dst = Path(sys.argv[2])
+true_dst = Path(sys.argv[3])
+map_path = str(Path(sys.argv[4]).resolve())
 data = yaml.safe_load(src.read_text(encoding="utf-8"))
-data["/**"]["ros__parameters"]["use_imu_preintegration"] = False
-dst.parent.mkdir(parents=True, exist_ok=True)
-dst.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+params = data["/**"]["ros__parameters"]
+params["map_path"] = map_path
+true_dst.parent.mkdir(parents=True, exist_ok=True)
+true_dst.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+params["use_imu_preintegration"] = False
+false_dst.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
 PY
 
 if [[ "${resume}" != "1" || ! -f "${istanbul_run_dir}/summary.json" ]]; then
@@ -248,7 +255,7 @@ for ((repeat_index=1; repeat_index<=hdl_repeat_count; repeat_index++)); do
       --target-process-pattern lidar_localization_node \
       --record-topic /pcl_pose \
       --diagnostic-topic /alignment_status \
-      --system-command "ros2 launch lidar_localization_ros2 lidar_localization.launch.py localization_param_dir:=${repo_root}/param/hdl_imu_preint.yaml cloud_topic:=${hdl_cloud_topic} imu_topic:=${hdl_imu_topic}"
+      --system-command "ros2 launch lidar_localization_ros2 lidar_localization.launch.py localization_param_dir:=${hdl_imu_yaml} cloud_topic:=${hdl_cloud_topic} imu_topic:=${hdl_imu_topic}"
   fi
 done
 
@@ -305,6 +312,12 @@ def as_float(value):
     if value in (None, "", "None"):
         return None
     return float(value)
+
+
+def fmt_float(value, digits=6):
+    if value is None:
+        return "None"
+    return f"{float(value):.{digits}f}"
 
 
 def collect_run_dirs(group_dir: Path):
@@ -496,7 +509,7 @@ summary_md.write_text(
             f"- pass: `{hdl_pass}`",
             f"- runs: `{len(hdl_false_runs)} baseline / {len(hdl_true_runs)} candidate`",
             f"- pose_rows_median: `{hdl_false_pose_rows} -> {hdl_true_pose_rows}`",
-            f"- alignment_time_median_sec_median: `{hdl_false_align_median:.6f} -> {hdl_true_align_median:.6f}`",
+            f"- alignment_time_median_sec_median: `{fmt_float(hdl_false_align_median)} -> {fmt_float(hdl_true_align_median)}`",
             f"- imu_prediction_active_rows_median(true): `{hdl_true_imu_active}`",
             f"- imu_smoother_diverged_imu_disabled_max: `{hdl_fallback_events}`",
             "",

--- a/scripts/run_registration_ordering_comparison.py
+++ b/scripts/run_registration_ordering_comparison.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import List
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run bounded NDT scorer comparisons for candidate_index and oracle_rank "
+            "candidate ordering. This is diagnostic only and never accepts or resets pose."
+        )
+    )
+    parser.add_argument("--attempts-csv", required=True)
+    parser.add_argument("--candidates-csv", required=True)
+    parser.add_argument("--bag-path", required=True)
+    parser.add_argument("--map-path", required=True)
+    parser.add_argument("--cloud-topic", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--top-k", type=int, default=5)
+    parser.add_argument("--registration-method", default="NDT_OMP")
+    parser.add_argument("--local-map-radius", type=float, default=150.0)
+    parser.add_argument("--voxel-leaf-size", type=float, default=1.0)
+    parser.add_argument("--scan-min-range", type=float, default=1.0)
+    parser.add_argument("--scan-max-range", type=float, default=120.0)
+    parser.add_argument("--max-scan-time-diff", type=float, default=0.25)
+    parser.add_argument("--ndt-resolution", type=float, default=1.0)
+    parser.add_argument("--ndt-step-size", type=float, default=0.1)
+    parser.add_argument("--transform-epsilon", type=float, default=0.01)
+    parser.add_argument("--max-iterations", type=int, default=30)
+    parser.add_argument("--num-threads", type=int, default=1)
+    parser.add_argument("--score-gate-threshold", type=float, default=6.0)
+    parser.add_argument("--refinement-delta-gate-m", type=float, default=2.0)
+    parser.add_argument("--refinement-yaw-gate-rad", type=float, default=0.7853981633974483)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--print-only", action="store_true")
+    return parser.parse_args()
+
+
+def quote_command(command: List[str]) -> str:
+    return " ".join(shlex.quote(part) for part in command)
+
+
+def run(command: List[str], print_only: bool) -> None:
+    print(quote_command(command), flush=True)
+    if print_only:
+        return
+    subprocess.run(command, check=True)
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    scan_dir = output_dir / "registration_scans"
+    labels = ["candidate_index", "oracle_rank"]
+    summary_args: List[str] = []
+
+    script_dir = Path(__file__).resolve().parent
+    for label in labels:
+        jobs_csv = output_dir / f"relocalization_registration_jobs_{label}_top{args.top_k}.csv"
+        scan_scores_csv = (
+            output_dir / f"relocalization_registration_scores_{label}_top{args.top_k}.csv"
+        )
+        ndt_scores_csv = (
+            output_dir / f"relocalization_registration_scores_ndt_{label}_top{args.top_k}.csv"
+        )
+        summary_json = (
+            output_dir / f"relocalization_registration_score_summary_{label}_top{args.top_k}.json"
+        )
+        summary_md = (
+            output_dir / f"relocalization_registration_score_summary_{label}_top{args.top_k}.md"
+        )
+
+        job_cmd = [
+            str(script_dir / "make_registration_relocalization_jobs.py"),
+            "--attempts-csv",
+            str(Path(args.attempts_csv).expanduser().resolve()),
+            "--candidates-csv",
+            str(Path(args.candidates_csv).expanduser().resolve()),
+            "--bag-path",
+            str(Path(args.bag_path).expanduser().resolve()),
+            "--map-path",
+            str(Path(args.map_path).expanduser().resolve()),
+            "--cloud-topic",
+            args.cloud_topic,
+            "--output-csv",
+            str(jobs_csv),
+            "--registration-method",
+            args.registration_method,
+            "--max-candidates-per-attempt",
+            str(args.top_k),
+            "--selection-source",
+            label,
+            "--voxel-leaf-size",
+            str(args.voxel_leaf_size),
+            "--local-map-radius",
+            str(args.local_map_radius),
+            "--timeout-sec",
+            "1.0",
+        ]
+        if args.overwrite:
+            job_cmd.append("--overwrite")
+        run(job_cmd, args.print_only)
+
+        resolve_cmd = [
+            str(script_dir / "resolve_registration_relocalization_scans.py"),
+            "--jobs-csv",
+            str(jobs_csv),
+            "--output-csv",
+            str(scan_scores_csv),
+            "--max-scan-time-diff",
+            str(args.max_scan_time_diff),
+            "--min-range",
+            str(args.scan_min_range),
+            "--max-range",
+            str(args.scan_max_range),
+            "--export-scan-pcd-dir",
+            str(scan_dir),
+        ]
+        if args.overwrite:
+            resolve_cmd.append("--overwrite")
+        run(resolve_cmd, args.print_only)
+
+        ndt_cmd = [
+            "ros2",
+            "run",
+            "lidar_localization_ros2",
+            "relocalization_ndt_score_jobs",
+            "--input-csv",
+            str(scan_scores_csv),
+            "--output-csv",
+            str(ndt_scores_csv),
+            "--max-jobs",
+            str(args.top_k),
+            "--ndt-resolution",
+            str(args.ndt_resolution),
+            "--ndt-step-size",
+            str(args.ndt_step_size),
+            "--transform-epsilon",
+            str(args.transform_epsilon),
+            "--max-iterations",
+            str(args.max_iterations),
+            "--num-threads",
+            str(args.num_threads),
+            "--scan-voxel-leaf-size",
+            str(args.voxel_leaf_size),
+            "--target-voxel-leaf-size",
+            str(args.voxel_leaf_size),
+            "--local-map-radius",
+            str(args.local_map_radius),
+            "--score-gate-threshold",
+            str(args.score_gate_threshold),
+            "--refinement-delta-gate-m",
+            str(args.refinement_delta_gate_m),
+            "--refinement-yaw-gate-rad",
+            str(args.refinement_yaw_gate_rad),
+        ]
+        run(ndt_cmd, args.print_only)
+
+        summary_cmd = [
+            str(script_dir / "summarize_registration_relocalization_scores.py"),
+            "--scores-csv",
+            str(ndt_scores_csv),
+            "--output-json",
+            str(summary_json),
+            "--output-md",
+            str(summary_md),
+        ]
+        run(summary_cmd, args.print_only)
+        summary_args.extend(["--summary", f"{label}_top{args.top_k}:{summary_json}"])
+
+    comparison_json = (
+        output_dir / f"relocalization_registration_score_comparison_top{args.top_k}.json"
+    )
+    comparison_md = (
+        output_dir / f"relocalization_registration_score_comparison_top{args.top_k}.md"
+    )
+    comparison_cmd = [
+        str(script_dir / "compare_registration_relocalization_score_summaries.py"),
+        *summary_args,
+        "--output-json",
+        str(comparison_json),
+        "--output-md",
+        str(comparison_md),
+    ]
+    run(comparison_cmd, args.print_only)
+    if not args.print_only:
+        comparison = json.loads(comparison_json.read_text(encoding="utf-8"))
+        print(
+            json.dumps(
+                {
+                    "output_json": str(comparison_json),
+                    "output_md": str(comparison_md),
+                    "best_by_gate_passed": comparison["best_by_gate_passed"],
+                }
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/score_relocalization_candidates_with_reference.py
+++ b/scripts/score_relocalization_candidates_with_reference.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import math
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+
+SCORED_CANDIDATE_EXTRA_FIELDS = [
+    "target_reference_stamp_sec",
+    "target_reference_time_delta_sec",
+    "target_reference_x",
+    "target_reference_y",
+    "target_reference_z",
+    "target_reference_yaw_rad",
+    "oracle_translation_error_m",
+    "oracle_xy_error_m",
+    "oracle_z_error_m",
+    "oracle_yaw_error_rad",
+    "oracle_yaw_error_deg",
+    "oracle_score",
+    "oracle_recoverable",
+    "oracle_rank",
+    "oracle_is_best",
+]
+
+
+ATTEMPT_EXTRA_FIELDS = [
+    "oracle_scored_candidate_count",
+    "oracle_best_candidate_index",
+    "oracle_best_translation_error_m",
+    "oracle_best_xy_error_m",
+    "oracle_best_yaw_error_deg",
+    "oracle_recoverable",
+    "oracle_translation_threshold_m",
+    "oracle_yaw_threshold_deg",
+    "oracle_yaw_weight_m_per_rad",
+    "scored_candidates_csv",
+    "scored_at",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Score relocalization candidates against a reference trajectory as an "
+            "offline oracle. This does not call registration and does not accept or "
+            "reset poses; it measures whether the candidate set contains a plausible "
+            "ground-truth-near pose."
+        )
+    )
+    parser.add_argument("--attempts-csv", required=True, help="Input relocalization_attempts.csv")
+    parser.add_argument(
+        "--candidates-csv",
+        required=True,
+        help="Input relocalization_candidates.csv from a candidate generator.",
+    )
+    parser.add_argument("--reference-csv", required=True, help="Reference trajectory CSV")
+    parser.add_argument(
+        "--output-attempts-csv",
+        required=True,
+        help="Output attempts CSV with oracle score fields filled.",
+    )
+    parser.add_argument(
+        "--output-scored-candidates-csv",
+        default="",
+        help="Output per-candidate score CSV. Defaults to relocalization_candidate_scores.csv.",
+    )
+    parser.add_argument(
+        "--translation-threshold-m",
+        type=float,
+        default=2.0,
+        help="Translation error threshold used only for oracle_recoverable.",
+    )
+    parser.add_argument(
+        "--yaw-threshold-deg",
+        type=float,
+        default=15.0,
+        help="Yaw error threshold used only for oracle_recoverable.",
+    )
+    parser.add_argument(
+        "--yaw-weight-m-per-rad",
+        type=float,
+        default=1.0,
+        help="Score = translation_error_m + yaw_weight_m_per_rad * yaw_error_rad.",
+    )
+    parser.add_argument(
+        "--rejection-reason",
+        default="offline_oracle_scored_no_reset",
+        help="Rejection reason written for scored attempts. Attempts remain accepted=false.",
+    )
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite output CSV files.")
+    return parser.parse_args()
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        number = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _yaw_from_quaternion(x: float, y: float, z: float, w: float) -> float:
+    siny_cosp = 2.0 * (w * z + x * y)
+    cosy_cosp = 1.0 - 2.0 * (y * y + z * z)
+    return math.atan2(siny_cosp, cosy_cosp)
+
+
+def _angle_error(a: float, b: float) -> float:
+    return abs(math.atan2(math.sin(a - b), math.cos(a - b)))
+
+
+def _read_csv_rows(path: Path) -> Tuple[List[str], List[Dict[str, Any]]]:
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        reader = csv.DictReader(stream)
+        return list(reader.fieldnames or []), list(reader)
+
+
+def load_reference_rows(path: Path) -> List[Dict[str, float]]:
+    rows: List[Dict[str, float]] = []
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        for record in csv.DictReader(stream):
+            qx = float(record["orientation_x"])
+            qy = float(record["orientation_y"])
+            qz = float(record["orientation_z"])
+            qw = float(record["orientation_w"])
+            rows.append(
+                {
+                    "stamp_sec": float(record["stamp_sec"]),
+                    "x": float(record["position_x"]),
+                    "y": float(record["position_y"]),
+                    "z": float(record["position_z"]),
+                    "yaw": _yaw_from_quaternion(qx, qy, qz, qw),
+                }
+            )
+    if not rows:
+        raise RuntimeError(f"reference CSV has no rows: {path}")
+    rows.sort(key=lambda row: row["stamp_sec"])
+    return rows
+
+
+def nearest_reference(
+    reference_rows: List[Dict[str, float]],
+    stamp_sec: float,
+) -> Dict[str, float]:
+    return min(reference_rows, key=lambda row: abs(row["stamp_sec"] - stamp_sec))
+
+
+def score_candidate(
+    candidate: Dict[str, Any],
+    target: Dict[str, float],
+    trigger_stamp_sec: float,
+    translation_threshold_m: float,
+    yaw_threshold_rad: float,
+    yaw_weight_m_per_rad: float,
+) -> Dict[str, Any]:
+    pose_x = float(candidate["pose_x"])
+    pose_y = float(candidate["pose_y"])
+    pose_z = float(candidate["pose_z"])
+    yaw = float(candidate["yaw_rad"])
+    xy_error = math.hypot(pose_x - target["x"], pose_y - target["y"])
+    z_error = abs(pose_z - target["z"])
+    translation_error = math.sqrt(xy_error * xy_error + z_error * z_error)
+    yaw_error = _angle_error(yaw, target["yaw"])
+    score = translation_error + yaw_weight_m_per_rad * yaw_error
+    recoverable = (
+        translation_error <= translation_threshold_m and yaw_error <= yaw_threshold_rad
+    )
+    scored = dict(candidate)
+    scored.update(
+        {
+            "target_reference_stamp_sec": f"{target['stamp_sec']:.9f}",
+            "target_reference_time_delta_sec": f"{target['stamp_sec'] - trigger_stamp_sec:.9f}",
+            "target_reference_x": f"{target['x']:.9f}",
+            "target_reference_y": f"{target['y']:.9f}",
+            "target_reference_z": f"{target['z']:.9f}",
+            "target_reference_yaw_rad": f"{target['yaw']:.9f}",
+            "oracle_translation_error_m": f"{translation_error:.9f}",
+            "oracle_xy_error_m": f"{xy_error:.9f}",
+            "oracle_z_error_m": f"{z_error:.9f}",
+            "oracle_yaw_error_rad": f"{yaw_error:.9f}",
+            "oracle_yaw_error_deg": f"{math.degrees(yaw_error):.9f}",
+            "oracle_score": f"{score:.9f}",
+            "oracle_recoverable": "true" if recoverable else "false",
+            "oracle_rank": "",
+            "oracle_is_best": "false",
+        }
+    )
+    return scored
+
+
+def build_scored_artifacts(
+    attempts: List[Dict[str, Any]],
+    candidates: List[Dict[str, Any]],
+    reference_rows: List[Dict[str, float]],
+    scored_candidates_csv: Path,
+    translation_threshold_m: float,
+    yaw_threshold_deg: float,
+    yaw_weight_m_per_rad: float,
+    rejection_reason: str,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    yaw_threshold_rad = math.radians(yaw_threshold_deg)
+    scored_at = datetime.now().astimezone().isoformat(timespec="seconds")
+    candidates_by_attempt: Dict[str, List[Dict[str, Any]]] = {}
+    for candidate in candidates:
+        candidates_by_attempt.setdefault(str(candidate["attempt_id"]), []).append(candidate)
+
+    scored_attempts: List[Dict[str, Any]] = []
+    scored_candidates: List[Dict[str, Any]] = []
+    for attempt in attempts:
+        started = time.monotonic()
+        updated = dict(attempt)
+        attempt_id = str(updated.get("attempt_id", ""))
+        trigger_stamp = _as_float(updated.get("trigger_stamp_sec"))
+        attempt_candidates = candidates_by_attempt.get(attempt_id, [])
+        if trigger_stamp is None or not attempt_candidates:
+            updated.update(
+                {
+                    "accepted": "false",
+                    "rejection_reason": "no_oracle_candidates",
+                    "oracle_scored_candidate_count": str(len(attempt_candidates)),
+                    "oracle_recoverable": "false",
+                    "scored_candidates_csv": str(scored_candidates_csv),
+                    "scored_at": scored_at,
+                }
+            )
+            scored_attempts.append(updated)
+            continue
+
+        target = nearest_reference(reference_rows, trigger_stamp)
+        scored_for_attempt = [
+            score_candidate(
+                candidate,
+                target=target,
+                trigger_stamp_sec=trigger_stamp,
+                translation_threshold_m=translation_threshold_m,
+                yaw_threshold_rad=yaw_threshold_rad,
+                yaw_weight_m_per_rad=yaw_weight_m_per_rad,
+            )
+            for candidate in attempt_candidates
+        ]
+        scored_for_attempt.sort(key=lambda row: float(row["oracle_score"]))
+        for rank, candidate in enumerate(scored_for_attempt, start=1):
+            candidate["oracle_rank"] = str(rank)
+            candidate["oracle_is_best"] = "true" if rank == 1 else "false"
+        scored_candidates.extend(scored_for_attempt)
+
+        best = scored_for_attempt[0]
+        second_score = (
+            float(scored_for_attempt[1]["oracle_score"])
+            if len(scored_for_attempt) > 1
+            else None
+        )
+        best_score = float(best["oracle_score"])
+        margin = "" if second_score is None else f"{second_score - best_score:.9f}"
+        recoverable = best["oracle_recoverable"] == "true"
+        runtime = _as_float(updated.get("runtime_sec")) or 0.0
+        updated.update(
+            {
+                "candidate_count": str(len(scored_for_attempt)),
+                "accepted": "false",
+                "accepted_candidate_rank": "",
+                "rejection_reason": rejection_reason,
+                "best_score": f"{best_score:.9f}",
+                "second_score": "" if second_score is None else f"{second_score:.9f}",
+                "candidate_margin": margin,
+                "converged": "false",
+                "post_reset_ok_rows": "0",
+                "false_recovery": "false",
+                "runtime_sec": f"{runtime + (time.monotonic() - started):.6f}",
+                "oracle_scored_candidate_count": str(len(scored_for_attempt)),
+                "oracle_best_candidate_index": str(best.get("candidate_index", "")),
+                "oracle_best_translation_error_m": best["oracle_translation_error_m"],
+                "oracle_best_xy_error_m": best["oracle_xy_error_m"],
+                "oracle_best_yaw_error_deg": best["oracle_yaw_error_deg"],
+                "oracle_recoverable": "true" if recoverable else "false",
+                "oracle_translation_threshold_m": f"{translation_threshold_m:.9f}",
+                "oracle_yaw_threshold_deg": f"{yaw_threshold_deg:.9f}",
+                "oracle_yaw_weight_m_per_rad": f"{yaw_weight_m_per_rad:.9f}",
+                "scored_candidates_csv": str(scored_candidates_csv),
+                "scored_at": scored_at,
+            }
+        )
+        scored_attempts.append(updated)
+    return scored_attempts, scored_candidates
+
+
+def _fieldnames(base: List[str], extra: List[str]) -> List[str]:
+    fields = list(base)
+    for field in extra:
+        if field not in fields:
+            fields.append(field)
+    return fields
+
+
+def write_csv(
+    path: Path,
+    rows: List[Dict[str, Any]],
+    fieldnames: List[str],
+    overwrite: bool,
+) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output CSV already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    args = parse_args()
+    attempts_csv = Path(args.attempts_csv).expanduser().resolve()
+    candidates_csv = Path(args.candidates_csv).expanduser().resolve()
+    reference_csv = Path(args.reference_csv).expanduser().resolve()
+    output_attempts_csv = Path(args.output_attempts_csv).expanduser().resolve()
+    output_scored_candidates_csv = (
+        Path(args.output_scored_candidates_csv).expanduser().resolve()
+        if args.output_scored_candidates_csv
+        else output_attempts_csv.with_name("relocalization_candidate_scores.csv")
+    )
+    for path, label in [
+        (attempts_csv, "attempts CSV"),
+        (candidates_csv, "candidates CSV"),
+        (reference_csv, "reference CSV"),
+    ]:
+        if not path.exists():
+            raise FileNotFoundError(f"{label} does not exist: {path}")
+
+    attempt_fields, attempts = _read_csv_rows(attempts_csv)
+    candidate_fields, candidates = _read_csv_rows(candidates_csv)
+    scored_attempts, scored_candidates = build_scored_artifacts(
+        attempts=attempts,
+        candidates=candidates,
+        reference_rows=load_reference_rows(reference_csv),
+        scored_candidates_csv=output_scored_candidates_csv,
+        translation_threshold_m=args.translation_threshold_m,
+        yaw_threshold_deg=args.yaw_threshold_deg,
+        yaw_weight_m_per_rad=args.yaw_weight_m_per_rad,
+        rejection_reason=args.rejection_reason,
+    )
+    write_csv(
+        output_attempts_csv,
+        scored_attempts,
+        _fieldnames(attempt_fields, ATTEMPT_EXTRA_FIELDS),
+        overwrite=args.overwrite or output_attempts_csv == attempts_csv,
+    )
+    write_csv(
+        output_scored_candidates_csv,
+        scored_candidates,
+        _fieldnames(candidate_fields, SCORED_CANDIDATE_EXTRA_FIELDS),
+        overwrite=args.overwrite,
+    )
+    recoverable_count = sum(
+        1 for attempt in scored_attempts if attempt.get("oracle_recoverable") == "true"
+    )
+    print(
+        json.dumps(
+            {
+                "output_attempts_csv": str(output_attempts_csv),
+                "output_scored_candidates_csv": str(output_scored_candidates_csv),
+                "attempt_count": len(scored_attempts),
+                "candidate_count": len(scored_candidates),
+                "oracle_recoverable_attempt_count": recoverable_count,
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/select_relocalization_reset_candidates.py
+++ b/scripts/select_relocalization_reset_candidates.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import math
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+
+PLAN_FIELDNAMES = [
+    "attempt_id",
+    "trigger_stamp_sec",
+    "selected",
+    "accepted",
+    "rejection_reason",
+    "policy_name",
+    "selected_job_id",
+    "selected_candidate_index",
+    "selected_selection_source",
+    "selected_selection_rank",
+    "selected_score",
+    "second_score",
+    "registration_score_margin",
+    "selected_converged",
+    "selected_registration_gate_passed",
+    "selected_registration_gate_reason",
+    "selected_refinement_delta_m",
+    "selected_refinement_delta_yaw_rad",
+    "selected_initial_pose_x",
+    "selected_initial_pose_y",
+    "selected_initial_pose_z",
+    "selected_initial_yaw_rad",
+    "selected_final_pose_x",
+    "selected_final_pose_y",
+    "selected_final_pose_z",
+    "selected_final_yaw_rad",
+    "eligible_candidate_count",
+    "scored_candidate_count",
+    "generated_at",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Select one registration-scored relocalization candidate per attempt for the future "
+            "guarded reset path. This writes an artifact only; it never accepts or resets pose."
+        )
+    )
+    parser.add_argument("--scores-csv", required=True)
+    parser.add_argument("--output-csv", required=True)
+    parser.add_argument("--output-json", default="")
+    parser.add_argument("--output-md", default="")
+    parser.add_argument("--policy-name", default="lowest_registration_score_with_gate")
+    parser.add_argument("--max-score", type=float, default=6.0)
+    parser.add_argument("--max-refinement-delta-m", type=float, default=2.0)
+    parser.add_argument("--max-refinement-yaw-rad", type=float, default=0.7853981633974483)
+    parser.add_argument(
+        "--min-score-margin",
+        type=float,
+        default=0.0,
+        help="Require second_score - selected_score to be at least this value. 0 disables it.",
+    )
+    parser.add_argument(
+        "--require-registration-gate",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Require registration_gate_passed=true when the column is present.",
+    )
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def _read_csv(path: Path) -> Tuple[List[str], List[Dict[str, Any]]]:
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        reader = csv.DictReader(stream)
+        return list(reader.fieldnames or []), list(reader)
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        number = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _as_int(value: Any) -> Optional[int]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        return int(float(str(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_bool(value: Any) -> Optional[bool]:
+    if value is None or str(value).strip() == "":
+        return None
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "y"}:
+        return True
+    if normalized in {"0", "false", "no", "n"}:
+        return False
+    return None
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float):
+        return f"{value:.9f}"
+    return str(value)
+
+
+def _row_sort_key(row: Dict[str, Any]) -> Tuple[float, int, int]:
+    score = _as_float(row.get("score"))
+    if score is None:
+        score = float("inf")
+    selection_rank = _as_int(row.get("selection_rank"))
+    if selection_rank is None:
+        selection_rank = 10**9
+    candidate_index = _as_int(row.get("candidate_index"))
+    if candidate_index is None:
+        candidate_index = 10**9
+    return (score, selection_rank, candidate_index)
+
+
+def _is_scored(row: Dict[str, Any]) -> bool:
+    return _as_float(row.get("score")) is not None
+
+
+def _is_eligible(
+    row: Dict[str, Any],
+    max_score: float,
+    max_refinement_delta_m: float,
+    max_refinement_yaw_rad: float,
+    require_registration_gate: bool,
+) -> bool:
+    if _as_bool(row.get("converged")) is not True:
+        return False
+    if require_registration_gate and _as_bool(row.get("registration_gate_passed")) is not True:
+        return False
+    score = _as_float(row.get("score"))
+    if score is None or score > max_score:
+        return False
+    refinement_delta = _as_float(row.get("refinement_delta_m"))
+    if refinement_delta is None or refinement_delta > max_refinement_delta_m:
+        return False
+    refinement_yaw = _as_float(row.get("refinement_delta_yaw_rad"))
+    if refinement_yaw is None or refinement_yaw > max_refinement_yaw_rad:
+        return False
+    return True
+
+
+def _blank_plan(
+    attempt_id: str,
+    trigger_stamp_sec: str,
+    rejection_reason: str,
+    policy_name: str,
+    scored_count: int,
+    eligible_count: int,
+    generated_at: str,
+) -> Dict[str, str]:
+    row = {field: "" for field in PLAN_FIELDNAMES}
+    row.update(
+        {
+            "attempt_id": attempt_id,
+            "trigger_stamp_sec": trigger_stamp_sec,
+            "selected": "false",
+            "accepted": "false",
+            "rejection_reason": rejection_reason,
+            "policy_name": policy_name,
+            "eligible_candidate_count": str(eligible_count),
+            "scored_candidate_count": str(scored_count),
+            "generated_at": generated_at,
+        }
+    )
+    return row
+
+
+def build_plan(
+    rows: List[Dict[str, Any]],
+    policy_name: str,
+    max_score: float,
+    max_refinement_delta_m: float,
+    max_refinement_yaw_rad: float,
+    min_score_margin: float,
+    require_registration_gate: bool,
+) -> List[Dict[str, str]]:
+    generated_at = datetime.now().astimezone().isoformat(timespec="seconds")
+    by_attempt: Dict[str, List[Dict[str, Any]]] = {}
+    for row in rows:
+        by_attempt.setdefault(str(row.get("attempt_id", "")), []).append(row)
+
+    plan_rows: List[Dict[str, str]] = []
+    for attempt_id, attempt_rows in sorted(by_attempt.items()):
+        trigger_stamp_sec = str(attempt_rows[0].get("trigger_stamp_sec", ""))
+        scored_rows = [row for row in attempt_rows if _is_scored(row)]
+        eligible_rows = [
+            row
+            for row in scored_rows
+            if _is_eligible(
+                row,
+                max_score=max_score,
+                max_refinement_delta_m=max_refinement_delta_m,
+                max_refinement_yaw_rad=max_refinement_yaw_rad,
+                require_registration_gate=require_registration_gate,
+            )
+        ]
+        eligible_rows.sort(key=_row_sort_key)
+        scored_rows.sort(key=_row_sort_key)
+
+        if not scored_rows:
+            plan_rows.append(
+                _blank_plan(
+                    attempt_id,
+                    trigger_stamp_sec,
+                    "no_scored_candidates",
+                    policy_name,
+                    scored_count=0,
+                    eligible_count=0,
+                    generated_at=generated_at,
+                )
+            )
+            continue
+        if not eligible_rows:
+            plan_rows.append(
+                _blank_plan(
+                    attempt_id,
+                    trigger_stamp_sec,
+                    "no_candidate_passed_registration_policy",
+                    policy_name,
+                    scored_count=len(scored_rows),
+                    eligible_count=0,
+                    generated_at=generated_at,
+                )
+            )
+            continue
+
+        selected = eligible_rows[0]
+        selected_score = _as_float(selected.get("score"))
+        second_score = None
+        for row in scored_rows:
+            if row is selected:
+                continue
+            candidate_score = _as_float(row.get("score"))
+            if candidate_score is not None:
+                second_score = candidate_score
+                break
+        margin = None
+        if selected_score is not None and second_score is not None:
+            margin = second_score - selected_score
+        if min_score_margin > 0.0 and (margin is None or margin < min_score_margin):
+            plan_rows.append(
+                _blank_plan(
+                    attempt_id,
+                    trigger_stamp_sec,
+                    "registration_score_margin_too_small",
+                    policy_name,
+                    scored_count=len(scored_rows),
+                    eligible_count=len(eligible_rows),
+                    generated_at=generated_at,
+                )
+            )
+            continue
+
+        plan_rows.append(
+            {
+                "attempt_id": attempt_id,
+                "trigger_stamp_sec": trigger_stamp_sec,
+                "selected": "true",
+                "accepted": "false",
+                "rejection_reason": "reset_execution_not_implemented",
+                "policy_name": policy_name,
+                "selected_job_id": str(selected.get("job_id", "")),
+                "selected_candidate_index": str(selected.get("candidate_index", "")),
+                "selected_selection_source": str(selected.get("selection_source", "")),
+                "selected_selection_rank": str(selected.get("selection_rank", "")),
+                "selected_score": _fmt(selected_score),
+                "second_score": _fmt(second_score),
+                "registration_score_margin": _fmt(margin),
+                "selected_converged": str(selected.get("converged", "")),
+                "selected_registration_gate_passed": str(
+                    selected.get("registration_gate_passed", "")
+                ),
+                "selected_registration_gate_reason": str(
+                    selected.get("registration_gate_reason", "")
+                ),
+                "selected_refinement_delta_m": str(selected.get("refinement_delta_m", "")),
+                "selected_refinement_delta_yaw_rad": str(
+                    selected.get("refinement_delta_yaw_rad", "")
+                ),
+                "selected_initial_pose_x": str(selected.get("initial_pose_x", "")),
+                "selected_initial_pose_y": str(selected.get("initial_pose_y", "")),
+                "selected_initial_pose_z": str(selected.get("initial_pose_z", "")),
+                "selected_initial_yaw_rad": str(selected.get("initial_yaw_rad", "")),
+                "selected_final_pose_x": str(selected.get("final_pose_x", "")),
+                "selected_final_pose_y": str(selected.get("final_pose_y", "")),
+                "selected_final_pose_z": str(selected.get("final_pose_z", "")),
+                "selected_final_yaw_rad": str(selected.get("final_yaw_rad", "")),
+                "eligible_candidate_count": str(len(eligible_rows)),
+                "scored_candidate_count": str(len(scored_rows)),
+                "generated_at": generated_at,
+            }
+        )
+    return plan_rows
+
+
+def write_csv(path: Path, rows: List[Dict[str, str]], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output CSV already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=PLAN_FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def build_summary(plan_rows: List[Dict[str, str]], scores_csv: Path, output_csv: Path) -> Dict[str, Any]:
+    selected_rows = [row for row in plan_rows if _as_bool(row.get("selected")) is True]
+    selected_scores = [
+        score
+        for score in (_as_float(row.get("selected_score")) for row in selected_rows)
+        if score is not None
+    ]
+    return {
+        "scores_csv": str(scores_csv),
+        "output_csv": str(output_csv),
+        "attempt_count": len(plan_rows),
+        "selected_count": len(selected_rows),
+        "accepted_count": 0,
+        "selected_rate_percent": (100.0 * len(selected_rows) / len(plan_rows))
+        if plan_rows
+        else 0.0,
+        "rejection_reason_counts": _counts(row.get("rejection_reason", "") for row in plan_rows),
+        "selected_score_min": min(selected_scores) if selected_scores else None,
+        "selected_score_median": _median(selected_scores),
+        "selected_score_max": max(selected_scores) if selected_scores else None,
+        "notes": [
+            "selected=true means a candidate passed the artifact policy",
+            "accepted is always false; this helper never resets pose",
+            "oracle_rank is not required or used by the default policy",
+        ],
+    }
+
+
+def _counts(values: Any) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for value in values:
+        key = str(value)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _median(values: List[float]) -> Optional[float]:
+    if not values:
+        return None
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return 0.5 * (ordered[mid - 1] + ordered[mid])
+
+
+def write_summary_json(path: Path, summary: Dict[str, Any], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output JSON already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_summary_md(path: Path, summary: Dict[str, Any], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output Markdown already exists: {path}")
+    lines = [
+        "# Relocalization Reset Candidate Plan",
+        "",
+        f"- scores CSV: `{summary['scores_csv']}`",
+        f"- output CSV: `{summary['output_csv']}`",
+        f"- attempts: `{summary['attempt_count']}`",
+        f"- selected: `{summary['selected_count']}`",
+        f"- accepted: `{summary['accepted_count']}`",
+        f"- selected rate: `{summary['selected_rate_percent']:.3f}%`",
+        f"- selected score median: `{summary['selected_score_median']}`",
+        "",
+        "## Rejection Reasons",
+        "",
+    ]
+    for reason, count in sorted(summary["rejection_reason_counts"].items()):
+        lines.append(f"- `{reason}`: `{count}`")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            "- `selected=true` means a candidate passed the artifact policy.",
+            "- `accepted=false` is intentional; this helper never resets pose.",
+            "- The default policy does not use `oracle_rank`.",
+            "",
+        ]
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    scores_csv = Path(args.scores_csv).expanduser().resolve()
+    output_csv = Path(args.output_csv).expanduser().resolve()
+    if not scores_csv.exists():
+        raise FileNotFoundError(f"scores CSV does not exist: {scores_csv}")
+
+    _, rows = _read_csv(scores_csv)
+    plan_rows = build_plan(
+        rows=rows,
+        policy_name=args.policy_name,
+        max_score=args.max_score,
+        max_refinement_delta_m=args.max_refinement_delta_m,
+        max_refinement_yaw_rad=args.max_refinement_yaw_rad,
+        min_score_margin=args.min_score_margin,
+        require_registration_gate=args.require_registration_gate,
+    )
+    write_csv(output_csv, plan_rows, overwrite=args.overwrite)
+
+    summary = build_summary(plan_rows, scores_csv=scores_csv, output_csv=output_csv)
+    if args.output_json:
+        write_summary_json(
+            Path(args.output_json).expanduser().resolve(), summary, overwrite=args.overwrite
+        )
+    if args.output_md:
+        write_summary_md(
+            Path(args.output_md).expanduser().resolve(), summary, overwrite=args.overwrite
+        )
+    print(json.dumps(summary, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/summarize_localization_health.py
+++ b/scripts/summarize_localization_health.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import math
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+
+
+FAILURE_MESSAGES = {
+    "local_map_crop_too_small",
+    "registration_not_converged",
+    "filtered_scan_empty",
+    "scan_missing_xyz_field",
+}
+
+FAILURE_STATES = {
+    "degraded",
+    "recovering",
+    "reinitialization_requested",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Summarize localization health and reinitialization windows from "
+            "benchmark_diagnostic_recorder alignment_status.csv artifacts."
+        )
+    )
+    parser.add_argument(
+        "--alignment-csv",
+        required=True,
+        help="Path to alignment_status.csv produced by benchmark_diagnostic_recorder.",
+    )
+    parser.add_argument(
+        "--trajectory-eval-json",
+        default="",
+        help="Optional trajectory_eval.json to include overall RMSE context.",
+    )
+    parser.add_argument("--output-json", default="", help="Optional output JSON path.")
+    parser.add_argument("--output-md", default="", help="Optional output Markdown path.")
+    parser.add_argument(
+        "--stable-ok-rows",
+        type=int,
+        default=5,
+        help="Minimum consecutive ok rows after a request window to count as recovered.",
+    )
+    parser.add_argument(
+        "--recovery-window-sec",
+        type=float,
+        default=10.0,
+        help="Maximum time after a request window start to search for stable recovery.",
+    )
+    parser.add_argument(
+        "--false-recovery-rmse-threshold-m",
+        type=float,
+        default=5.0,
+        help=(
+            "Overall translation RMSE threshold used only to flag recovered runs as "
+            "reference-risky when trajectory_eval_json is available."
+        ),
+    )
+    return parser.parse_args()
+
+
+def _as_bool(value: Any) -> bool:
+    return str(value).strip().lower() == "true"
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        number = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _as_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(float(str(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _percent(numerator: int, denominator: int) -> Optional[float]:
+    if denominator <= 0:
+        return None
+    return 100.0 * float(numerator) / float(denominator)
+
+
+def load_alignment_rows(path: Path) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        for record in csv.DictReader(stream):
+            values = json.loads(record["values_json"])
+            message = str(record.get("message", ""))
+            requested = _as_bool(values.get("reinitialization_requested"))
+            recovery_state = str(values.get("recovery_state", ""))
+            failure_like = (
+                message in FAILURE_MESSAGES
+                or message.startswith("fitness_score_over_")
+                or requested
+                or recovery_state in FAILURE_STATES
+            )
+            rows.append(
+                {
+                    "stamp_sec": float(record["stamp_sec"]),
+                    "level": _as_int(record.get("level")),
+                    "message": message,
+                    "registration_method": values.get("registration_method"),
+                    "has_converged": _as_bool(values.get("has_converged")),
+                    "fitness_score": _as_float(values.get("fitness_score")),
+                    "alignment_time_sec": _as_float(values.get("alignment_time_sec")),
+                    "accepted_gap_sec": _as_float(values.get("accepted_gap_sec")),
+                    "consecutive_rejected_updates": _as_int(
+                        values.get("consecutive_rejected_updates")
+                    ),
+                    "recovery_state": recovery_state,
+                    "recovery_action": values.get("recovery_action"),
+                    "reinitialization_requested": requested,
+                    "reinitialization_request_reason": values.get(
+                        "reinitialization_request_reason"
+                    ),
+                    "reinitialization_request_score": _as_float(
+                        values.get("reinitialization_request_score")
+                    ),
+                    "failure_like": failure_like,
+                }
+            )
+    return rows
+
+
+def _segment_rows(rows: List[Dict[str, Any]], key: str) -> List[Dict[str, Any]]:
+    segments: List[Dict[str, Any]] = []
+    index = 0
+    while index < len(rows):
+        if not rows[index][key]:
+            index += 1
+            continue
+        start = index
+        while index < len(rows) and rows[index][key]:
+            index += 1
+        end = index - 1
+        segments.append(
+            {
+                "start_index": start,
+                "end_index": end,
+                "start_stamp_sec": rows[start]["stamp_sec"],
+                "end_stamp_sec": rows[end]["stamp_sec"],
+                "duration_sec": max(0.0, rows[end]["stamp_sec"] - rows[start]["stamp_sec"]),
+                "row_count": end - start + 1,
+                "first_message": rows[start]["message"],
+                "last_message": rows[end]["message"],
+            }
+        )
+    return segments
+
+
+def _max_optional(values: Iterable[Optional[float]]) -> Optional[float]:
+    finite_values = [value for value in values if value is not None]
+    return max(finite_values) if finite_values else None
+
+
+def _stable_ok_rows_after(
+    rows: List[Dict[str, Any]],
+    start_index: int,
+    deadline_sec: float,
+) -> Dict[str, Any]:
+    first_ok_index: Optional[int] = None
+    for index in range(start_index, len(rows)):
+        if rows[index]["stamp_sec"] > deadline_sec:
+            break
+        if rows[index]["message"] == "ok":
+            first_ok_index = index
+            break
+
+    if first_ok_index is None:
+        return {
+            "first_ok_index": None,
+            "first_ok_delay_sec": None,
+            "stable_ok_rows": 0,
+        }
+
+    stable_ok_rows = 0
+    for index in range(first_ok_index, len(rows)):
+        if rows[index]["message"] != "ok":
+            break
+        stable_ok_rows += 1
+
+    return {
+        "first_ok_index": first_ok_index,
+        "first_ok_delay_sec": rows[first_ok_index]["stamp_sec"] - rows[start_index]["stamp_sec"],
+        "stable_ok_rows": stable_ok_rows,
+    }
+
+
+def summarize_request_windows(
+    rows: List[Dict[str, Any]],
+    stable_ok_rows_required: int,
+    recovery_window_sec: float,
+) -> List[Dict[str, Any]]:
+    request_segments = _segment_rows(rows, "reinitialization_requested")
+    windows: List[Dict[str, Any]] = []
+    for segment in request_segments:
+        start_index = int(segment["start_index"])
+        end_index = int(segment["end_index"])
+        deadline_sec = rows[start_index]["stamp_sec"] + recovery_window_sec
+        stable = _stable_ok_rows_after(rows, end_index + 1, deadline_sec)
+        reason_counts = Counter(
+            str(rows[index]["reinitialization_request_reason"])
+            for index in range(start_index, end_index + 1)
+            if rows[index]["reinitialization_request_reason"] is not None
+        )
+        recovered = stable["stable_ok_rows"] >= stable_ok_rows_required
+        windows.append(
+            {
+                "start_delta_sec": rows[start_index]["stamp_sec"] - rows[0]["stamp_sec"],
+                "duration_sec": segment["duration_sec"],
+                "row_count": segment["row_count"],
+                "reason_counts": dict(reason_counts),
+                "first_ok_after_request_sec": stable["first_ok_delay_sec"],
+                "stable_ok_rows_after_request": stable["stable_ok_rows"],
+                "recovered": recovered,
+            }
+        )
+    return windows
+
+
+def summarize_alignment(
+    rows: List[Dict[str, Any]],
+    stable_ok_rows_required: int,
+    recovery_window_sec: float,
+) -> Dict[str, Any]:
+    if not rows:
+        return {
+            "row_count": 0,
+            "ok_rows": 0,
+            "failure_like_rows": 0,
+            "reinitialization_requested_rows": 0,
+            "reinitialization_request_transition_count": 0,
+            "reinitialization_windows": [],
+            "lost_windows": [],
+            "message_counts": {},
+            "recovery_state_counts": {},
+            "recovery_action_counts": {},
+            "max_accepted_gap_sec": None,
+            "max_consecutive_rejected_updates": None,
+            "max_fitness_score": None,
+            "max_alignment_time_sec": None,
+        }
+
+    request_transitions = 0
+    previous_requested = False
+    for row in rows:
+        requested = bool(row["reinitialization_requested"])
+        if requested and not previous_requested:
+            request_transitions += 1
+        previous_requested = requested
+
+    request_windows = summarize_request_windows(
+        rows,
+        stable_ok_rows_required=stable_ok_rows_required,
+        recovery_window_sec=recovery_window_sec,
+    )
+    recovered_count = sum(1 for window in request_windows if window["recovered"])
+
+    first_stamp_sec = rows[0]["stamp_sec"]
+    plausible_accepted_gaps = [
+        row["accepted_gap_sec"]
+        for row in rows
+        if row["accepted_gap_sec"] is not None
+        and row["accepted_gap_sec"] <= (row["stamp_sec"] - first_stamp_sec + 1.0)
+    ]
+
+    return {
+        "row_count": len(rows),
+        "ok_rows": sum(1 for row in rows if row["message"] == "ok"),
+        "ok_rate_percent": _percent(sum(1 for row in rows if row["message"] == "ok"), len(rows)),
+        "failure_like_rows": sum(1 for row in rows if row["failure_like"]),
+        "failure_like_rate_percent": _percent(
+            sum(1 for row in rows if row["failure_like"]),
+            len(rows),
+        ),
+        "reinitialization_requested_rows": sum(
+            1 for row in rows if row["reinitialization_requested"]
+        ),
+        "reinitialization_request_transition_count": request_transitions,
+        "reinitialization_recovered_count": recovered_count,
+        "reinitialization_unrecovered_count": len(request_windows) - recovered_count,
+        "reinitialization_windows": request_windows,
+        "lost_windows": _segment_rows(rows, "failure_like"),
+        "message_counts": dict(Counter(str(row["message"]) for row in rows)),
+        "recovery_state_counts": dict(Counter(str(row["recovery_state"]) for row in rows)),
+        "recovery_action_counts": dict(Counter(str(row["recovery_action"]) for row in rows)),
+        "request_reason_counts": dict(
+            Counter(
+                str(row["reinitialization_request_reason"])
+                for row in rows
+                if row["reinitialization_requested"]
+            )
+        ),
+        "max_accepted_gap_sec": _max_optional(plausible_accepted_gaps),
+        "max_consecutive_rejected_updates": max(
+            (
+                row["consecutive_rejected_updates"]
+                for row in rows
+                if row["consecutive_rejected_updates"] is not None
+            ),
+            default=None,
+        ),
+        "max_fitness_score": _max_optional(row["fitness_score"] for row in rows),
+        "max_alignment_time_sec": _max_optional(row["alignment_time_sec"] for row in rows),
+    }
+
+
+def load_trajectory_eval(path: Optional[Path]) -> Optional[Dict[str, Any]]:
+    if path is None:
+        return None
+    with path.open("r", encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def build_summary(
+    alignment_csv: Path,
+    trajectory_eval_json: Optional[Path],
+    stable_ok_rows_required: int,
+    recovery_window_sec: float,
+    false_recovery_rmse_threshold_m: float,
+) -> Dict[str, Any]:
+    rows = load_alignment_rows(alignment_csv)
+    alignment = summarize_alignment(
+        rows,
+        stable_ok_rows_required=stable_ok_rows_required,
+        recovery_window_sec=recovery_window_sec,
+    )
+    trajectory_eval = load_trajectory_eval(trajectory_eval_json)
+
+    reference_risk = "not_evaluated"
+    if trajectory_eval is not None and alignment["reinitialization_recovered_count"] > 0:
+        translation_rmse_m = trajectory_eval.get("translation_rmse_m")
+        if isinstance(translation_rmse_m, (int, float)):
+            reference_risk = (
+                "high_overall_rmse_after_recovery"
+                if translation_rmse_m > false_recovery_rmse_threshold_m
+                else "overall_rmse_within_threshold"
+            )
+
+    return {
+        "generated_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "alignment_csv": str(alignment_csv),
+        "trajectory_eval_json": None if trajectory_eval_json is None else str(trajectory_eval_json),
+        "stable_ok_rows_required": stable_ok_rows_required,
+        "recovery_window_sec": recovery_window_sec,
+        "false_recovery_rmse_threshold_m": false_recovery_rmse_threshold_m,
+        "alignment": alignment,
+        "trajectory_eval": trajectory_eval,
+        "reference_risk": reference_risk,
+        "notes": [
+            "false recovery cannot be proven from diagnostics alone",
+            "event-local false recovery needs per-event reference evaluation in a future relocalization benchmark",
+        ],
+    }
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def build_markdown(summary: Dict[str, Any]) -> str:
+    alignment = summary["alignment"]
+    trajectory_eval = summary.get("trajectory_eval")
+    lines = [
+        "# Localization Health Summary",
+        "",
+        f"Generated at: {summary['generated_at']}",
+        "",
+        f"- alignment_csv: `{summary['alignment_csv']}`",
+        f"- trajectory_eval_json: `{summary['trajectory_eval_json']}`",
+        f"- reference_risk: `{summary['reference_risk']}`",
+        "",
+        "## Alignment",
+        "",
+        f"- rows: `{alignment['row_count']}`",
+        f"- ok rows: `{alignment['ok_rows']}` (`{_fmt(alignment.get('ok_rate_percent'))}%`)",
+        (
+            f"- failure-like rows: `{alignment['failure_like_rows']}` "
+            f"(`{_fmt(alignment.get('failure_like_rate_percent'))}%`)"
+        ),
+        f"- reinitialization requested rows: `{alignment['reinitialization_requested_rows']}`",
+        (
+            "- reinitialization transitions: "
+            f"`{alignment['reinitialization_request_transition_count']}`"
+        ),
+        f"- recovered request windows: `{alignment['reinitialization_recovered_count']}`",
+        f"- unrecovered request windows: `{alignment['reinitialization_unrecovered_count']}`",
+        f"- max accepted gap sec: `{_fmt(alignment['max_accepted_gap_sec'])}`",
+        (
+            "- max consecutive rejected updates: "
+            f"`{_fmt(alignment['max_consecutive_rejected_updates'])}`"
+        ),
+        f"- max fitness score: `{_fmt(alignment['max_fitness_score'])}`",
+        f"- max alignment time sec: `{_fmt(alignment['max_alignment_time_sec'])}`",
+        "",
+        "## Request Windows",
+        "",
+    ]
+
+    if alignment["reinitialization_windows"]:
+        lines.extend(
+            [
+                "| Start [s] | Rows | Duration [s] | Recovered | First OK [s] | Stable OK rows | Reasons |",
+                "| ---: | ---: | ---: | --- | ---: | ---: | --- |",
+            ]
+        )
+        for window in alignment["reinitialization_windows"]:
+            lines.append(
+                "| "
+                f"{_fmt(window['start_delta_sec'])} | "
+                f"{window['row_count']} | "
+                f"{_fmt(window['duration_sec'])} | "
+                f"{window['recovered']} | "
+                f"{_fmt(window['first_ok_after_request_sec'])} | "
+                f"{window['stable_ok_rows_after_request']} | "
+                f"`{json.dumps(window['reason_counts'], sort_keys=True)}` |"
+            )
+    else:
+        lines.append("- none")
+
+    lines.extend(
+        [
+            "",
+            "## Counts",
+            "",
+            f"- message_counts: `{json.dumps(alignment['message_counts'], sort_keys=True)}`",
+            (
+                "- recovery_state_counts: "
+                f"`{json.dumps(alignment['recovery_state_counts'], sort_keys=True)}`"
+            ),
+            (
+                "- recovery_action_counts: "
+                f"`{json.dumps(alignment['recovery_action_counts'], sort_keys=True)}`"
+            ),
+            (
+                "- request_reason_counts: "
+                f"`{json.dumps(alignment['request_reason_counts'], sort_keys=True)}`"
+            ),
+        ]
+    )
+
+    if trajectory_eval is not None:
+        lines.extend(
+            [
+                "",
+                "## Trajectory Eval",
+                "",
+                f"- matched_sample_count: `{trajectory_eval.get('matched_sample_count')}`",
+                f"- translation_rmse_m: `{_fmt(trajectory_eval.get('translation_rmse_m'))}`",
+                f"- rotation_rmse_deg: `{_fmt(trajectory_eval.get('rotation_rmse_deg'))}`",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Caveat",
+            "",
+            "- Diagnostics can show request/recovery timing, but event-local false recovery needs reference evaluation around each reset.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    args = parse_args()
+    alignment_csv = Path(args.alignment_csv).expanduser().resolve()
+    if not alignment_csv.exists():
+        raise FileNotFoundError(f"alignment CSV does not exist: {alignment_csv}")
+
+    trajectory_eval_json: Optional[Path] = None
+    if args.trajectory_eval_json:
+        trajectory_eval_json = Path(args.trajectory_eval_json).expanduser().resolve()
+        if not trajectory_eval_json.exists():
+            raise FileNotFoundError(
+                f"trajectory eval JSON does not exist: {trajectory_eval_json}"
+            )
+
+    summary = build_summary(
+        alignment_csv=alignment_csv,
+        trajectory_eval_json=trajectory_eval_json,
+        stable_ok_rows_required=args.stable_ok_rows,
+        recovery_window_sec=args.recovery_window_sec,
+        false_recovery_rmse_threshold_m=args.false_recovery_rmse_threshold_m,
+    )
+
+    if args.output_json:
+        output_json = Path(args.output_json).expanduser().resolve()
+        output_json.parent.mkdir(parents=True, exist_ok=True)
+        output_json.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.output_md:
+        output_md = Path(args.output_md).expanduser().resolve()
+        output_md.parent.mkdir(parents=True, exist_ok=True)
+        output_md.write_text(build_markdown(summary) + "\n", encoding="utf-8")
+
+    if not args.output_json and not args.output_md:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/summarize_registration_relocalization_scores.py
+++ b/scripts/summarize_registration_relocalization_scores.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import math
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from statistics import median
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Summarize relocalization registration score artifacts. This helper "
+            "does not accept or reset poses; it reports scorer coverage and gate "
+            "diagnostics from relocalization_registration_scores*.csv."
+        )
+    )
+    parser.add_argument("--scores-csv", required=True, help="Input registration scores CSV")
+    parser.add_argument("--output-json", default="", help="Optional output JSON path")
+    parser.add_argument("--output-md", default="", help="Optional output Markdown path")
+    return parser.parse_args()
+
+
+def _as_bool(value: Any) -> Optional[bool]:
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if normalized in {"true", "1", "yes", "y"}:
+        return True
+    if normalized in {"false", "0", "no", "n"}:
+        return False
+    return None
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        number = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _percent(numerator: int, denominator: int) -> Optional[float]:
+    if denominator <= 0:
+        return None
+    return 100.0 * float(numerator) / float(denominator)
+
+
+def _stats(values: Iterable[Optional[float]]) -> Dict[str, Optional[float]]:
+    finite_values = [value for value in values if value is not None]
+    if not finite_values:
+        return {"min": None, "median": None, "max": None}
+    return {
+        "min": min(finite_values),
+        "median": float(median(finite_values)),
+        "max": max(finite_values),
+    }
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def load_rows(path: Path) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        for row in csv.DictReader(stream):
+            rows.append(
+                {
+                    "job_id": row.get("job_id", ""),
+                    "attempt_id": row.get("attempt_id", ""),
+                    "candidate_index": row.get("candidate_index", ""),
+                    "status": row.get("status", ""),
+                    "rejection_reason": row.get("rejection_reason", ""),
+                    "registration_method": row.get("registration_method", ""),
+                    "converged": _as_bool(row.get("converged")),
+                    "registration_gate_passed": _as_bool(
+                        row.get("registration_gate_passed")
+                    ),
+                    "registration_gate_reason": row.get("registration_gate_reason", ""),
+                    "score": _as_float(row.get("score")),
+                    "overlap": _as_float(row.get("overlap")),
+                    "refinement_delta_m": _as_float(row.get("refinement_delta_m")),
+                    "refinement_delta_yaw_rad": _as_float(
+                        row.get("refinement_delta_yaw_rad")
+                    ),
+                    "runtime_sec": _as_float(row.get("runtime_sec")),
+                    "scan_time_delta_sec": _as_float(row.get("scan_time_delta_sec")),
+                    "scan_point_count_valid": _as_float(row.get("scan_point_count_valid")),
+                    "source_point_count": _as_float(row.get("source_point_count")),
+                    "target_point_count": _as_float(row.get("target_point_count")),
+                }
+            )
+    return rows
+
+
+def build_summary(scores_csv: Path) -> Dict[str, Any]:
+    rows = load_rows(scores_csv)
+    scored_rows = [row for row in rows if row["status"] == "registration_scored_no_reset"]
+    scan_resolved_rows = [
+        row for row in rows if row["status"] == "scan_resolved_no_registration"
+    ]
+    converged_rows = [row for row in rows if row["converged"] is True]
+    gate_passed_rows = [row for row in rows if row["registration_gate_passed"] is True]
+    gate_failed_rows = [row for row in rows if row["registration_gate_passed"] is False]
+
+    attempt_ids = {row["attempt_id"] for row in rows if row["attempt_id"]}
+    scored_attempt_ids = {row["attempt_id"] for row in scored_rows if row["attempt_id"]}
+    gate_passed_attempt_ids = {
+        row["attempt_id"] for row in gate_passed_rows if row["attempt_id"]
+    }
+
+    return {
+        "generated_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "scores_csv": str(scores_csv),
+        "rows": {
+            "count": len(rows),
+            "scored_count": len(scored_rows),
+            "scan_resolved_unscored_count": len(scan_resolved_rows),
+            "converged_count": len(converged_rows),
+            "gate_passed_count": len(gate_passed_rows),
+            "gate_failed_count": len(gate_failed_rows),
+            "scored_rate_percent": _percent(len(scored_rows), len(rows)),
+            "gate_passed_rate_percent": _percent(len(gate_passed_rows), len(rows)),
+        },
+        "attempts": {
+            "count": len(attempt_ids),
+            "scored_count": len(scored_attempt_ids),
+            "gate_passed_count": len(gate_passed_attempt_ids),
+        },
+        "counts": {
+            "status": dict(Counter(row["status"] or "unknown" for row in rows)),
+            "rejection_reason": dict(
+                Counter(row["rejection_reason"] or "unknown" for row in rows)
+            ),
+            "registration_method": dict(
+                Counter(row["registration_method"] or "unknown" for row in rows)
+            ),
+            "registration_gate_reason": dict(
+                Counter(row["registration_gate_reason"] or "unknown" for row in rows)
+            ),
+        },
+        "stats": {
+            "score": _stats(row["score"] for row in rows),
+            "overlap": _stats(row["overlap"] for row in rows),
+            "refinement_delta_m": _stats(row["refinement_delta_m"] for row in rows),
+            "refinement_delta_yaw_rad": _stats(
+                row["refinement_delta_yaw_rad"] for row in rows
+            ),
+            "runtime_sec": _stats(row["runtime_sec"] for row in rows),
+            "scan_time_delta_sec_abs": _stats(
+                abs(row["scan_time_delta_sec"])
+                if row["scan_time_delta_sec"] is not None
+                else None
+                for row in rows
+            ),
+            "scan_point_count_valid": _stats(row["scan_point_count_valid"] for row in rows),
+            "source_point_count": _stats(row["source_point_count"] for row in rows),
+            "target_point_count": _stats(row["target_point_count"] for row in rows),
+        },
+        "scored_stats": {
+            "score": _stats(row["score"] for row in scored_rows),
+            "overlap": _stats(row["overlap"] for row in scored_rows),
+            "refinement_delta_m": _stats(
+                row["refinement_delta_m"] for row in scored_rows
+            ),
+            "refinement_delta_yaw_rad": _stats(
+                row["refinement_delta_yaw_rad"] for row in scored_rows
+            ),
+            "runtime_sec": _stats(row["runtime_sec"] for row in scored_rows),
+            "source_point_count": _stats(
+                row["source_point_count"] for row in scored_rows
+            ),
+            "target_point_count": _stats(
+                row["target_point_count"] for row in scored_rows
+            ),
+        },
+        "notes": [
+            "registration gate pass does not mean pose reset was accepted",
+            "rows marked registration_scored_no_reset are scorer artifacts only",
+            "scan_resolved_no_registration rows have scan inputs but no backend score yet",
+        ],
+    }
+
+
+def build_markdown(summary: Dict[str, Any]) -> str:
+    rows = summary["rows"]
+    attempts = summary["attempts"]
+    counts = summary["counts"]
+    stats = summary["stats"]
+    scored_stats = summary["scored_stats"]
+    lines = [
+        "# Registration Relocalization Score Summary",
+        "",
+        f"Generated at: {summary['generated_at']}",
+        "",
+        f"- scores_csv: `{summary['scores_csv']}`",
+        "",
+        "## Coverage",
+        "",
+        f"- rows: `{rows['count']}`",
+        f"- scored rows: `{rows['scored_count']}` (`{_fmt(rows['scored_rate_percent'])}%`)",
+        f"- scan-resolved unscored rows: `{rows['scan_resolved_unscored_count']}`",
+        f"- converged rows: `{rows['converged_count']}`",
+        f"- gate-passed rows: `{rows['gate_passed_count']}` (`{_fmt(rows['gate_passed_rate_percent'])}%`)",
+        f"- gate-failed rows: `{rows['gate_failed_count']}`",
+        f"- attempts: `{attempts['count']}`",
+        f"- attempts with scored rows: `{attempts['scored_count']}`",
+        f"- attempts with gate-passed rows: `{attempts['gate_passed_count']}`",
+        "",
+        "## Counts",
+        "",
+        f"- status: `{json.dumps(counts['status'], sort_keys=True)}`",
+        f"- rejection_reason: `{json.dumps(counts['rejection_reason'], sort_keys=True)}`",
+        f"- registration_gate_reason: `{json.dumps(counts['registration_gate_reason'], sort_keys=True)}`",
+        "",
+        "## Stats",
+        "",
+        f"- score: `{json.dumps(stats['score'], sort_keys=True)}`",
+        f"- refinement_delta_m: `{json.dumps(stats['refinement_delta_m'], sort_keys=True)}`",
+        f"- refinement_delta_yaw_rad: `{json.dumps(stats['refinement_delta_yaw_rad'], sort_keys=True)}`",
+        f"- runtime_sec: `{json.dumps(stats['runtime_sec'], sort_keys=True)}`",
+        f"- source_point_count: `{json.dumps(stats['source_point_count'], sort_keys=True)}`",
+        f"- target_point_count: `{json.dumps(stats['target_point_count'], sort_keys=True)}`",
+        "",
+        "## Scored-Only Stats",
+        "",
+        f"- score: `{json.dumps(scored_stats['score'], sort_keys=True)}`",
+        f"- refinement_delta_m: `{json.dumps(scored_stats['refinement_delta_m'], sort_keys=True)}`",
+        f"- refinement_delta_yaw_rad: `{json.dumps(scored_stats['refinement_delta_yaw_rad'], sort_keys=True)}`",
+        f"- runtime_sec: `{json.dumps(scored_stats['runtime_sec'], sort_keys=True)}`",
+        "",
+        "## Caveat",
+        "",
+        "- A passed registration gate is not an accepted reset. Reset acceptance remains disabled.",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> None:
+    args = parse_args()
+    scores_csv = Path(args.scores_csv).expanduser().resolve()
+    if not scores_csv.exists():
+        raise FileNotFoundError(f"scores CSV does not exist: {scores_csv}")
+
+    summary = build_summary(scores_csv)
+    if args.output_json:
+        output_json = Path(args.output_json).expanduser().resolve()
+        output_json.parent.mkdir(parents=True, exist_ok=True)
+        output_json.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.output_md:
+        output_md = Path(args.output_md).expanduser().resolve()
+        output_md.parent.mkdir(parents=True, exist_ok=True)
+        output_md.write_text(build_markdown(summary) + "\n", encoding="utf-8")
+
+    if not args.output_json and not args.output_md:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/summarize_relocalization_attempts.py
+++ b/scripts/summarize_relocalization_attempts.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import math
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from statistics import median
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Summarize experimental relocalization attempt artifacts and match them "
+            "against reinitialization request windows from alignment_status.csv."
+        )
+    )
+    parser.add_argument(
+        "--alignment-csv",
+        required=True,
+        help="Path to alignment_status.csv produced by benchmark_diagnostic_recorder.",
+    )
+    parser.add_argument(
+        "--attempts-csv",
+        default="",
+        help=(
+            "Optional relocalization_attempts.csv. When omitted or missing with "
+            "--allow-missing-attempts, the summary records zero attempts."
+        ),
+    )
+    parser.add_argument(
+        "--trajectory-eval-json",
+        default="",
+        help="Optional trajectory_eval.json for run-level reference-risk context.",
+    )
+    parser.add_argument("--output-json", default="", help="Optional output JSON path.")
+    parser.add_argument("--output-md", default="", help="Optional output Markdown path.")
+    parser.add_argument(
+        "--allow-missing-attempts",
+        action="store_true",
+        help="Treat a missing attempts CSV as an empty attempt set.",
+    )
+    parser.add_argument(
+        "--request-match-window-sec",
+        type=float,
+        default=10.0,
+        help="Seconds after a request window ends in which an attempt still matches it.",
+    )
+    parser.add_argument(
+        "--post-reset-stable-ok-rows",
+        type=int,
+        default=5,
+        help="Stable accepted rows required for an accepted attempt to count as recovered.",
+    )
+    parser.add_argument(
+        "--false-recovery-rmse-threshold-m",
+        type=float,
+        default=5.0,
+        help=(
+            "Overall translation RMSE threshold used only to mark accepted attempts "
+            "as reference-risky when event-local false recovery is unknown."
+        ),
+    )
+    return parser.parse_args()
+
+
+def _as_bool(value: Any) -> Optional[bool]:
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if normalized in {"true", "1", "yes", "y"}:
+        return True
+    if normalized in {"false", "0", "no", "n"}:
+        return False
+    return None
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        number = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _as_int(value: Any) -> Optional[int]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        return int(float(str(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _percent(numerator: int, denominator: int) -> Optional[float]:
+    if denominator <= 0:
+        return None
+    return 100.0 * float(numerator) / float(denominator)
+
+
+def _first_present(row: Dict[str, Any], keys: Iterable[str]) -> Any:
+    for key in keys:
+        if key in row and str(row[key]).strip() != "":
+            return row[key]
+    return None
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def _stats(values: Iterable[Optional[float]]) -> Dict[str, Optional[float]]:
+    finite_values = [value for value in values if value is not None]
+    if not finite_values:
+        return {"min": None, "median": None, "max": None}
+    return {
+        "min": min(finite_values),
+        "median": float(median(finite_values)),
+        "max": max(finite_values),
+    }
+
+
+def load_alignment_rows(path: Path) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        for record in csv.DictReader(stream):
+            values = json.loads(record["values_json"])
+            rows.append(
+                {
+                    "stamp_sec": float(record["stamp_sec"]),
+                    "message": str(record.get("message", "")),
+                    "reinitialization_requested": _as_bool(
+                        values.get("reinitialization_requested")
+                    )
+                    is True,
+                    "reinitialization_request_reason": values.get(
+                        "reinitialization_request_reason"
+                    ),
+                }
+            )
+    return rows
+
+
+def request_windows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    windows: List[Dict[str, Any]] = []
+    index = 0
+    while index < len(rows):
+        if not rows[index]["reinitialization_requested"]:
+            index += 1
+            continue
+        start = index
+        while index < len(rows) and rows[index]["reinitialization_requested"]:
+            index += 1
+        end = index - 1
+        reasons = Counter(
+            str(rows[row_index]["reinitialization_request_reason"])
+            for row_index in range(start, end + 1)
+            if rows[row_index]["reinitialization_request_reason"] is not None
+        )
+        windows.append(
+            {
+                "start_index": start,
+                "end_index": end,
+                "start_stamp_sec": rows[start]["stamp_sec"],
+                "end_stamp_sec": rows[end]["stamp_sec"],
+                "start_delta_sec": rows[start]["stamp_sec"] - rows[0]["stamp_sec"],
+                "duration_sec": max(0.0, rows[end]["stamp_sec"] - rows[start]["stamp_sec"]),
+                "row_count": end - start + 1,
+                "reason_counts": dict(reasons),
+            }
+        )
+    return windows
+
+
+def normalize_attempt(row: Dict[str, Any], row_number: int) -> Dict[str, Any]:
+    trigger_stamp = _as_float(
+        _first_present(row, ["trigger_stamp_sec", "trigger_time_sec", "stamp_sec", "start_stamp_sec"])
+    )
+    start_stamp = _as_float(_first_present(row, ["start_stamp_sec", "start_time_sec"]))
+    end_stamp = _as_float(_first_present(row, ["end_stamp_sec", "end_time_sec"]))
+    runtime = _as_float(_first_present(row, ["runtime_sec", "duration_sec", "elapsed_sec"]))
+    if runtime is None and start_stamp is not None and end_stamp is not None:
+        runtime = max(0.0, end_stamp - start_stamp)
+
+    accepted = _as_bool(_first_present(row, ["accepted", "reset_accepted"]))
+    false_recovery = _as_bool(_first_present(row, ["false_recovery", "event_false_recovery"]))
+    post_reset_ok_rows = _as_int(
+        _first_present(row, ["post_reset_ok_rows", "stable_ok_rows_after_reset"])
+    )
+    recovered = accepted is True and (
+        post_reset_ok_rows is not None and post_reset_ok_rows > 0
+    )
+
+    return {
+        "attempt_id": str(_first_present(row, ["attempt_id", "id"]) or row_number),
+        "trigger_stamp_sec": trigger_stamp,
+        "start_stamp_sec": start_stamp,
+        "end_stamp_sec": end_stamp,
+        "source": str(_first_present(row, ["source", "candidate_source"]) or "unknown"),
+        "mode": str(_first_present(row, ["mode", "roi_mode"]) or "unknown"),
+        "roi_type": str(_first_present(row, ["roi_type", "roi"]) or "unknown"),
+        "candidate_count": _as_int(_first_present(row, ["candidate_count", "candidates"])),
+        "accepted": accepted,
+        "accepted_candidate_rank": _as_int(
+            _first_present(row, ["accepted_candidate_rank", "accepted_rank"])
+        ),
+        "rejection_reason": str(
+            _first_present(row, ["rejection_reason", "reason", "accepted_reason"]) or ""
+        ),
+        "best_score": _as_float(_first_present(row, ["best_score", "score"])),
+        "second_score": _as_float(_first_present(row, ["second_score", "runner_up_score"])),
+        "candidate_margin": _as_float(_first_present(row, ["candidate_margin", "margin"])),
+        "overlap": _as_float(_first_present(row, ["overlap", "effective_overlap"])),
+        "converged": _as_bool(_first_present(row, ["converged", "has_converged"])),
+        "refinement_delta_m": _as_float(
+            _first_present(row, ["refinement_delta_m", "delta_m"])
+        ),
+        "refinement_delta_yaw_rad": _as_float(
+            _first_present(row, ["refinement_delta_yaw_rad", "delta_yaw_rad"])
+        ),
+        "runtime_sec": runtime,
+        "post_reset_ok_rows": post_reset_ok_rows,
+        "post_reset_window_sec": _as_float(
+            _first_present(row, ["post_reset_window_sec", "stable_window_sec"])
+        ),
+        "recovered": recovered,
+        "false_recovery": false_recovery,
+    }
+
+
+def load_attempts(path: Optional[Path], allow_missing: bool) -> List[Dict[str, Any]]:
+    if path is None:
+        return []
+    if not path.exists():
+        if allow_missing:
+            return []
+        raise FileNotFoundError(f"attempts CSV does not exist: {path}")
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        return [
+            normalize_attempt(row, row_number)
+            for row_number, row in enumerate(csv.DictReader(stream), start=1)
+        ]
+
+
+def match_attempts_to_windows(
+    windows: List[Dict[str, Any]],
+    attempts: List[Dict[str, Any]],
+    match_window_sec: float,
+) -> List[Dict[str, Any]]:
+    matched_windows: List[Dict[str, Any]] = []
+    for window_index, window in enumerate(windows):
+        start = float(window["start_stamp_sec"])
+        end = float(window["end_stamp_sec"]) + match_window_sec
+        matching_attempts = []
+        for attempt in attempts:
+            stamp = attempt["trigger_stamp_sec"]
+            if stamp is None:
+                stamp = attempt["start_stamp_sec"]
+            if stamp is not None and start <= stamp <= end:
+                matching_attempts.append(attempt)
+        accepted_attempts = [attempt for attempt in matching_attempts if attempt["accepted"] is True]
+        recovered_attempts = [attempt for attempt in matching_attempts if attempt["recovered"]]
+        matched_windows.append(
+            {
+                "window_index": window_index,
+                "start_delta_sec": window["start_delta_sec"],
+                "duration_sec": window["duration_sec"],
+                "row_count": window["row_count"],
+                "reason_counts": window["reason_counts"],
+                "attempt_count": len(matching_attempts),
+                "accepted_attempt_count": len(accepted_attempts),
+                "recovered_attempt_count": len(recovered_attempts),
+                "attempt_ids": [attempt["attempt_id"] for attempt in matching_attempts],
+            }
+        )
+    return matched_windows
+
+
+def load_trajectory_eval(path: Optional[Path]) -> Optional[Dict[str, Any]]:
+    if path is None:
+        return None
+    with path.open("r", encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def build_summary(
+    alignment_csv: Path,
+    attempts_csv: Optional[Path],
+    trajectory_eval_json: Optional[Path],
+    allow_missing_attempts: bool,
+    request_match_window_sec: float,
+    post_reset_stable_ok_rows: int,
+    false_recovery_rmse_threshold_m: float,
+) -> Dict[str, Any]:
+    rows = load_alignment_rows(alignment_csv)
+    windows = request_windows(rows)
+    attempts = load_attempts(attempts_csv, allow_missing=allow_missing_attempts)
+    matched_windows = match_attempts_to_windows(windows, attempts, request_match_window_sec)
+    trajectory_eval = load_trajectory_eval(trajectory_eval_json)
+
+    accepted_attempts = [attempt for attempt in attempts if attempt["accepted"] is True]
+    rejected_attempts = [attempt for attempt in attempts if attempt["accepted"] is False]
+    unknown_decision_attempts = [attempt for attempt in attempts if attempt["accepted"] is None]
+    recovered_attempts = [
+        attempt
+        for attempt in accepted_attempts
+        if (attempt["post_reset_ok_rows"] or 0) >= post_reset_stable_ok_rows
+    ]
+    false_recovery_known = [
+        attempt for attempt in attempts if attempt["false_recovery"] is not None
+    ]
+    false_recovery_count = sum(
+        1 for attempt in false_recovery_known if attempt["false_recovery"] is True
+    )
+
+    reference_risk = "not_evaluated"
+    if accepted_attempts and not false_recovery_known and trajectory_eval is not None:
+        translation_rmse_m = trajectory_eval.get("translation_rmse_m")
+        if isinstance(translation_rmse_m, (int, float)):
+            reference_risk = (
+                "accepted_attempts_high_overall_rmse_event_local_unknown"
+                if translation_rmse_m > false_recovery_rmse_threshold_m
+                else "accepted_attempts_overall_rmse_within_threshold_event_local_unknown"
+            )
+
+    request_window_count = len(windows)
+    attempted_window_count = sum(1 for window in matched_windows if window["attempt_count"] > 0)
+    accepted_window_count = sum(
+        1 for window in matched_windows if window["accepted_attempt_count"] > 0
+    )
+
+    return {
+        "generated_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "alignment_csv": str(alignment_csv),
+        "attempts_csv": None if attempts_csv is None else str(attempts_csv),
+        "attempts_csv_exists": attempts_csv.exists() if attempts_csv is not None else False,
+        "trajectory_eval_json": None if trajectory_eval_json is None else str(trajectory_eval_json),
+        "request_match_window_sec": request_match_window_sec,
+        "post_reset_stable_ok_rows": post_reset_stable_ok_rows,
+        "false_recovery_rmse_threshold_m": false_recovery_rmse_threshold_m,
+        "request_windows": {
+            "count": request_window_count,
+            "attempted_count": attempted_window_count,
+            "unattempted_count": request_window_count - attempted_window_count,
+            "accepted_count": accepted_window_count,
+            "attempted_rate_percent": _percent(attempted_window_count, request_window_count),
+            "matched": matched_windows,
+        },
+        "attempts": {
+            "count": len(attempts),
+            "accepted_count": len(accepted_attempts),
+            "rejected_count": len(rejected_attempts),
+            "unknown_decision_count": len(unknown_decision_attempts),
+            "recovered_count": len(recovered_attempts),
+            "false_recovery_count": false_recovery_count,
+            "false_recovery_unknown_count": len(attempts) - len(false_recovery_known),
+            "source_counts": dict(Counter(attempt["source"] for attempt in attempts)),
+            "mode_counts": dict(Counter(attempt["mode"] for attempt in attempts)),
+            "roi_type_counts": dict(Counter(attempt["roi_type"] for attempt in attempts)),
+            "rejection_reason_counts": dict(
+                Counter(
+                    attempt["rejection_reason"] or "unknown"
+                    for attempt in attempts
+                    if attempt["accepted"] is not True
+                )
+            ),
+            "candidate_count_stats": _stats(
+                float(attempt["candidate_count"])
+                if attempt["candidate_count"] is not None
+                else None
+                for attempt in attempts
+            ),
+            "runtime_sec_stats": _stats(attempt["runtime_sec"] for attempt in attempts),
+            "best_score_stats": _stats(attempt["best_score"] for attempt in attempts),
+            "candidate_margin_stats": _stats(
+                attempt["candidate_margin"] for attempt in attempts
+            ),
+            "refinement_delta_m_stats": _stats(
+                attempt["refinement_delta_m"] for attempt in attempts
+            ),
+        },
+        "trajectory_eval": trajectory_eval,
+        "reference_risk": reference_risk,
+        "schema": {
+            "required_csv_columns": [
+                "attempt_id",
+                "trigger_stamp_sec",
+                "source",
+                "candidate_count",
+                "accepted",
+                "rejection_reason",
+                "runtime_sec",
+            ],
+            "recommended_csv_columns": [
+                "start_stamp_sec",
+                "end_stamp_sec",
+                "mode",
+                "roi_type",
+                "accepted_candidate_rank",
+                "best_score",
+                "second_score",
+                "candidate_margin",
+                "overlap",
+                "converged",
+                "refinement_delta_m",
+                "refinement_delta_yaw_rad",
+                "post_reset_ok_rows",
+                "post_reset_window_sec",
+                "false_recovery",
+            ],
+        },
+        "notes": [
+            "an absent attempts CSV means no relocalization candidate generator ran",
+            "false recovery is authoritative only when event-local false_recovery is recorded",
+            "overall trajectory RMSE is only a coarse reference-risk signal",
+        ],
+    }
+
+
+def build_markdown(summary: Dict[str, Any]) -> str:
+    requests = summary["request_windows"]
+    attempts = summary["attempts"]
+    lines = [
+        "# Relocalization Attempt Summary",
+        "",
+        f"Generated at: {summary['generated_at']}",
+        "",
+        f"- alignment_csv: `{summary['alignment_csv']}`",
+        f"- attempts_csv: `{summary['attempts_csv']}`",
+        f"- attempts_csv_exists: `{summary['attempts_csv_exists']}`",
+        f"- trajectory_eval_json: `{summary['trajectory_eval_json']}`",
+        f"- reference_risk: `{summary['reference_risk']}`",
+        "",
+        "## Attempts",
+        "",
+        f"- attempts: `{attempts['count']}`",
+        f"- accepted: `{attempts['accepted_count']}`",
+        f"- rejected: `{attempts['rejected_count']}`",
+        f"- unknown decision: `{attempts['unknown_decision_count']}`",
+        f"- recovered: `{attempts['recovered_count']}`",
+        f"- false recovery: `{attempts['false_recovery_count']}`",
+        f"- false recovery unknown: `{attempts['false_recovery_unknown_count']}`",
+        f"- source_counts: `{json.dumps(attempts['source_counts'], sort_keys=True)}`",
+        f"- rejection_reason_counts: `{json.dumps(attempts['rejection_reason_counts'], sort_keys=True)}`",
+        f"- runtime_sec_stats: `{json.dumps(attempts['runtime_sec_stats'], sort_keys=True)}`",
+        "",
+        "## Request Window Coverage",
+        "",
+        f"- request windows: `{requests['count']}`",
+        f"- attempted windows: `{requests['attempted_count']}` (`{_fmt(requests['attempted_rate_percent'])}%`)",
+        f"- unattempted windows: `{requests['unattempted_count']}`",
+        f"- windows with accepted attempt: `{requests['accepted_count']}`",
+        "",
+    ]
+
+    if requests["matched"]:
+        lines.extend(
+            [
+                "| Window | Start [s] | Rows | Attempts | Accepted | Recovered | Attempt IDs | Reasons |",
+                "| ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |",
+            ]
+        )
+        for window in requests["matched"]:
+            lines.append(
+                "| "
+                f"{window['window_index']} | "
+                f"{_fmt(window['start_delta_sec'])} | "
+                f"{window['row_count']} | "
+                f"{window['attempt_count']} | "
+                f"{window['accepted_attempt_count']} | "
+                f"{window['recovered_attempt_count']} | "
+                f"`{json.dumps(window['attempt_ids'])}` | "
+                f"`{json.dumps(window['reason_counts'], sort_keys=True)}` |"
+            )
+    else:
+        lines.append("- no reinitialization request windows")
+
+    lines.extend(
+        [
+            "",
+            "## Attempt CSV Schema",
+            "",
+            f"- required: `{', '.join(summary['schema']['required_csv_columns'])}`",
+            f"- recommended: `{', '.join(summary['schema']['recommended_csv_columns'])}`",
+            "",
+            "## Caveat",
+            "",
+            "- Use this artifact to measure candidate generation and guarded reset behavior; it does not implement global relocalization by itself.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    args = parse_args()
+    alignment_csv = Path(args.alignment_csv).expanduser().resolve()
+    if not alignment_csv.exists():
+        raise FileNotFoundError(f"alignment CSV does not exist: {alignment_csv}")
+
+    attempts_csv: Optional[Path] = None
+    if args.attempts_csv:
+        attempts_csv = Path(args.attempts_csv).expanduser().resolve()
+
+    trajectory_eval_json: Optional[Path] = None
+    if args.trajectory_eval_json:
+        trajectory_eval_json = Path(args.trajectory_eval_json).expanduser().resolve()
+        if not trajectory_eval_json.exists():
+            raise FileNotFoundError(
+                f"trajectory eval JSON does not exist: {trajectory_eval_json}"
+            )
+
+    summary = build_summary(
+        alignment_csv=alignment_csv,
+        attempts_csv=attempts_csv,
+        trajectory_eval_json=trajectory_eval_json,
+        allow_missing_attempts=args.allow_missing_attempts,
+        request_match_window_sec=args.request_match_window_sec,
+        post_reset_stable_ok_rows=args.post_reset_stable_ok_rows,
+        false_recovery_rmse_threshold_m=args.false_recovery_rmse_threshold_m,
+    )
+
+    if args.output_json:
+        output_json = Path(args.output_json).expanduser().resolve()
+        output_json.parent.mkdir(parents=True, exist_ok=True)
+        output_json.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.output_md:
+        output_md = Path(args.output_md).expanduser().resolve()
+        output_md.parent.mkdir(parents=True, exist_ok=True)
+        output_md.write_text(build_markdown(summary) + "\n", encoding="utf-8")
+
+    if not args.output_json and not args.output_md:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_relocalization_reset_candidate_plan.py
+++ b/scripts/validate_relocalization_reset_candidate_plan.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+
+REQUIRED_PLAN_COLUMNS = [
+    "attempt_id",
+    "selected",
+    "accepted",
+    "rejection_reason",
+    "selected_job_id",
+    "selected_candidate_index",
+    "selected_score",
+    "selected_converged",
+    "selected_registration_gate_passed",
+    "selected_final_pose_x",
+    "selected_final_pose_y",
+    "selected_final_pose_z",
+    "selected_final_yaw_rad",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate a relocalization reset candidate plan artifact. This is a contract "
+            "checker only; it does not execute or accept resets."
+        )
+    )
+    parser.add_argument("--plan-csv", required=True)
+    parser.add_argument(
+        "--scores-csv",
+        default="",
+        help="Optional registration score CSV to cross-check selected job/candidate rows.",
+    )
+    parser.add_argument("--output-json", default="")
+    parser.add_argument("--output-md", default="")
+    parser.add_argument("--max-score", type=float, default=6.0)
+    parser.add_argument("--max-refinement-delta-m", type=float, default=2.0)
+    parser.add_argument("--max-refinement-yaw-rad", type=float, default=0.7853981633974483)
+    parser.add_argument("--min-selected-count", type=int, default=0)
+    parser.add_argument("--max-selected-count", type=int, default=-1)
+    parser.add_argument("--allow-accepted", action="store_true")
+    parser.add_argument("--allow-oracle-selection", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def _read_csv(path: Path) -> Tuple[List[str], List[Dict[str, str]]]:
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        reader = csv.DictReader(stream)
+        return list(reader.fieldnames or []), list(reader)
+
+
+def _as_bool(value: Any) -> Optional[bool]:
+    if value is None or str(value).strip() == "":
+        return None
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "y"}:
+        return True
+    if normalized in {"0", "false", "no", "n"}:
+        return False
+    return None
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        number = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _selected_key(row: Dict[str, str]) -> Tuple[str, str, str]:
+    return (
+        str(row.get("attempt_id", "")),
+        str(row.get("selected_job_id", "")),
+        str(row.get("selected_candidate_index", "")),
+    )
+
+
+def _score_key(row: Dict[str, str]) -> Tuple[str, str, str]:
+    return (
+        str(row.get("attempt_id", "")),
+        str(row.get("job_id", "")),
+        str(row.get("candidate_index", "")),
+    )
+
+
+def _counts(values: Iterable[str]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for value in values:
+        key = str(value)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def validate(
+    plan_header: List[str],
+    plan_rows: List[Dict[str, str]],
+    scores_rows: List[Dict[str, str]],
+    args: argparse.Namespace,
+) -> Dict[str, Any]:
+    failures: List[str] = []
+    warnings: List[str] = []
+
+    missing = [column for column in REQUIRED_PLAN_COLUMNS if column not in plan_header]
+    for column in missing:
+        failures.append(f"missing required plan column: {column}")
+
+    if not plan_rows:
+        failures.append("plan CSV has no rows")
+
+    attempts = [str(row.get("attempt_id", "")) for row in plan_rows]
+    for attempt_id, count in _counts(attempts).items():
+        if not attempt_id:
+            failures.append("plan row has empty attempt_id")
+        if count > 1:
+            failures.append(f"attempt_id appears more than once: {attempt_id}")
+
+    selected_rows = [row for row in plan_rows if _as_bool(row.get("selected")) is True]
+    accepted_rows = [row for row in plan_rows if _as_bool(row.get("accepted")) is True]
+    if accepted_rows and not args.allow_accepted:
+        failures.append(
+            f"accepted=true rows are not allowed in artifact-only mode: {len(accepted_rows)}"
+        )
+
+    if len(selected_rows) < args.min_selected_count:
+        failures.append(
+            f"selected row count {len(selected_rows)} is below minimum {args.min_selected_count}"
+        )
+    if args.max_selected_count >= 0 and len(selected_rows) > args.max_selected_count:
+        failures.append(
+            f"selected row count {len(selected_rows)} is above maximum {args.max_selected_count}"
+        )
+
+    scores_by_key = {_score_key(row): row for row in scores_rows}
+    for row in selected_rows:
+        attempt_id = str(row.get("attempt_id", ""))
+        prefix = f"attempt {attempt_id}: "
+        if not str(row.get("selected_job_id", "")):
+            failures.append(prefix + "selected_job_id is empty")
+        if not str(row.get("selected_candidate_index", "")):
+            failures.append(prefix + "selected_candidate_index is empty")
+        if (
+            str(row.get("selected_selection_source", "")) == "oracle_rank"
+            and not args.allow_oracle_selection
+        ):
+            failures.append(prefix + "oracle_rank selection is not allowed by default")
+        if _as_bool(row.get("selected_converged")) is not True:
+            failures.append(prefix + "selected_converged is not true")
+        if _as_bool(row.get("selected_registration_gate_passed")) is not True:
+            failures.append(prefix + "selected_registration_gate_passed is not true")
+
+        selected_score = _as_float(row.get("selected_score"))
+        if selected_score is None:
+            failures.append(prefix + "selected_score is missing or non-finite")
+        elif selected_score > args.max_score:
+            failures.append(
+                prefix + f"selected_score {selected_score:.6f} exceeds {args.max_score:.6f}"
+            )
+
+        refinement_delta = _as_float(row.get("selected_refinement_delta_m"))
+        if refinement_delta is None:
+            failures.append(prefix + "selected_refinement_delta_m is missing or non-finite")
+        elif refinement_delta > args.max_refinement_delta_m:
+            failures.append(
+                prefix
+                + f"selected_refinement_delta_m {refinement_delta:.6f} exceeds "
+                + f"{args.max_refinement_delta_m:.6f}"
+            )
+
+        refinement_yaw = _as_float(row.get("selected_refinement_delta_yaw_rad"))
+        if refinement_yaw is None:
+            failures.append(
+                prefix + "selected_refinement_delta_yaw_rad is missing or non-finite"
+            )
+        elif refinement_yaw > args.max_refinement_yaw_rad:
+            failures.append(
+                prefix
+                + f"selected_refinement_delta_yaw_rad {refinement_yaw:.6f} exceeds "
+                + f"{args.max_refinement_yaw_rad:.6f}"
+            )
+
+        for field in [
+            "selected_final_pose_x",
+            "selected_final_pose_y",
+            "selected_final_pose_z",
+            "selected_final_yaw_rad",
+        ]:
+            if _as_float(row.get(field)) is None:
+                failures.append(prefix + f"{field} is missing or non-finite")
+
+        if scores_rows:
+            key = _selected_key(row)
+            score_row = scores_by_key.get(key)
+            if score_row is None:
+                failures.append(prefix + "selected job/candidate does not exist in scores CSV")
+            else:
+                if _as_bool(score_row.get("registration_gate_passed")) is not True:
+                    failures.append(prefix + "scores CSV row did not pass registration gate")
+                score_value = _as_float(score_row.get("score"))
+                if selected_score is not None and score_value is not None:
+                    if abs(score_value - selected_score) > 1e-5:
+                        failures.append(prefix + "selected_score differs from scores CSV")
+                elif selected_score is not None or score_value is not None:
+                    failures.append(prefix + "score presence differs from scores CSV")
+
+    for row in plan_rows:
+        if _as_bool(row.get("selected")) is not True and str(row.get("rejection_reason", "")) == "":
+            warnings.append(
+                f"attempt {row.get('attempt_id', '')}: unselected row has empty rejection_reason"
+            )
+
+    return {
+        "validation_passed": not failures,
+        "failure_count": len(failures),
+        "warning_count": len(warnings),
+        "failures": failures,
+        "warnings": warnings,
+        "attempt_count": len(plan_rows),
+        "selected_count": len(selected_rows),
+        "accepted_count": len(accepted_rows),
+        "rejection_reason_counts": _counts(
+            str(row.get("rejection_reason", "")) for row in plan_rows
+        ),
+        "selected_selection_source_counts": _counts(
+            str(row.get("selected_selection_source", "")) for row in selected_rows
+        ),
+    }
+
+
+def write_json(path: Path, data: Dict[str, Any], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output JSON already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_md(path: Path, data: Dict[str, Any], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output Markdown already exists: {path}")
+    lines = [
+        "# Relocalization Reset Candidate Plan Validation",
+        "",
+        f"- validation passed: `{str(data['validation_passed']).lower()}`",
+        f"- failures: `{data['failure_count']}`",
+        f"- warnings: `{data['warning_count']}`",
+        f"- attempts: `{data['attempt_count']}`",
+        f"- selected: `{data['selected_count']}`",
+        f"- accepted: `{data['accepted_count']}`",
+        f"- rejection reasons: `{json.dumps(data['rejection_reason_counts'], sort_keys=True)}`",
+        f"- selected sources: `{json.dumps(data['selected_selection_source_counts'], sort_keys=True)}`",
+        "",
+        "## Failures",
+        "",
+    ]
+    if data["failures"]:
+        lines.extend(f"- {failure}" for failure in data["failures"])
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Warnings", ""])
+    if data["warnings"]:
+        lines.extend(f"- {warning}" for warning in data["warnings"])
+    else:
+        lines.append("- none")
+    lines.append("")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    plan_csv = Path(args.plan_csv).expanduser().resolve()
+    scores_csv = Path(args.scores_csv).expanduser().resolve() if args.scores_csv else None
+    if not plan_csv.exists():
+        raise FileNotFoundError(f"plan CSV does not exist: {plan_csv}")
+    if scores_csv is not None and not scores_csv.exists():
+        raise FileNotFoundError(f"scores CSV does not exist: {scores_csv}")
+
+    plan_header, plan_rows = _read_csv(plan_csv)
+    _, scores_rows = _read_csv(scores_csv) if scores_csv is not None else ([], [])
+    result = validate(plan_header, plan_rows, scores_rows, args)
+    result.update(
+        {
+            "plan_csv": str(plan_csv),
+            "scores_csv": "" if scores_csv is None else str(scores_csv),
+            "notes": [
+                "this validator does not execute resets",
+                "accepted=true is rejected by default for artifact-only plans",
+                "oracle_rank selection is rejected by default",
+            ],
+        }
+    )
+    if args.output_json:
+        write_json(Path(args.output_json).expanduser().resolve(), result, args.overwrite)
+    if args.output_md:
+        write_md(Path(args.output_md).expanduser().resolve(), result, args.overwrite)
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["validation_passed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_relocalization_reset_commands.py
+++ b/scripts/validate_relocalization_reset_commands.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+
+REQUIRED_COLUMNS = [
+    "command_id",
+    "attempt_id",
+    "command_type",
+    "dry_run",
+    "publish_topic",
+    "frame_id",
+    "position_x",
+    "position_y",
+    "position_z",
+    "orientation_x",
+    "orientation_y",
+    "orientation_z",
+    "orientation_w",
+    "yaw_rad",
+    "source_plan_row_accepted",
+    "source_selection_source",
+    "status",
+    "rejection_reason",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate dry-run relocalization reset command artifacts. This checker never "
+            "publishes /initialpose; it only enforces the dry-run command contract."
+        )
+    )
+    parser.add_argument("--commands-csv", required=True)
+    parser.add_argument(
+        "--summary-json",
+        default="",
+        help="Optional relocalization_reset_commands.json summary to cross-check published_count.",
+    )
+    parser.add_argument("--output-json", default="")
+    parser.add_argument("--output-md", default="")
+    parser.add_argument("--expected-topic", default="/initialpose")
+    parser.add_argument("--expected-frame-id", default="map")
+    parser.add_argument("--quaternion-norm-tolerance", type=float, default=1e-3)
+    parser.add_argument("--min-generated-count", type=int, default=0)
+    parser.add_argument("--max-generated-count", type=int, default=-1)
+    parser.add_argument("--allow-published", action="store_true")
+    parser.add_argument("--allow-accepted-source-plan", action="store_true")
+    parser.add_argument("--allow-oracle-selection", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def _read_csv(path: Path) -> Tuple[List[str], List[Dict[str, str]]]:
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        reader = csv.DictReader(stream)
+        return list(reader.fieldnames or []), list(reader)
+
+
+def _as_bool(value: Any) -> Optional[bool]:
+    if value is None or str(value).strip() == "":
+        return None
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "y"}:
+        return True
+    if normalized in {"0", "false", "no", "n"}:
+        return False
+    return None
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        number = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _counts(values: Iterable[str]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for value in values:
+        key = str(value)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _load_summary(path: Optional[Path]) -> Dict[str, Any]:
+    if path is None:
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate(
+    header: List[str],
+    rows: List[Dict[str, str]],
+    summary: Dict[str, Any],
+    args: argparse.Namespace,
+) -> Dict[str, Any]:
+    failures: List[str] = []
+    warnings: List[str] = []
+
+    missing = [column for column in REQUIRED_COLUMNS if column not in header]
+    for column in missing:
+        failures.append(f"missing required command column: {column}")
+    if not rows:
+        failures.append("commands CSV has no rows")
+
+    command_ids = [str(row.get("command_id", "")) for row in rows]
+    for command_id, count in _counts(command_ids).items():
+        if not command_id:
+            failures.append("command row has empty command_id")
+        if count > 1:
+            failures.append(f"command_id appears more than once: {command_id}")
+
+    generated_rows = [row for row in rows if row.get("status") == "dry_run_command_generated"]
+    if len(generated_rows) < args.min_generated_count:
+        failures.append(
+            f"generated command count {len(generated_rows)} is below minimum {args.min_generated_count}"
+        )
+    if args.max_generated_count >= 0 and len(generated_rows) > args.max_generated_count:
+        failures.append(
+            f"generated command count {len(generated_rows)} is above maximum {args.max_generated_count}"
+        )
+
+    for row in rows:
+        prefix = f"command {row.get('command_id', '')}: "
+        dry_run = _as_bool(row.get("dry_run"))
+        if dry_run is not True:
+            failures.append(prefix + "dry_run is not true")
+        if row.get("command_type") != "initialpose":
+            failures.append(prefix + "command_type is not initialpose")
+        if row.get("publish_topic") != args.expected_topic:
+            failures.append(prefix + f"publish_topic is not {args.expected_topic}")
+        if row.get("frame_id") != args.expected_frame_id:
+            failures.append(prefix + f"frame_id is not {args.expected_frame_id}")
+        if (
+            _as_bool(row.get("source_plan_row_accepted")) is True
+            and not args.allow_accepted_source_plan
+        ):
+            failures.append(prefix + "source_plan_row_accepted=true is not allowed")
+        if row.get("source_selection_source") == "oracle_rank" and not args.allow_oracle_selection:
+            failures.append(prefix + "oracle_rank selection is not allowed")
+
+        if row.get("status") == "dry_run_command_generated":
+            if row.get("rejection_reason") != "publish_disabled":
+                failures.append(prefix + "generated dry-run command must use publish_disabled")
+            for field in [
+                "stamp_sec",
+                "position_x",
+                "position_y",
+                "position_z",
+                "orientation_x",
+                "orientation_y",
+                "orientation_z",
+                "orientation_w",
+                "yaw_rad",
+            ]:
+                if _as_float(row.get(field)) is None:
+                    failures.append(prefix + f"{field} is missing or non-finite")
+            qx = _as_float(row.get("orientation_x"))
+            qy = _as_float(row.get("orientation_y"))
+            qz = _as_float(row.get("orientation_z"))
+            qw = _as_float(row.get("orientation_w"))
+            if None not in (qx, qy, qz, qw):
+                assert qx is not None and qy is not None and qz is not None and qw is not None
+                norm = math.sqrt(qx * qx + qy * qy + qz * qz + qw * qw)
+                if abs(norm - 1.0) > args.quaternion_norm_tolerance:
+                    failures.append(prefix + f"quaternion norm {norm:.9f} is not near 1.0")
+        elif row.get("status") == "rejected":
+            if not row.get("rejection_reason"):
+                warnings.append(prefix + "rejected command has empty rejection_reason")
+        else:
+            failures.append(prefix + f"unknown status: {row.get('status', '')}")
+
+    published_count = summary.get("published_count")
+    if published_count is not None:
+        try:
+            published_count_int = int(published_count)
+        except (TypeError, ValueError):
+            failures.append("summary published_count is not an integer")
+        else:
+            if published_count_int != 0 and not args.allow_published:
+                failures.append(f"summary published_count is not zero: {published_count_int}")
+    elif summary:
+        warnings.append("summary JSON has no published_count field")
+
+    return {
+        "validation_passed": not failures,
+        "failure_count": len(failures),
+        "warning_count": len(warnings),
+        "failures": failures,
+        "warnings": warnings,
+        "command_count": len(rows),
+        "dry_run_generated_count": len(generated_rows),
+        "status_counts": _counts(row.get("status", "") for row in rows),
+        "rejection_reason_counts": _counts(row.get("rejection_reason", "") for row in rows),
+        "source_selection_source_counts": _counts(
+            row.get("source_selection_source", "") for row in generated_rows
+        ),
+        "summary_published_count": published_count,
+    }
+
+
+def write_json(path: Path, data: Dict[str, Any], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output JSON already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_md(path: Path, data: Dict[str, Any], overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output Markdown already exists: {path}")
+    lines = [
+        "# Relocalization Reset Command Validation",
+        "",
+        f"- validation passed: `{str(data['validation_passed']).lower()}`",
+        f"- failures: `{data['failure_count']}`",
+        f"- warnings: `{data['warning_count']}`",
+        f"- commands: `{data['command_count']}`",
+        f"- dry-run generated: `{data['dry_run_generated_count']}`",
+        f"- summary published count: `{data['summary_published_count']}`",
+        f"- status counts: `{json.dumps(data['status_counts'], sort_keys=True)}`",
+        f"- rejection reasons: `{json.dumps(data['rejection_reason_counts'], sort_keys=True)}`",
+        f"- selected sources: `{json.dumps(data['source_selection_source_counts'], sort_keys=True)}`",
+        "",
+        "## Failures",
+        "",
+    ]
+    lines.extend(f"- {failure}" for failure in data["failures"]) if data["failures"] else lines.append("- none")
+    lines.extend(["", "## Warnings", ""])
+    lines.extend(f"- {warning}" for warning in data["warnings"]) if data["warnings"] else lines.append("- none")
+    lines.append("")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    commands_csv = Path(args.commands_csv).expanduser().resolve()
+    summary_json = Path(args.summary_json).expanduser().resolve() if args.summary_json else None
+    if not commands_csv.exists():
+        raise FileNotFoundError(f"commands CSV does not exist: {commands_csv}")
+    if summary_json is not None and not summary_json.exists():
+        raise FileNotFoundError(f"summary JSON does not exist: {summary_json}")
+
+    header, rows = _read_csv(commands_csv)
+    summary = _load_summary(summary_json)
+    result = validate(header, rows, summary, args)
+    result.update(
+        {
+            "commands_csv": str(commands_csv),
+            "summary_json": "" if summary_json is None else str(summary_json),
+            "notes": [
+                "this validator never publishes /initialpose",
+                "dry_run=true is required by default",
+                "published_count must be zero by default when summary JSON is provided",
+                "oracle_rank command provenance is rejected by default",
+            ],
+        }
+    )
+    if args.output_json:
+        write_json(Path(args.output_json).expanduser().resolve(), result, args.overwrite)
+    if args.output_md:
+        write_md(Path(args.output_md).expanduser().resolve(), result, args.overwrite)
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["validation_passed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/relocalization_ndt_score_jobs.cpp
+++ b/src/relocalization_ndt_score_jobs.cpp
@@ -1,0 +1,468 @@
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <Eigen/Geometry>
+#include <pcl/PCLPointCloud2.h>
+#include <pcl/common/io.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/io/ply_io.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include <pclomp/ndt_omp.h>
+#include <pclomp/ndt_omp_impl.hpp>
+#include <pclomp/voxel_grid_covariance_omp_impl.hpp>
+
+namespace
+{
+using Cloud = pcl::PointCloud<pcl::PointXYZI>;
+using CloudPtr = Cloud::Ptr;
+
+std::vector<std::string> split_csv_line(const std::string & line)
+{
+  std::vector<std::string> fields;
+  std::string field;
+  bool in_quotes = false;
+  for (std::size_t i = 0; i < line.size(); ++i) {
+    const char c = line[i];
+    if (c == '"') {
+      if (in_quotes && i + 1 < line.size() && line[i + 1] == '"') {
+        field.push_back('"');
+        ++i;
+      } else {
+        in_quotes = !in_quotes;
+      }
+    } else if (c == ',' && !in_quotes) {
+      fields.push_back(field);
+      field.clear();
+    } else {
+      field.push_back(c);
+    }
+  }
+  fields.push_back(field);
+  return fields;
+}
+
+std::string csv_escape(const std::string & value)
+{
+  if (value.find_first_of(",\"\n\r") == std::string::npos) {
+    return value;
+  }
+  std::string escaped = "\"";
+  for (const char c : value) {
+    if (c == '"') {
+      escaped += "\"\"";
+    } else {
+      escaped.push_back(c);
+    }
+  }
+  escaped.push_back('"');
+  return escaped;
+}
+
+std::vector<std::map<std::string, std::string>> read_csv(
+  const std::string & path,
+  std::vector<std::string> * header_out)
+{
+  std::ifstream stream(path);
+  if (!stream) {
+    throw std::runtime_error("failed to open input CSV: " + path);
+  }
+  std::string line;
+  if (!std::getline(stream, line)) {
+    throw std::runtime_error("empty input CSV: " + path);
+  }
+  if (!line.empty() && line.back() == '\r') {
+    line.pop_back();
+  }
+  std::vector<std::string> header = split_csv_line(line);
+  std::vector<std::map<std::string, std::string>> rows;
+  while (std::getline(stream, line)) {
+    if (!line.empty() && line.back() == '\r') {
+      line.pop_back();
+    }
+    if (line.empty()) {
+      continue;
+    }
+    const std::vector<std::string> values = split_csv_line(line);
+    std::map<std::string, std::string> row;
+    for (std::size_t i = 0; i < header.size(); ++i) {
+      row[header[i]] = i < values.size() ? values[i] : "";
+    }
+    rows.push_back(row);
+  }
+  *header_out = header;
+  return rows;
+}
+
+void write_csv(
+  const std::string & path,
+  const std::vector<std::string> & header,
+  const std::vector<std::map<std::string, std::string>> & rows)
+{
+  std::ofstream stream(path);
+  if (!stream) {
+    throw std::runtime_error("failed to open output CSV: " + path);
+  }
+  for (std::size_t i = 0; i < header.size(); ++i) {
+    if (i > 0) {
+      stream << ',';
+    }
+    stream << csv_escape(header[i]);
+  }
+  stream << '\n';
+  for (const auto & row : rows) {
+    for (std::size_t i = 0; i < header.size(); ++i) {
+      if (i > 0) {
+        stream << ',';
+      }
+      const auto iter = row.find(header[i]);
+      if (iter != row.end()) {
+        stream << csv_escape(iter->second);
+      }
+    }
+    stream << '\n';
+  }
+}
+
+double as_double(const std::map<std::string, std::string> & row, const std::string & key)
+{
+  const auto iter = row.find(key);
+  if (iter == row.end() || iter->second.empty()) {
+    throw std::runtime_error("missing numeric field: " + key);
+  }
+  return std::stod(iter->second);
+}
+
+std::string get_value(const std::map<std::string, std::string> & row, const std::string & key)
+{
+  const auto iter = row.find(key);
+  return iter == row.end() ? "" : iter->second;
+}
+
+bool has_field(const std::vector<pcl::PCLPointField> & fields, const std::string & name)
+{
+  return std::any_of(fields.begin(), fields.end(), [&](const auto & field) {
+    return field.name == name;
+  });
+}
+
+CloudPtr load_cloud_xyzi(const std::string & path)
+{
+  pcl::PCLPointCloud2 raw;
+  const std::string lower = [&]() {
+    std::string copy = path;
+    std::transform(copy.begin(), copy.end(), copy.begin(), [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+    });
+    return copy;
+  }();
+  int result = -1;
+  if (lower.size() >= 4 && lower.substr(lower.size() - 4) == ".pcd") {
+    result = pcl::io::loadPCDFile(path, raw);
+  } else if (lower.size() >= 4 && lower.substr(lower.size() - 4) == ".ply") {
+    result = pcl::io::loadPLYFile(path, raw);
+  } else {
+    throw std::runtime_error("unsupported point cloud suffix: " + path);
+  }
+  if (result != 0) {
+    throw std::runtime_error("failed to load point cloud: " + path);
+  }
+
+  CloudPtr cloud(new Cloud());
+  if (has_field(raw.fields, "intensity")) {
+    pcl::fromPCLPointCloud2(raw, *cloud);
+  } else {
+    pcl::PointCloud<pcl::PointXYZ> xyz;
+    pcl::fromPCLPointCloud2(raw, xyz);
+    cloud->reserve(xyz.size());
+    for (const auto & point : xyz.points) {
+      pcl::PointXYZI xyzi;
+      xyzi.x = point.x;
+      xyzi.y = point.y;
+      xyzi.z = point.z;
+      xyzi.intensity = 0.0F;
+      cloud->push_back(xyzi);
+    }
+  }
+  return cloud;
+}
+
+CloudPtr voxel_downsample(const CloudPtr & input, double leaf_size)
+{
+  if (leaf_size <= 0.0 || input->empty()) {
+    return input;
+  }
+  CloudPtr filtered(new Cloud());
+  pcl::VoxelGrid<pcl::PointXYZI> voxel;
+  voxel.setLeafSize(
+    static_cast<float>(leaf_size),
+    static_cast<float>(leaf_size),
+    static_cast<float>(leaf_size));
+  voxel.setInputCloud(input);
+  voxel.filter(*filtered);
+  return filtered;
+}
+
+CloudPtr crop_map(const CloudPtr & map, double x, double y, double radius)
+{
+  if (radius <= 0.0) {
+    return map;
+  }
+  const double r2 = radius * radius;
+  CloudPtr cropped(new Cloud());
+  cropped->reserve(map->size() / 10);
+  for (const auto & point : map->points) {
+    const double dx = static_cast<double>(point.x) - x;
+    const double dy = static_cast<double>(point.y) - y;
+    if (dx * dx + dy * dy <= r2) {
+      cropped->push_back(point);
+    }
+  }
+  return cropped;
+}
+
+Eigen::Matrix4f pose_matrix(double x, double y, double z, double yaw)
+{
+  Eigen::Matrix4f matrix = Eigen::Matrix4f::Identity();
+  const float c = static_cast<float>(std::cos(yaw));
+  const float s = static_cast<float>(std::sin(yaw));
+  matrix(0, 0) = c;
+  matrix(0, 1) = -s;
+  matrix(1, 0) = s;
+  matrix(1, 1) = c;
+  matrix(0, 3) = static_cast<float>(x);
+  matrix(1, 3) = static_cast<float>(y);
+  matrix(2, 3) = static_cast<float>(z);
+  return matrix;
+}
+
+double yaw_from_matrix(const Eigen::Matrix4f & matrix)
+{
+  return std::atan2(static_cast<double>(matrix(1, 0)), static_cast<double>(matrix(0, 0)));
+}
+
+void ensure_header_field(std::vector<std::string> * header, const std::string & field)
+{
+  if (std::find(header->begin(), header->end(), field) == header->end()) {
+    header->push_back(field);
+  }
+}
+
+struct Args
+{
+  std::string input_csv;
+  std::string output_csv;
+  int max_jobs{0};
+  double ndt_resolution{1.0};
+  double ndt_step_size{0.1};
+  double transform_epsilon{0.01};
+  int max_iterations{30};
+  int num_threads{1};
+  double scan_voxel_leaf_size{1.0};
+  double target_voxel_leaf_size{1.0};
+  double local_map_radius{150.0};
+  std::size_t min_target_points{100};
+  double score_gate_threshold{6.0};
+  double refinement_delta_gate_m{2.0};
+  double refinement_yaw_gate_rad{0.7853981633974483};
+};
+
+Args parse_args(int argc, char ** argv)
+{
+  Args args;
+  for (int i = 1; i < argc; ++i) {
+    const std::string key = argv[i];
+    auto require_value = [&](const std::string & option) -> std::string {
+      if (i + 1 >= argc) {
+        throw std::runtime_error("missing value for " + option);
+      }
+      return argv[++i];
+    };
+    if (key == "--input-csv") {
+      args.input_csv = require_value(key);
+    } else if (key == "--output-csv") {
+      args.output_csv = require_value(key);
+    } else if (key == "--max-jobs") {
+      args.max_jobs = std::stoi(require_value(key));
+    } else if (key == "--ndt-resolution") {
+      args.ndt_resolution = std::stod(require_value(key));
+    } else if (key == "--ndt-step-size") {
+      args.ndt_step_size = std::stod(require_value(key));
+    } else if (key == "--transform-epsilon") {
+      args.transform_epsilon = std::stod(require_value(key));
+    } else if (key == "--max-iterations") {
+      args.max_iterations = std::stoi(require_value(key));
+    } else if (key == "--num-threads") {
+      args.num_threads = std::stoi(require_value(key));
+    } else if (key == "--scan-voxel-leaf-size") {
+      args.scan_voxel_leaf_size = std::stod(require_value(key));
+    } else if (key == "--target-voxel-leaf-size") {
+      args.target_voxel_leaf_size = std::stod(require_value(key));
+    } else if (key == "--local-map-radius") {
+      args.local_map_radius = std::stod(require_value(key));
+    } else if (key == "--min-target-points") {
+      args.min_target_points = static_cast<std::size_t>(std::stoul(require_value(key)));
+    } else if (key == "--score-gate-threshold") {
+      args.score_gate_threshold = std::stod(require_value(key));
+    } else if (key == "--refinement-delta-gate-m") {
+      args.refinement_delta_gate_m = std::stod(require_value(key));
+    } else if (key == "--refinement-yaw-gate-rad") {
+      args.refinement_yaw_gate_rad = std::stod(require_value(key));
+    } else {
+      throw std::runtime_error("unknown argument: " + key);
+    }
+  }
+  if (args.input_csv.empty() || args.output_csv.empty()) {
+    throw std::runtime_error("--input-csv and --output-csv are required");
+  }
+  return args;
+}
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  try {
+    const Args args = parse_args(argc, argv);
+    std::vector<std::string> header;
+    auto rows = read_csv(args.input_csv, &header);
+    for (const std::string & field : {
+        "target_point_count", "source_point_count", "final_pose_x", "final_pose_y", "final_pose_z",
+        "final_yaw_rad", "score_gate_threshold", "refinement_delta_gate_m",
+        "refinement_yaw_gate_rad", "registration_gate_passed", "registration_gate_reason"}) {
+      ensure_header_field(&header, field);
+    }
+
+    std::unordered_map<std::string, CloudPtr> map_cache;
+    std::unordered_map<std::string, CloudPtr> scan_cache;
+    int processed = 0;
+    std::map<std::string, int> status_counts;
+
+    for (auto & row : rows) {
+      if (args.max_jobs > 0 && processed >= args.max_jobs) {
+        continue;
+      }
+      if (get_value(row, "status") != "scan_resolved_no_registration") {
+        continue;
+      }
+      const std::string scan_path = get_value(row, "scan_pcd_path");
+      const std::string map_path = get_value(row, "map_path");
+      if (scan_path.empty()) {
+        row["status"] = "registration_skipped";
+        row["rejection_reason"] = "scan_pcd_path_missing";
+        status_counts[row["status"]]++;
+        continue;
+      }
+
+      const auto started = std::chrono::steady_clock::now();
+      CloudPtr full_map;
+      if (map_cache.count(map_path) == 0) {
+        map_cache[map_path] = load_cloud_xyzi(map_path);
+      }
+      full_map = map_cache[map_path];
+      if (scan_cache.count(scan_path) == 0) {
+        scan_cache[scan_path] = load_cloud_xyzi(scan_path);
+      }
+      CloudPtr source = voxel_downsample(scan_cache[scan_path], args.scan_voxel_leaf_size);
+
+      const double x = as_double(row, "initial_pose_x");
+      const double y = as_double(row, "initial_pose_y");
+      const double z = as_double(row, "initial_pose_z");
+      const double yaw = as_double(row, "initial_yaw_rad");
+      CloudPtr target = crop_map(full_map, x, y, args.local_map_radius);
+      if (target->size() < args.min_target_points) {
+        row["status"] = "registration_target_too_small";
+        row["rejection_reason"] = "local_map_crop_too_small";
+        row["target_point_count"] = std::to_string(target->size());
+        row["source_point_count"] = std::to_string(source->size());
+        status_counts[row["status"]]++;
+        continue;
+      }
+      target = voxel_downsample(target, args.target_voxel_leaf_size);
+
+      pclomp::NormalDistributionsTransform<pcl::PointXYZI, pcl::PointXYZI> ndt;
+      ndt.setResolution(args.ndt_resolution);
+      ndt.setStepSize(args.ndt_step_size);
+      ndt.setTransformationEpsilon(args.transform_epsilon);
+      ndt.setMaximumIterations(args.max_iterations);
+      ndt.setNumThreads(std::max(1, args.num_threads));
+      ndt.setInputTarget(target);
+      ndt.setInputSource(source);
+
+      const Eigen::Matrix4f init = pose_matrix(x, y, z, yaw);
+      Cloud output;
+      ndt.align(output, init);
+      const Eigen::Matrix4f final = ndt.getFinalTransformation();
+      const Eigen::Matrix4f delta = init.inverse() * final;
+      const double fitness_score = ndt.getFitnessScore();
+      const double refinement_delta_m = delta.block<3, 1>(0, 3).norm();
+      const double refinement_delta_yaw_rad = std::abs(yaw_from_matrix(delta));
+      bool gate_passed = false;
+      std::string gate_reason;
+      if (!ndt.hasConverged()) {
+        gate_reason = "not_converged";
+      } else if (!std::isfinite(fitness_score) || fitness_score > args.score_gate_threshold) {
+        gate_reason = "score_above_threshold";
+      } else if (refinement_delta_m > args.refinement_delta_gate_m) {
+        gate_reason = "refinement_delta_above_threshold";
+      } else if (refinement_delta_yaw_rad > args.refinement_yaw_gate_rad) {
+        gate_reason = "refinement_yaw_above_threshold";
+      } else {
+        gate_passed = true;
+        gate_reason = "passed_reset_disabled";
+      }
+      const auto ended = std::chrono::steady_clock::now();
+      const double runtime_sec =
+        std::chrono::duration<double>(ended - started).count();
+
+      row["status"] = "registration_scored_no_reset";
+      row["rejection_reason"] = ndt.hasConverged() ? "reset_disabled" : "registration_not_converged";
+      row["converged"] = ndt.hasConverged() ? "true" : "false";
+      row["score"] = std::to_string(fitness_score);
+      row["overlap"] = "";
+      row["refinement_delta_m"] = std::to_string(refinement_delta_m);
+      row["refinement_delta_yaw_rad"] = std::to_string(refinement_delta_yaw_rad);
+      row["runtime_sec"] = std::to_string(runtime_sec);
+      row["target_point_count"] = std::to_string(target->size());
+      row["source_point_count"] = std::to_string(source->size());
+      row["final_pose_x"] = std::to_string(final(0, 3));
+      row["final_pose_y"] = std::to_string(final(1, 3));
+      row["final_pose_z"] = std::to_string(final(2, 3));
+      row["final_yaw_rad"] = std::to_string(yaw_from_matrix(final));
+      row["score_gate_threshold"] = std::to_string(args.score_gate_threshold);
+      row["refinement_delta_gate_m"] = std::to_string(args.refinement_delta_gate_m);
+      row["refinement_yaw_gate_rad"] = std::to_string(args.refinement_yaw_gate_rad);
+      row["registration_gate_passed"] = gate_passed ? "true" : "false";
+      row["registration_gate_reason"] = gate_reason;
+      status_counts[row["status"]]++;
+      ++processed;
+    }
+
+    write_csv(args.output_csv, header, rows);
+    std::cout << "{\"output_csv\":\"" << args.output_csv << "\",\"processed_jobs\":"
+              << processed << ",\"row_count\":" << rows.size() << ",\"status_counts\":{";
+    bool first = true;
+    for (const auto & [status, count] : status_counts) {
+      if (!first) {
+        std::cout << ',';
+      }
+      first = false;
+      std::cout << "\"" << status << "\":" << count;
+    }
+    std::cout << "}}" << std::endl;
+    return 0;
+  } catch (const std::exception & error) {
+    std::cerr << "error: " << error.what() << std::endl;
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary

Adds an experimental artifact-first relocalization evaluation pipeline for v1.1. The public endpoint is intentionally bounded to a validated dry-run `/initialpose` command artifact derived from NDT_OMP-scored route-grid candidates.

This does not claim automatic runtime recovery. Actual reset publication remains guarded, opt-in only, and outside the default public benchmark path.

## What Changed

- Added v1.1 relocalization boundary documentation and safe claim language.
- Added Boreas localizer-only and Koide Outdoor01 public-map failure-boundary starter manifests.
- Extended `benchmark_from_manifest` with opt-in health, candidate, registration scoring, reset plan, dry-run command, and validation artifact hooks.
- Added NDT_OMP registration scoring executable and supporting helper scripts.
- Kept guarded reset publication behind explicit `--execute`.
- Fixed public regression HDL candidate YAML generation to inject the real public HDL map path instead of using the placeholder config path.

## Validation

- `python3 -m py_compile scripts/*.py scripts/benchmark_from_manifest`
- `git diff --cached --check`
- v1.1 Boreas and Koide example manifests generated expected `--print-only` command chains
- `colcon build --symlink-install --packages-select lidar_localization_ros2`
- `ros2 run lidar_localization_ros2 run_public_regression_suite.sh`
- `ros2 run lidar_localization_ros2 run_nav2_reinit_supervisor_regression.sh`

Release summary artifacts report `overall_pass: True` for public and Nav2 regression suites.
