### PR TITLE
[codex] Split localization policies and add MID360 legged bringup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(tf2_sensor_msgs  REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(PCL REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(ndt_omp_ros2 REQUIRED)
 find_package(small_gicp QUIET CONFIG)
 find_package(nav2_util QUIET)
@@ -184,5 +185,294 @@ install(DIRECTORY
   param
   DESTINATION share/${PROJECT_NAME}/
 )
+
+if(BUILD_TESTING)
+  add_executable(test_registration_seed_policy
+    test/test_registration_seed_policy.cpp)
+  target_include_directories(test_registration_seed_policy PRIVATE
+    include)
+  add_test(
+    NAME registration_seed_policy
+    COMMAND test_registration_seed_policy
+  )
+
+  add_executable(test_scan_admission_policy
+    test/test_scan_admission_policy.cpp)
+  target_include_directories(test_scan_admission_policy PRIVATE
+    include)
+  add_test(
+    NAME scan_admission_policy
+    COMMAND test_scan_admission_policy
+  )
+
+  add_executable(test_ndt_initializer_policy
+    test/test_ndt_initializer_policy.cpp)
+  target_include_directories(test_ndt_initializer_policy PRIVATE
+    include)
+  add_test(
+    NAME ndt_initializer_policy
+    COMMAND test_ndt_initializer_policy
+  )
+
+  add_executable(test_registration_backend_policy
+    test/test_registration_backend_policy.cpp)
+  target_include_directories(test_registration_backend_policy PRIVATE
+    include)
+  add_test(
+    NAME registration_backend_policy
+    COMMAND test_registration_backend_policy
+  )
+
+  add_executable(test_alignment_diagnostics_policy
+    test/test_alignment_diagnostics_policy.cpp)
+  target_include_directories(test_alignment_diagnostics_policy PRIVATE
+    include)
+  add_test(
+    NAME alignment_diagnostics_policy
+    COMMAND test_alignment_diagnostics_policy
+  )
+
+  add_executable(test_alignment_diagnostic_ros_adapter
+    test/test_alignment_diagnostic_ros_adapter.cpp)
+  target_include_directories(test_alignment_diagnostic_ros_adapter PRIVATE
+    include)
+  ament_target_dependencies(test_alignment_diagnostic_ros_adapter
+    diagnostic_msgs)
+  add_test(
+    NAME alignment_diagnostic_ros_adapter
+    COMMAND test_alignment_diagnostic_ros_adapter
+  )
+
+  add_executable(test_alignment_status_policy
+    test/test_alignment_status_policy.cpp)
+  target_include_directories(test_alignment_status_policy PRIVATE
+    include)
+  add_test(
+    NAME alignment_status_policy
+    COMMAND test_alignment_status_policy
+  )
+
+  add_executable(test_alignment_attempt_policy
+    test/test_alignment_attempt_policy.cpp)
+  target_include_directories(test_alignment_attempt_policy PRIVATE
+    include)
+  target_link_libraries(test_alignment_attempt_policy
+    Eigen3::Eigen)
+  add_test(
+    NAME alignment_attempt_policy
+    COMMAND test_alignment_attempt_policy
+  )
+
+  add_executable(test_alignment_retry_policy
+    test/test_alignment_retry_policy.cpp)
+  target_include_directories(test_alignment_retry_policy PRIVATE
+    include)
+  add_test(
+    NAME alignment_retry_policy
+    COMMAND test_alignment_retry_policy
+  )
+
+  add_executable(test_alignment_pipeline_policy
+    test/test_alignment_pipeline_policy.cpp)
+  target_include_directories(test_alignment_pipeline_policy PRIVATE
+    include)
+  target_link_libraries(test_alignment_pipeline_policy
+    Eigen3::Eigen)
+  add_test(
+    NAME alignment_pipeline_policy
+    COMMAND test_alignment_pipeline_policy
+  )
+
+  add_executable(test_registration_observation_policy
+    test/test_registration_observation_policy.cpp)
+  target_include_directories(test_registration_observation_policy PRIVATE
+    include)
+  target_link_libraries(test_registration_observation_policy
+    Eigen3::Eigen)
+  add_test(
+    NAME registration_observation_policy
+    COMMAND test_registration_observation_policy
+  )
+
+  add_executable(test_pose_backend_selection_policy
+    test/test_pose_backend_selection_policy.cpp)
+  target_include_directories(test_pose_backend_selection_policy PRIVATE
+    include)
+  add_test(
+    NAME pose_backend_selection_policy
+    COMMAND test_pose_backend_selection_policy
+  )
+
+  add_executable(test_pose_backend_result_policy
+    test/test_pose_backend_result_policy.cpp)
+  target_include_directories(test_pose_backend_result_policy PRIVATE
+    include)
+  target_link_libraries(test_pose_backend_result_policy
+    Eigen3::Eigen)
+  add_test(
+    NAME pose_backend_result_policy
+    COMMAND test_pose_backend_result_policy
+  )
+
+  add_executable(test_imu_preintegration_guard_policy
+    test/test_imu_preintegration_guard_policy.cpp)
+  target_include_directories(test_imu_preintegration_guard_policy PRIVATE
+    include)
+  add_test(
+    NAME imu_preintegration_guard_policy
+    COMMAND test_imu_preintegration_guard_policy
+  )
+
+  add_executable(test_prediction_state_policy
+    test/test_prediction_state_policy.cpp)
+  target_include_directories(test_prediction_state_policy PRIVATE
+    include)
+  target_link_libraries(test_prediction_state_policy
+    Eigen3::Eigen)
+  add_test(
+    NAME prediction_state_policy
+    COMMAND test_prediction_state_policy
+  )
+
+  add_executable(test_pose_publish_policy
+    test/test_pose_publish_policy.cpp)
+  target_include_directories(test_pose_publish_policy PRIVATE
+    include)
+  ament_target_dependencies(test_pose_publish_policy
+    geometry_msgs
+    nav_msgs
+    tf2_geometry_msgs)
+  target_link_libraries(test_pose_publish_policy
+    Eigen3::Eigen)
+  add_test(
+    NAME pose_publish_policy
+    COMMAND test_pose_publish_policy
+  )
+
+  add_executable(test_pose_covariance_policy
+    test/test_pose_covariance_policy.cpp)
+  target_include_directories(test_pose_covariance_policy PRIVATE
+    include)
+  target_link_libraries(test_pose_covariance_policy
+    Eigen3::Eigen)
+  add_test(
+    NAME pose_covariance_policy
+    COMMAND test_pose_covariance_policy
+  )
+
+  add_executable(test_reinitialization_latch_policy
+    test/test_reinitialization_latch_policy.cpp)
+  target_include_directories(test_reinitialization_latch_policy PRIVATE
+    include)
+  add_test(
+    NAME reinitialization_latch_policy
+    COMMAND test_reinitialization_latch_policy
+  )
+
+  add_executable(test_reinitialization_request_output_policy
+    test/test_reinitialization_request_output_policy.cpp)
+  target_include_directories(test_reinitialization_request_output_policy PRIVATE
+    include)
+  add_test(
+    NAME reinitialization_request_output_policy
+    COMMAND test_reinitialization_request_output_policy
+  )
+
+  add_executable(test_recovery_supervisor_state_policy
+    test/test_recovery_supervisor_state_policy.cpp)
+  target_include_directories(test_recovery_supervisor_state_policy PRIVATE
+    include)
+  add_test(
+    NAME recovery_supervisor_state_policy
+    COMMAND test_recovery_supervisor_state_policy
+  )
+
+  add_executable(test_parameter_validation_policy
+    test/test_parameter_validation_policy.cpp)
+  target_include_directories(test_parameter_validation_policy PRIVATE
+    include)
+  add_test(
+    NAME parameter_validation_policy
+    COMMAND test_parameter_validation_policy
+  )
+
+  add_executable(test_point_cloud_conversion
+    test/test_point_cloud_conversion.cpp)
+  target_include_directories(test_point_cloud_conversion PRIVATE
+    include
+    ${PCL_INCLUDE_DIRS})
+  ament_target_dependencies(test_point_cloud_conversion
+    pcl_conversions
+    sensor_msgs)
+  target_link_libraries(test_point_cloud_conversion
+    ${PCL_LIBRARIES})
+  add_test(
+    NAME point_cloud_conversion
+    COMMAND test_point_cloud_conversion
+  )
+
+  add_executable(test_local_map_target_policy
+    test/test_local_map_target_policy.cpp)
+  target_include_directories(test_local_map_target_policy PRIVATE
+    include
+    ${PCL_INCLUDE_DIRS})
+  target_link_libraries(test_local_map_target_policy
+    ${PCL_LIBRARIES})
+  add_test(
+    NAME local_map_target_policy
+    COMMAND test_local_map_target_policy
+  )
+
+  add_executable(test_map_initialization_policy
+    test/test_map_initialization_policy.cpp)
+  target_include_directories(test_map_initialization_policy PRIVATE
+    include
+    ${PCL_INCLUDE_DIRS})
+  ament_target_dependencies(test_map_initialization_policy
+    pcl_conversions
+    sensor_msgs)
+  target_link_libraries(test_map_initialization_policy
+    ${PCL_LIBRARIES})
+  add_test(
+    NAME map_initialization_policy
+    COMMAND test_map_initialization_policy
+  )
+
+  add_executable(test_measurement_gate_policy
+    test/test_measurement_gate_policy.cpp)
+  target_include_directories(test_measurement_gate_policy PRIVATE
+    include)
+  add_test(
+    NAME measurement_gate_policy
+    COMMAND test_measurement_gate_policy
+  )
+
+  add_executable(test_localization_update_policy
+    test/test_localization_update_policy.cpp)
+  target_include_directories(test_localization_update_policy PRIVATE
+    include)
+  add_test(
+    NAME localization_update_policy
+    COMMAND test_localization_update_policy
+  )
+
+  add_executable(test_scan_preprocessing_policy
+    test/test_scan_preprocessing_policy.cpp)
+  target_include_directories(test_scan_preprocessing_policy PRIVATE
+    include)
+  add_test(
+    NAME scan_preprocessing_policy
+    COMMAND test_scan_preprocessing_policy
+  )
+
+  add_executable(test_recovery_supervisor
+    test/test_recovery_supervisor.cpp)
+  target_include_directories(test_recovery_supervisor PRIVATE
+    include)
+  add_test(
+    NAME recovery_supervisor
+    COMMAND test_recovery_supervisor
+  )
+endif()
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 SET(CMAKE_CXX_FLAGS "-O2 -g ${CMAKE_CXX_FLAGS}")
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
@@ -116,6 +117,7 @@ install(TARGETS
 install(PROGRAMS
   scripts/benchmark_analyze_drift_window
   scripts/benchmark_compare_runs
+  scripts/check_mid360_legged_bringup.py
   scripts/compare_nav2_reinit_supervisor_runs.py
   scripts/convert_boreas_sequence_to_rosbag2.py
   scripts/benchmark_extract_pose_reference_from_rosbag2
@@ -177,6 +179,11 @@ install(PROGRAMS
   scripts/run_autoware_istanbul_60s_predictor_compare.sh
   scripts/run_hdl_localization_docker_benchmark.sh
   DESTINATION lib/${PROJECT_NAME})
+
+install(DIRECTORY
+  scripts/lidar_localization_mid360
+  DESTINATION lib/${PROJECT_NAME}
+  PATTERN "__pycache__" EXCLUDE)
 
 install(DIRECTORY
   launch
@@ -472,6 +479,10 @@ if(BUILD_TESTING)
   add_test(
     NAME recovery_supervisor
     COMMAND test_recovery_supervisor
+  )
+  add_test(
+    NAME mid360_bringup_model
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_mid360_bringup_model.py
   )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Then choose the path that matches what you want to do:
 |---|---|
 | Build the package in this workspace | [Local Build](docs/local_build.md) |
 | Launch the LiDAR localizer for Nav2 | [Nav2 launch](#nav2-launch) |
+| Bring up Jetson + MID-360 on a legged robot | [MID-360 legged bringup](docs/mid360_legged_jetson.md) |
 | Run a self-contained Nav2 smoke path | [Recommended entry points](docs/v1_status.md#recommended-entry-points) |
 | Run public replay/regression checks | [Benchmarking](#benchmarking) |
 | Evaluate a rosbag against reference poses | [Benchmarking guide](docs/benchmarking.md) |
@@ -186,6 +187,23 @@ Detailed health, relocalization, registration-scoring, and dry-run reset artifac
 |reinitialization_trigger_fitness_explosion_threshold|double|1000.0|fitness threshold treated as a catastrophic divergence for reinitialization scoring|
 |enable_timer_publishing|bool|false|if true, publish tf and pose on a set timer frequency|
 |pose_publish_frequency|double|10.0|publishing frequency if enable_timer_publishing is true|
+
+## MID-360 legged launch
+
+For Jetson + Livox MID-360 on quadruped or biped robots, start from:
+
+```bash
+ros2 launch lidar_localization_ros2 mid360_legged_localization.launch.py \
+  map_path:=/absolute/path/to/map.pcd \
+  cloud_topic:=/livox/points \
+  imu_topic:=/livox/imu
+```
+
+This uses `param/mid360_legged.yaml`, publishes `map -> odom` by default, and assumes the robot
+state estimator publishes `odom -> base_link`. See
+[docs/mid360_legged_jetson.md](docs/mid360_legged_jetson.md) for frame, IMU, and Jetson tuning notes.
+After launch, `ros2 run lidar_localization_ros2 check_mid360_legged_bringup.py` checks the MID-360
+topics, required TFs, and localizer output.
 
 ## Nav2 launch
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Detailed health, relocalization, registration-scoring, and dry-run reset artifac
 |max_twist_prediction_dt|double|0.5|maximum time span integrated in one twist-based prediction step[sec]|
 |use_imu|bool|false|whether 9-axis imu is used or not for point cloud distortion correction|
 |use_imu_preintegration|bool|true|enable IMU preintegration for seed prediction; if no new IMU samples have arrived, the node falls back to the twist/previous-delta seed path, and if the IMU smoother diverges it disables IMU preintegration for the remainder of the run|
+|imu_preintegration_use_base_frame_transform|bool|false|rotate IMU gyro and acceleration samples into `base_frame_id` with TF before preintegration|
 |imu_prediction_correction_guard_translation_m|double|2.0|disable IMU preintegration for the remainder of the run when an IMU-predicted scan needs a larger translation correction than this threshold[m]|
 |imu_prediction_correction_guard_yaw_deg|double|4.0|disable IMU preintegration for the remainder of the run when an IMU-predicted scan needs a larger yaw correction than this threshold[deg]|
 |enable_scan_voxel_filter|bool|true|apply the built-in `VoxelGrid` downsampling pass to each incoming scan before range filtering|

--- a/docs/mid360_legged_jetson.md
+++ b/docs/mid360_legged_jetson.md
@@ -1,0 +1,174 @@
+# Jetson MID-360 Legged Robot Bringup
+
+This path targets Jetson-class compute, a Livox MID-360 pointcloud, and
+quadruped or biped robots. It is a localization stack boundary: it does not
+own walking control, motor state estimation, global planning, or the MID-360
+driver process.
+
+## Runtime Contract
+
+Required inputs:
+
+- `PointCloud2` from the MID-360, default launch remap: `/livox/points`
+- optional MID-360 IMU, default launch remap: `/livox/imu`
+- optional body twist as `TwistWithCovarianceStamped`, default launch remap: `/twist`
+- an odometry source publishing `odom -> base_link` when `enable_map_odom_tf:=true`
+- an initial pose on `/initialpose`, unless `set_initial_pose:=true`
+- a prebuilt `.pcd` or `.ply` pointcloud map
+
+Published outputs:
+
+- `/localization/pose_with_covariance`
+- `/path`
+- `/alignment_status`
+- `/reinitialization_requested`
+- `map -> odom` TF by default
+- `/initial_map`
+
+## Launch
+
+Use the MID-360 legged preset:
+
+```bash
+ros2 launch lidar_localization_ros2 mid360_legged_localization.launch.py \
+  map_path:=/absolute/path/to/map.pcd \
+  cloud_topic:=/livox/points \
+  imu_topic:=/livox/imu \
+  lidar_frame_id:=livox_frame \
+  lidar_tf_x:=0.0 lidar_tf_y:=0.0 lidar_tf_z:=0.0 \
+  lidar_tf_roll:=0.0 lidar_tf_pitch:=0.0 lidar_tf_yaw:=0.0
+```
+
+If your Livox driver publishes a different `PointCloud2` topic, override
+`cloud_topic`. If the driver publishes a Livox custom message instead of
+`sensor_msgs/msg/PointCloud2`, configure the driver or add a bridge so this
+localizer receives `PointCloud2`.
+
+For the first field run, either publish `/initialpose` from RViz/Nav2 or pass a
+known starting pose:
+
+```bash
+ros2 launch lidar_localization_ros2 mid360_legged_localization.launch.py \
+  map_path:=/absolute/path/to/map.pcd \
+  set_initial_pose:=true \
+  initial_pose_x:=0.0 initial_pose_y:=0.0 initial_pose_z:=0.0 \
+  initial_pose_qx:=0.0 initial_pose_qy:=0.0 initial_pose_qz:=0.0 initial_pose_qw:=1.0
+```
+
+## Frames
+
+Recommended TF tree:
+
+```text
+map -> odom -> base_link -> livox_frame
+```
+
+The robot state estimator should publish `odom -> base_link`. This package
+publishes `map -> odom`. The launch file can publish a static
+`base_link -> livox_frame`, but the default zero transform is only a placeholder;
+replace it with measured MID-360 extrinsics.
+
+The preset enables `imu_preintegration_use_base_frame_transform`. That means IMU
+gyro and acceleration samples are rotated into `base_frame_id` before
+preintegration when the IMU message frame differs from `base_link`. If the IMU
+message uses a separate frame, publish it:
+
+```bash
+ros2 launch lidar_localization_ros2 mid360_legged_localization.launch.py \
+  map_path:=/absolute/path/to/map.pcd \
+  publish_imu_tf:=true \
+  imu_frame_id:=livox_imu_frame \
+  imu_tf_x:=0.0 imu_tf_y:=0.0 imu_tf_z:=0.0 \
+  imu_tf_roll:=0.0 imu_tf_pitch:=0.0 imu_tf_yaw:=0.0
+```
+
+If you are not confident in the IMU frame or extrinsics yet, start with:
+
+```bash
+use_imu_preintegration:=false
+```
+
+## Jetson Defaults
+
+`param/mid360_legged.yaml` starts conservative:
+
+- `NDT_OMP` with `ndt_num_threads: 4`
+- scan voxel leaf size `0.25 m`
+- range clamp `0.8 m` to `60 m`
+- local map crop radius `80 m`
+- timer publishing at `20 Hz` for stable `map -> odom`
+- twist prediction enabled, but angular twist prediction disabled
+- IMU preintegration enabled with correction guards
+
+For a smaller Jetson or thermal-limited run, first reduce CPU cost:
+
+```bash
+ndt_num_threads:=2
+```
+
+Then increase `voxel_leaf_size` or reduce `scan_max_range` in a copied YAML if
+CPU is still saturated. For Jetson Orin-class devices with cooling, `4` to `6`
+threads is usually the first range to test before widening map crop or scan
+range.
+
+## Bringup Checks
+
+Before starting localization:
+
+```bash
+ros2 topic hz /livox/points
+ros2 topic echo /livox/imu --once
+ros2 run tf2_ros tf2_echo base_link livox_frame
+ros2 run tf2_ros tf2_echo odom base_link
+```
+
+After launch:
+
+```bash
+ros2 topic echo /alignment_status --once
+ros2 topic echo /localization/pose_with_covariance --once
+ros2 run tf2_ros tf2_echo map odom
+```
+
+Or run the bringup doctor:
+
+```bash
+ros2 run lidar_localization_ros2 check_mid360_legged_bringup.py \
+  --duration-sec 5 \
+  --cloud-topic /livox/points \
+  --imu-topic /livox/imu \
+  --base-frame base_link \
+  --lidar-frame livox_frame
+```
+
+For a stricter check after localization is active and the robot estimator is
+publishing odometry:
+
+```bash
+ros2 run lidar_localization_ros2 check_mid360_legged_bringup.py \
+  --require-imu \
+  --require-map-odom-tf \
+  --require-localization-output
+```
+
+Watch `/alignment_status` first. If fitness is rejected repeatedly, check the
+initial pose, map frame, pointcloud frame, and whether the MID-360 scan is being
+converted to `PointCloud2` with `x/y/z` fields.
+
+## Scope Boundary
+
+In scope:
+
+- MID-360 pointcloud localization against an existing 3D map
+- `map -> odom` publication for a legged robot stack
+- IMU/twist-aided registration seeds
+- Jetson-oriented launch and parameters
+- diagnostics for rejected alignments and reinitialization requests
+
+Out of scope:
+
+- walking control
+- motor or contact state estimation
+- Nav2 global/local planning
+- live SLAM map building as part of this launch
+- cloud services or UI

--- a/include/lidar_localization/alignment_attempt_policy.hpp
+++ b/include/lidar_localization/alignment_attempt_policy.hpp
@@ -1,0 +1,72 @@
+#ifndef LIDAR_LOCALIZATION_ALIGNMENT_ATTEMPT_POLICY_HPP_
+#define LIDAR_LOCALIZATION_ALIGNMENT_ATTEMPT_POLICY_HPP_
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include <Eigen/Dense>
+
+namespace lidar_localization
+{
+
+struct AlignmentSeedMetrics
+{
+  double translation_since_accept_m{std::numeric_limits<double>::quiet_NaN()};
+  double yaw_since_accept_deg{std::numeric_limits<double>::quiet_NaN()};
+  double accepted_gap_sec{std::numeric_limits<double>::quiet_NaN()};
+};
+
+struct AlignmentCorrectionMetrics
+{
+  double translation_m{std::numeric_limits<double>::quiet_NaN()};
+  double yaw_deg{std::numeric_limits<double>::quiet_NaN()};
+};
+
+inline double poseDeltaTranslationNormM(const Eigen::Matrix4f & delta_matrix)
+{
+  return static_cast<double>(delta_matrix.block<3, 1>(0, 3).norm());
+}
+
+inline double poseDeltaYawAbsDeg(const Eigen::Matrix4f & delta_matrix)
+{
+  constexpr double kRadiansToDegrees = 180.0 / 3.14159265358979323846;
+  return std::abs(
+    std::atan2(
+      static_cast<double>(delta_matrix(1, 0)),
+      static_cast<double>(delta_matrix(0, 0)))) * kRadiansToDegrees;
+}
+
+inline AlignmentSeedMetrics computeAlignmentSeedMetrics(
+  bool have_last_accepted_pose,
+  const Eigen::Matrix4f & last_accepted_pose_matrix,
+  const Eigen::Matrix4f & init_guess,
+  double scan_stamp_sec,
+  double last_accepted_pose_time_sec)
+{
+  AlignmentSeedMetrics metrics;
+  if (!have_last_accepted_pose) {
+    return metrics;
+  }
+
+  const Eigen::Matrix4f seed_delta_matrix =
+    last_accepted_pose_matrix.inverse() * init_guess;
+  metrics.translation_since_accept_m = poseDeltaTranslationNormM(seed_delta_matrix);
+  metrics.yaw_since_accept_deg = poseDeltaYawAbsDeg(seed_delta_matrix);
+  metrics.accepted_gap_sec = std::max(0.0, scan_stamp_sec - last_accepted_pose_time_sec);
+  return metrics;
+}
+
+inline AlignmentCorrectionMetrics computeAlignmentCorrectionMetrics(
+  const Eigen::Matrix4f & init_guess,
+  const Eigen::Matrix4f & final_transformation)
+{
+  const Eigen::Matrix4f correction_matrix = init_guess.inverse() * final_transformation;
+  return {
+    poseDeltaTranslationNormM(correction_matrix),
+    poseDeltaYawAbsDeg(correction_matrix)};
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_ALIGNMENT_ATTEMPT_POLICY_HPP_

--- a/include/lidar_localization/alignment_diagnostic_ros_adapter.hpp
+++ b/include/lidar_localization/alignment_diagnostic_ros_adapter.hpp
@@ -1,0 +1,41 @@
+#ifndef LIDAR_LOCALIZATION_ALIGNMENT_DIAGNOSTIC_ROS_ADAPTER_HPP_
+#define LIDAR_LOCALIZATION_ALIGNMENT_DIAGNOSTIC_ROS_ADAPTER_HPP_
+
+#include "lidar_localization/alignment_diagnostics_policy.hpp"
+
+#include <diagnostic_msgs/msg/key_value.hpp>
+
+#include <vector>
+
+namespace lidar_localization
+{
+
+inline diagnostic_msgs::msg::KeyValue makeRosDiagnosticKeyValue(
+  const DiagnosticKeyValue & value)
+{
+  diagnostic_msgs::msg::KeyValue key_value;
+  key_value.key = value.first;
+  key_value.value = value.second;
+  return key_value;
+}
+
+inline std::vector<diagnostic_msgs::msg::KeyValue> makeRosDiagnosticKeyValues(
+  const std::vector<DiagnosticKeyValue> & values)
+{
+  std::vector<diagnostic_msgs::msg::KeyValue> key_values;
+  key_values.reserve(values.size());
+  for (const auto & value : values) {
+    key_values.push_back(makeRosDiagnosticKeyValue(value));
+  }
+  return key_values;
+}
+
+inline std::vector<diagnostic_msgs::msg::KeyValue> makeRosAlignmentDiagnosticKeyValues(
+  const AlignmentDiagnosticValuesInput & input)
+{
+  return makeRosDiagnosticKeyValues(buildAlignmentDiagnosticValues(input));
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_ALIGNMENT_DIAGNOSTIC_ROS_ADAPTER_HPP_

--- a/include/lidar_localization/alignment_diagnostics_policy.hpp
+++ b/include/lidar_localization/alignment_diagnostics_policy.hpp
@@ -1,0 +1,155 @@
+#ifndef LIDAR_LOCALIZATION_ALIGNMENT_DIAGNOSTICS_POLICY_HPP_
+#define LIDAR_LOCALIZATION_ALIGNMENT_DIAGNOSTICS_POLICY_HPP_
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace lidar_localization
+{
+
+using DiagnosticKeyValue = std::pair<std::string, std::string>;
+
+struct EffectiveReinitializationMetricsInput
+{
+  double accepted_gap_sec{NAN};
+  double seed_translation_since_accept_m{NAN};
+  bool have_last_accepted_pose{false};
+  double stamp_sec{0.0};
+  double last_accepted_pose_time_sec{0.0};
+  double fallback_seed_translation_since_accept_m{NAN};
+};
+
+struct EffectiveReinitializationMetrics
+{
+  double accepted_gap_sec{NAN};
+  double seed_translation_since_accept_m{NAN};
+};
+
+struct AlignmentDiagnosticValuesInput
+{
+  std::string registration_method;
+  bool has_converged{false};
+  double fitness_score{NAN};
+  double score_threshold{NAN};
+  double effective_score_threshold{NAN};
+  bool post_reject_strict_active{false};
+  bool open_loop_strict_active{false};
+  bool borderline_seed_gate_active{false};
+  double alignment_time_sec{0.0};
+  std::size_t filtered_point_count{0};
+  double correction_translation_m{NAN};
+  double correction_yaw_deg{NAN};
+  double seed_translation_since_accept_m{NAN};
+  double seed_yaw_since_accept_deg{NAN};
+  double accepted_gap_sec{NAN};
+  std::size_t consecutive_rejected_updates{0};
+  std::string recovery_state;
+  std::string recovery_action;
+  double recovery_state_age_sec{0.0};
+  std::size_t recovery_state_transition_count{0};
+  bool imu_prediction_active{false};
+  bool reinitialization_requested{false};
+  std::string reinitialization_request_reason;
+  double reinitialization_request_score{0.0};
+  bool reinitialization_request_latched{false};
+  double reinitialization_request_latch_age_sec{0.0};
+  bool map_received{false};
+  bool initialpose_received{false};
+};
+
+inline const char * boolString(bool value)
+{
+  return value ? "true" : "false";
+}
+
+inline double nonnegativeElapsedOrZero(double stamp_sec, double start_sec)
+{
+  return start_sec > 0.0 ? std::max(0.0, stamp_sec - start_sec) : 0.0;
+}
+
+inline EffectiveReinitializationMetrics resolveEffectiveReinitializationMetrics(
+  const EffectiveReinitializationMetricsInput & input)
+{
+  EffectiveReinitializationMetrics metrics;
+  metrics.accepted_gap_sec = input.accepted_gap_sec;
+  if (!std::isfinite(metrics.accepted_gap_sec) && input.have_last_accepted_pose) {
+    metrics.accepted_gap_sec =
+      std::max(0.0, input.stamp_sec - input.last_accepted_pose_time_sec);
+  }
+
+  metrics.seed_translation_since_accept_m = input.seed_translation_since_accept_m;
+  if (
+    !std::isfinite(metrics.seed_translation_since_accept_m) &&
+    input.have_last_accepted_pose)
+  {
+    metrics.seed_translation_since_accept_m =
+      input.fallback_seed_translation_since_accept_m;
+  }
+  return metrics;
+}
+
+inline std::vector<DiagnosticKeyValue> buildAlignmentDiagnosticValues(
+  const AlignmentDiagnosticValuesInput & input)
+{
+  std::vector<DiagnosticKeyValue> values;
+  values.reserve(31);
+  auto append = [&values](const std::string & key, const std::string & value) {
+      values.emplace_back(key, value);
+    };
+
+  append("registration_method", input.registration_method);
+  append("has_converged", boolString(input.has_converged));
+  append("fitness_score", std::to_string(input.fitness_score));
+  append("score_threshold", std::to_string(input.score_threshold));
+  append("effective_score_threshold", std::to_string(input.effective_score_threshold));
+  append(
+    "post_reject_strict_score_threshold_active",
+    boolString(input.post_reject_strict_active));
+  append(
+    "open_loop_strict_score_threshold_active",
+    boolString(input.open_loop_strict_active));
+  append(
+    "borderline_seed_rejection_gate_active",
+    boolString(input.borderline_seed_gate_active));
+  append("alignment_time_sec", std::to_string(input.alignment_time_sec));
+  append("filtered_point_count", std::to_string(input.filtered_point_count));
+  append("correction_translation_m", std::to_string(input.correction_translation_m));
+  append("correction_yaw_deg", std::to_string(input.correction_yaw_deg));
+  append(
+    "seed_translation_since_accept_m",
+    std::to_string(input.seed_translation_since_accept_m));
+  append("seed_yaw_since_accept_deg", std::to_string(input.seed_yaw_since_accept_deg));
+  append("accepted_gap_sec", std::to_string(input.accepted_gap_sec));
+  append(
+    "consecutive_rejected_updates",
+    std::to_string(input.consecutive_rejected_updates));
+  append("recovery_state", input.recovery_state);
+  append("recovery_action", input.recovery_action);
+  append("recovery_state_age_sec", std::to_string(input.recovery_state_age_sec));
+  append(
+    "recovery_state_transition_count",
+    std::to_string(input.recovery_state_transition_count));
+  append("imu_prediction_active", boolString(input.imu_prediction_active));
+  append("reinitialization_requested", boolString(input.reinitialization_requested));
+  append("reinitialization_request_reason", input.reinitialization_request_reason);
+  append(
+    "reinitialization_request_score",
+    std::to_string(input.reinitialization_request_score));
+  append(
+    "reinitialization_request_latched",
+    boolString(input.reinitialization_request_latched));
+  append(
+    "reinitialization_request_latch_age_sec",
+    std::to_string(input.reinitialization_request_latch_age_sec));
+  append("map_received", boolString(input.map_received));
+  append("initialpose_received", boolString(input.initialpose_received));
+  return values;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_ALIGNMENT_DIAGNOSTICS_POLICY_HPP_

--- a/include/lidar_localization/alignment_pipeline_policy.hpp
+++ b/include/lidar_localization/alignment_pipeline_policy.hpp
@@ -1,0 +1,173 @@
+#ifndef LIDAR_LOCALIZATION_ALIGNMENT_PIPELINE_POLICY_HPP_
+#define LIDAR_LOCALIZATION_ALIGNMENT_PIPELINE_POLICY_HPP_
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string>
+
+#include <Eigen/Dense>
+
+#include "lidar_localization/alignment_retry_policy.hpp"
+#include "lidar_localization/measurement_gate_policy.hpp"
+
+namespace lidar_localization
+{
+
+constexpr std::uint8_t kAlignmentPipelineError = 2;
+
+struct AlignmentAttempt
+{
+  bool target_ready{false};
+  bool has_converged{false};
+  double alignment_time_sec{0.0};
+  double fitness_score{std::numeric_limits<double>::quiet_NaN()};
+  Eigen::Matrix4f init_guess{Eigen::Matrix4f::Identity()};
+  Eigen::Matrix4f final_transformation{Eigen::Matrix4f::Identity()};
+  double correction_translation_m{std::numeric_limits<double>::quiet_NaN()};
+  double correction_yaw_deg{std::numeric_limits<double>::quiet_NaN()};
+  double seed_translation_since_accept_m{std::numeric_limits<double>::quiet_NaN()};
+  double seed_yaw_since_accept_deg{std::numeric_limits<double>::quiet_NaN()};
+  double accepted_gap_sec{std::numeric_limits<double>::quiet_NaN()};
+};
+
+struct AlignmentPipelineInput
+{
+  bool have_last_accepted_pose{false};
+  std::size_t consecutive_rejected_updates{0};
+  double scan_stamp_sec{std::numeric_limits<double>::quiet_NaN()};
+  double last_accepted_pose_time_sec{std::numeric_limits<double>::quiet_NaN()};
+  RecoveryRetryFromLastPoseParams recovery_retry_params;
+};
+
+struct AlignmentPipelineResult
+{
+  AlignmentAttempt selected_attempt;
+  MeasurementGateDecision gate_result;
+  bool recovered_by_retry_from_last_pose{false};
+  bool should_continue{true};
+  bool should_advance_prediction_without_measurement{false};
+  std::uint8_t status_level{kMeasurementGateOk};
+  std::string status_message{"ok"};
+};
+
+struct AlignmentPipelineHandlingDecision
+{
+  bool log_recovery_retry_success{false};
+  bool publish_terminal_status{false};
+  bool warn_registration_not_converged{false};
+  bool advance_prediction_without_measurement{false};
+  bool continue_to_backend{true};
+};
+
+inline AlignmentPipelineResult makeTerminalAlignmentPipelineResult(
+  const AlignmentAttempt & attempt,
+  const std::string & status_message)
+{
+  AlignmentPipelineResult result;
+  result.selected_attempt = attempt;
+  result.should_continue = false;
+  result.should_advance_prediction_without_measurement = true;
+  result.status_level = kAlignmentPipelineError;
+  result.status_message = status_message;
+  return result;
+}
+
+inline AlignmentPipelineHandlingDecision decideAlignmentPipelineHandling(
+  const AlignmentPipelineResult & result)
+{
+  AlignmentPipelineHandlingDecision decision;
+  decision.log_recovery_retry_success = result.recovered_by_retry_from_last_pose;
+  decision.publish_terminal_status = !result.should_continue;
+  decision.warn_registration_not_converged =
+    decision.publish_terminal_status && result.status_message == "registration_not_converged";
+  decision.advance_prediction_without_measurement =
+    decision.publish_terminal_status && result.should_advance_prediction_without_measurement;
+  decision.continue_to_backend = result.should_continue;
+  return decision;
+}
+
+inline void syncPipelineStatusFromGate(AlignmentPipelineResult & result)
+{
+  result.status_level = result.gate_result.status_level;
+  result.status_message = result.gate_result.status_message;
+}
+
+template<typename RetryAttemptFn, typename GateEvaluatorFn>
+AlignmentPipelineResult runAlignmentPipeline(
+  const AlignmentAttempt & primary_attempt,
+  const AlignmentPipelineInput & input,
+  RetryAttemptFn retry_attempt_fn,
+  GateEvaluatorFn evaluate_gate)
+{
+  AlignmentPipelineResult result;
+  result.selected_attempt = primary_attempt;
+
+  auto try_recovery_retry = [&]() {
+      const double fallback_accepted_gap_sec =
+        computeRecoveryRetryFallbackAcceptedGapSec(
+          input.have_last_accepted_pose,
+          input.scan_stamp_sec,
+          input.last_accepted_pose_time_sec);
+      const auto retry_decision = decideRecoveryRetryFromLastPose(
+        input.recovery_retry_params,
+        makeRecoveryRetryFromLastPoseInput(
+          input.have_last_accepted_pose,
+          input.consecutive_rejected_updates,
+          result.selected_attempt.accepted_gap_sec,
+          fallback_accepted_gap_sec,
+          result.selected_attempt.seed_translation_since_accept_m));
+      if (!retry_decision.should_retry) {
+        return false;
+      }
+
+      const AlignmentAttempt retry_attempt = retry_attempt_fn();
+      if (!isRecoveryRetryAlignmentUsable(
+          retry_attempt.target_ready, retry_attempt.has_converged))
+      {
+        return false;
+      }
+
+      const MeasurementGateDecision retry_gate = evaluate_gate(retry_attempt);
+      if (!shouldUseRecoveryRetryResult(
+          retry_attempt.target_ready,
+          retry_attempt.has_converged,
+          retry_gate.reject_measurement))
+      {
+        return false;
+      }
+
+      result.selected_attempt = retry_attempt;
+      result.gate_result = makeRecoveryRetryRecoveredGateDecision(retry_gate);
+      result.recovered_by_retry_from_last_pose = true;
+      syncPipelineStatusFromGate(result);
+      return true;
+    };
+
+  if (!result.selected_attempt.target_ready) {
+    if (try_recovery_retry()) {
+      return result;
+    }
+    return makeTerminalAlignmentPipelineResult(
+      result.selected_attempt, "local_map_crop_too_small");
+  }
+
+  if (!result.selected_attempt.has_converged) {
+    if (try_recovery_retry()) {
+      return result;
+    }
+    return makeTerminalAlignmentPipelineResult(
+      result.selected_attempt, "registration_not_converged");
+  }
+
+  result.gate_result = evaluate_gate(result.selected_attempt);
+  syncPipelineStatusFromGate(result);
+  if (result.gate_result.reject_measurement) {
+    (void)try_recovery_retry();
+  }
+  return result;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_ALIGNMENT_PIPELINE_POLICY_HPP_

--- a/include/lidar_localization/alignment_retry_policy.hpp
+++ b/include/lidar_localization/alignment_retry_policy.hpp
@@ -1,0 +1,147 @@
+#ifndef LIDAR_LOCALIZATION_ALIGNMENT_RETRY_POLICY_HPP_
+#define LIDAR_LOCALIZATION_ALIGNMENT_RETRY_POLICY_HPP_
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <string>
+
+#include "lidar_localization/measurement_gate_policy.hpp"
+
+namespace lidar_localization
+{
+
+struct RecoveryRetryFromLastPoseParams
+{
+  bool enable{false};
+  int min_rejections{1};
+  double max_accepted_gap_sec{1.0};
+  double max_seed_translation_m{1000000000.0};
+};
+
+struct RecoveryRetryFromLastPoseInput
+{
+  bool have_last_accepted_pose{false};
+  std::size_t consecutive_rejected_updates{0};
+  double selected_accepted_gap_sec{std::numeric_limits<double>::quiet_NaN()};
+  double fallback_accepted_gap_sec{std::numeric_limits<double>::quiet_NaN()};
+  double selected_seed_translation_since_accept_m{
+    std::numeric_limits<double>::quiet_NaN()};
+};
+
+struct RecoveryRetryFromLastPoseDecision
+{
+  bool should_retry{false};
+  std::string reason{"disabled"};
+  double accepted_gap_sec{std::numeric_limits<double>::quiet_NaN()};
+};
+
+inline RecoveryRetryFromLastPoseParams makeRecoveryRetryFromLastPoseParams(
+  bool enable,
+  int min_rejections,
+  double max_accepted_gap_sec,
+  double max_seed_translation_m)
+{
+  return {
+    enable,
+    min_rejections,
+    max_accepted_gap_sec,
+    max_seed_translation_m};
+}
+
+inline double computeRecoveryRetryFallbackAcceptedGapSec(
+  bool have_last_accepted_pose,
+  double scan_stamp_sec,
+  double last_accepted_pose_time_sec)
+{
+  if (!have_last_accepted_pose) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  return std::max(0.0, scan_stamp_sec - last_accepted_pose_time_sec);
+}
+
+inline RecoveryRetryFromLastPoseInput makeRecoveryRetryFromLastPoseInput(
+  bool have_last_accepted_pose,
+  std::size_t consecutive_rejected_updates,
+  double selected_accepted_gap_sec,
+  double fallback_accepted_gap_sec,
+  double selected_seed_translation_since_accept_m)
+{
+  return {
+    have_last_accepted_pose,
+    consecutive_rejected_updates,
+    selected_accepted_gap_sec,
+    fallback_accepted_gap_sec,
+    selected_seed_translation_since_accept_m};
+}
+
+inline RecoveryRetryFromLastPoseDecision decideRecoveryRetryFromLastPose(
+  const RecoveryRetryFromLastPoseParams & params,
+  const RecoveryRetryFromLastPoseInput & input)
+{
+  RecoveryRetryFromLastPoseDecision decision;
+  if (!params.enable) {
+    decision.reason = "disabled";
+    return decision;
+  }
+  if (!input.have_last_accepted_pose) {
+    decision.reason = "no_last_accepted_pose";
+    return decision;
+  }
+  if (static_cast<int>(input.consecutive_rejected_updates) < params.min_rejections) {
+    decision.reason = "not_enough_rejections";
+    return decision;
+  }
+
+  decision.accepted_gap_sec = std::isfinite(input.selected_accepted_gap_sec) ?
+    input.selected_accepted_gap_sec : input.fallback_accepted_gap_sec;
+  if (!std::isfinite(decision.accepted_gap_sec)) {
+    decision.reason = "accepted_gap_unavailable";
+    return decision;
+  }
+  if (decision.accepted_gap_sec > params.max_accepted_gap_sec) {
+    decision.reason = "accepted_gap_too_large";
+    return decision;
+  }
+  if (
+    std::isfinite(input.selected_seed_translation_since_accept_m) &&
+    input.selected_seed_translation_since_accept_m > params.max_seed_translation_m)
+  {
+    decision.reason = "seed_translation_too_large";
+    return decision;
+  }
+
+  decision.should_retry = true;
+  decision.reason = "retry_allowed";
+  return decision;
+}
+
+inline bool isRecoveryRetryAlignmentUsable(bool target_ready, bool has_converged)
+{
+  return target_ready && has_converged;
+}
+
+inline bool shouldUseRecoveryRetryResult(
+  bool target_ready,
+  bool has_converged,
+  bool retry_gate_reject_measurement)
+{
+  return isRecoveryRetryAlignmentUsable(target_ready, has_converged) &&
+         !retry_gate_reject_measurement;
+}
+
+inline MeasurementGateDecision makeRecoveryRetryRecoveredGateDecision(
+  const MeasurementGateDecision & gate)
+{
+  MeasurementGateDecision recovered_gate = gate;
+  recovered_gate.status_level = kMeasurementGateWarn;
+  recovered_gate.status_message = "recovery_retry_from_last_pose_recovered";
+  recovered_gate.reject_measurement = false;
+  recovered_gate.rejected_seed_update_applied = false;
+  return recovered_gate;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_ALIGNMENT_RETRY_POLICY_HPP_

--- a/include/lidar_localization/alignment_status_policy.hpp
+++ b/include/lidar_localization/alignment_status_policy.hpp
@@ -1,0 +1,265 @@
+#ifndef LIDAR_LOCALIZATION_ALIGNMENT_STATUS_POLICY_HPP_
+#define LIDAR_LOCALIZATION_ALIGNMENT_STATUS_POLICY_HPP_
+
+#include <cstddef>
+#include <cstdint>
+#include <cmath>
+#include <string>
+
+#include "lidar_localization/alignment_diagnostics_policy.hpp"
+#include "lidar_localization/measurement_gate_policy.hpp"
+#include "lidar_localization/recovery_supervisor.hpp"
+
+namespace lidar_localization
+{
+
+struct AlignmentStatusInput
+{
+  std::string registration_method;
+  std::uint8_t level{0};
+  std::string message{"ok"};
+  bool has_converged{false};
+  double fitness_score{0.0};
+  double alignment_time_sec{0.0};
+  std::size_t filtered_point_count{0};
+  double correction_translation_m{NAN};
+  double correction_yaw_deg{NAN};
+  double seed_translation_since_accept_m{NAN};
+  double seed_yaw_since_accept_deg{NAN};
+  double accepted_gap_sec{NAN};
+  std::size_t consecutive_rejected_updates{0};
+  bool have_last_accepted_pose{false};
+  double stamp_sec{0.0};
+  double last_accepted_pose_time_sec{0.0};
+  double fallback_seed_translation_since_accept_m{NAN};
+  bool imu_prediction_active{false};
+  bool map_received{false};
+  bool initialpose_received{false};
+  MeasurementGateParams gate_params;
+  ReinitializationTriggerParams reinitialization_params;
+};
+
+struct AlignmentStatusObservation
+{
+  std::uint8_t level{0};
+  std::string message{"ok"};
+  bool has_converged{false};
+  double fitness_score{0.0};
+  double alignment_time_sec{0.0};
+  std::size_t filtered_point_count{0};
+  double correction_translation_m{NAN};
+  double correction_yaw_deg{NAN};
+  double seed_translation_since_accept_m{NAN};
+  double seed_yaw_since_accept_deg{NAN};
+  double accepted_gap_sec{NAN};
+  bool imu_prediction_active{false};
+};
+
+struct AlignmentStatusRuntimeContext
+{
+  std::string registration_method;
+  std::size_t consecutive_rejected_updates{0};
+  bool have_last_accepted_pose{false};
+  double stamp_sec{0.0};
+  double last_accepted_pose_time_sec{0.0};
+  double fallback_seed_translation_since_accept_m{NAN};
+  bool map_received{false};
+  bool initialpose_received{false};
+  MeasurementGateParams gate_params;
+  ReinitializationTriggerParams reinitialization_params;
+};
+
+struct AlignmentStatusPreparation
+{
+  MeasurementGateInput gate_input;
+  EffectiveScoreThresholdDecision threshold_decision;
+  bool borderline_seed_gate_active{false};
+  EffectiveReinitializationMetrics effective_reinitialization_metrics;
+  ReinitializationRequestDecision reinitialization_request;
+};
+
+struct AlignmentStatusDiagnosticInput
+{
+  AlignmentStatusInput status_input;
+  AlignmentStatusPreparation preparation;
+  ReinitializationRequestDecision reinitialization_request;
+  std::string recovery_state;
+  std::string recovery_action;
+  double recovery_state_age_sec{0.0};
+  std::size_t recovery_state_transition_count{0};
+  bool reinitialization_request_latched{false};
+  double reinitialization_request_latch_age_sec{0.0};
+};
+
+struct AlignmentStatusDiagnosticRuntimeContext
+{
+  std::string recovery_state;
+  std::string recovery_action;
+  double recovery_state_entered_stamp_sec{0.0};
+  std::size_t recovery_state_transition_count{0};
+  bool reinitialization_request_latched{false};
+  double reinitialization_request_latch_stamp_sec{0.0};
+};
+
+inline AlignmentStatusInput makeAlignmentStatusInput(
+  const AlignmentStatusObservation & observation,
+  const AlignmentStatusRuntimeContext & context)
+{
+  AlignmentStatusInput input;
+  input.registration_method = context.registration_method;
+  input.level = observation.level;
+  input.message = observation.message;
+  input.has_converged = observation.has_converged;
+  input.fitness_score = observation.fitness_score;
+  input.alignment_time_sec = observation.alignment_time_sec;
+  input.filtered_point_count = observation.filtered_point_count;
+  input.correction_translation_m = observation.correction_translation_m;
+  input.correction_yaw_deg = observation.correction_yaw_deg;
+  input.seed_translation_since_accept_m = observation.seed_translation_since_accept_m;
+  input.seed_yaw_since_accept_deg = observation.seed_yaw_since_accept_deg;
+  input.accepted_gap_sec = observation.accepted_gap_sec;
+  input.consecutive_rejected_updates = context.consecutive_rejected_updates;
+  input.have_last_accepted_pose = context.have_last_accepted_pose;
+  input.stamp_sec = context.stamp_sec;
+  input.last_accepted_pose_time_sec = context.last_accepted_pose_time_sec;
+  input.fallback_seed_translation_since_accept_m =
+    context.fallback_seed_translation_since_accept_m;
+  input.imu_prediction_active = observation.imu_prediction_active;
+  input.map_received = context.map_received;
+  input.initialpose_received = context.initialpose_received;
+  input.gate_params = context.gate_params;
+  input.reinitialization_params = context.reinitialization_params;
+  return input;
+}
+
+inline AlignmentStatusPreparation prepareAlignmentStatus(
+  const AlignmentStatusInput & input)
+{
+  AlignmentStatusPreparation preparation;
+  preparation.gate_input = makeMeasurementGateInput(
+    input.fitness_score,
+    input.accepted_gap_sec,
+    input.seed_translation_since_accept_m,
+    input.correction_translation_m,
+    input.correction_yaw_deg,
+    input.consecutive_rejected_updates);
+  preparation.threshold_decision =
+    computeEffectiveScoreThreshold(input.gate_params, preparation.gate_input);
+  preparation.borderline_seed_gate_active = isBorderlineSeedGateActive(
+    input.gate_params,
+    preparation.gate_input,
+    preparation.threshold_decision.effective_score_threshold);
+
+  preparation.effective_reinitialization_metrics =
+    resolveEffectiveReinitializationMetrics(
+      EffectiveReinitializationMetricsInput{
+        input.accepted_gap_sec,
+        input.seed_translation_since_accept_m,
+        input.have_last_accepted_pose,
+        input.stamp_sec,
+        input.last_accepted_pose_time_sec,
+        input.fallback_seed_translation_since_accept_m});
+
+  const auto reinit_input = makeReinitializationTriggerInput(
+    input.message,
+    input.fitness_score,
+    preparation.effective_reinitialization_metrics.seed_translation_since_accept_m,
+    preparation.effective_reinitialization_metrics.accepted_gap_sec,
+    input.consecutive_rejected_updates);
+  preparation.reinitialization_request =
+    computeReinitializationRequest(input.reinitialization_params, reinit_input);
+  return preparation;
+}
+
+inline RecoverySupervisorEvaluation evaluateAlignmentStatusRecovery(
+  const AlignmentStatusInput & input,
+  const ReinitializationRequestDecision & reinitialization_request)
+{
+  return evaluateRecoverySupervisor(
+    input.level,
+    input.message,
+    reinitialization_request,
+    input.consecutive_rejected_updates);
+}
+
+inline AlignmentStatusDiagnosticInput makeAlignmentStatusDiagnosticInput(
+  const AlignmentStatusInput & status_input,
+  const AlignmentStatusPreparation & preparation,
+  const ReinitializationRequestDecision & reinitialization_request,
+  const AlignmentStatusDiagnosticRuntimeContext & context)
+{
+  const double recovery_state_age_sec =
+    nonnegativeElapsedOrZero(
+      status_input.stamp_sec,
+      context.recovery_state_entered_stamp_sec);
+  const double reinitialization_request_latch_age_sec =
+    context.reinitialization_request_latched &&
+    context.reinitialization_request_latch_stamp_sec > 0.0 ?
+    nonnegativeElapsedOrZero(
+      status_input.stamp_sec,
+      context.reinitialization_request_latch_stamp_sec) : 0.0;
+
+  return AlignmentStatusDiagnosticInput{
+    status_input,
+    preparation,
+    reinitialization_request,
+    context.recovery_state,
+    context.recovery_action,
+    recovery_state_age_sec,
+    context.recovery_state_transition_count,
+    context.reinitialization_request_latched,
+    reinitialization_request_latch_age_sec};
+}
+
+inline AlignmentDiagnosticValuesInput makeAlignmentStatusDiagnosticValuesInput(
+  const AlignmentStatusDiagnosticInput & input)
+{
+  const auto & status = input.status_input;
+  const auto & preparation = input.preparation;
+  AlignmentDiagnosticValuesInput diagnostic_input;
+  diagnostic_input.registration_method = status.registration_method;
+  diagnostic_input.has_converged = status.has_converged;
+  diagnostic_input.fitness_score = status.fitness_score;
+  diagnostic_input.score_threshold = status.gate_params.score_threshold;
+  diagnostic_input.effective_score_threshold =
+    preparation.threshold_decision.effective_score_threshold;
+  diagnostic_input.post_reject_strict_active =
+    preparation.threshold_decision.post_reject_strict_active;
+  diagnostic_input.open_loop_strict_active =
+    preparation.threshold_decision.open_loop_strict_active;
+  diagnostic_input.borderline_seed_gate_active =
+    preparation.borderline_seed_gate_active;
+  diagnostic_input.alignment_time_sec = status.alignment_time_sec;
+  diagnostic_input.filtered_point_count = status.filtered_point_count;
+  diagnostic_input.correction_translation_m = status.correction_translation_m;
+  diagnostic_input.correction_yaw_deg = status.correction_yaw_deg;
+  diagnostic_input.seed_translation_since_accept_m =
+    status.seed_translation_since_accept_m;
+  diagnostic_input.seed_yaw_since_accept_deg = status.seed_yaw_since_accept_deg;
+  diagnostic_input.accepted_gap_sec = status.accepted_gap_sec;
+  diagnostic_input.consecutive_rejected_updates =
+    status.consecutive_rejected_updates;
+  diagnostic_input.recovery_state = input.recovery_state;
+  diagnostic_input.recovery_action = input.recovery_action;
+  diagnostic_input.recovery_state_age_sec = input.recovery_state_age_sec;
+  diagnostic_input.recovery_state_transition_count =
+    input.recovery_state_transition_count;
+  diagnostic_input.imu_prediction_active = status.imu_prediction_active;
+  diagnostic_input.reinitialization_requested =
+    input.reinitialization_request.requested;
+  diagnostic_input.reinitialization_request_reason =
+    input.reinitialization_request.reason;
+  diagnostic_input.reinitialization_request_score =
+    input.reinitialization_request.score;
+  diagnostic_input.reinitialization_request_latched =
+    input.reinitialization_request_latched;
+  diagnostic_input.reinitialization_request_latch_age_sec =
+    input.reinitialization_request_latch_age_sec;
+  diagnostic_input.map_received = status.map_received;
+  diagnostic_input.initialpose_received = status.initialpose_received;
+  return diagnostic_input;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_ALIGNMENT_STATUS_POLICY_HPP_

--- a/include/lidar_localization/imu_preintegration_guard_policy.hpp
+++ b/include/lidar_localization/imu_preintegration_guard_policy.hpp
@@ -1,0 +1,146 @@
+#ifndef LIDAR_LOCALIZATION_IMU_PREINTEGRATION_GUARD_POLICY_HPP_
+#define LIDAR_LOCALIZATION_IMU_PREINTEGRATION_GUARD_POLICY_HPP_
+
+#include <cmath>
+
+namespace lidar_localization
+{
+
+constexpr double kDefaultImuSmootherMeasurementTranslationGuardM = 2.0;
+constexpr double kDefaultImuSmootherMeasurementRotationGuardDeg = 10.0;
+
+struct ImuPreintegrationGuardParams
+{
+  double prediction_correction_guard_translation_m{2.0};
+  double prediction_correction_guard_yaw_deg{4.0};
+  double smoother_measurement_translation_guard_m{
+    kDefaultImuSmootherMeasurementTranslationGuardM};
+  double smoother_measurement_rotation_guard_deg{
+    kDefaultImuSmootherMeasurementRotationGuardDeg};
+};
+
+struct ImuPredictionCorrectionGuardInput
+{
+  bool fallback_mode{false};
+  bool imu_prediction_ready{false};
+  double correction_translation_m{0.0};
+  double correction_yaw_deg{0.0};
+};
+
+struct ImuSmootherDivergenceInput
+{
+  bool pose_all_finite{true};
+  double measurement_translation_delta_m{0.0};
+  double measurement_rotation_delta_deg{0.0};
+};
+
+struct ImuPreintegrationStatusDecision
+{
+  bool warning{false};
+  const char * status_message{"ok"};
+};
+
+struct ImuPreintegrationBackendState
+{
+  bool fallback_mode{false};
+  bool state_reset{false};
+  bool correction_guard_tripped{false};
+  bool smoother_diverged{false};
+  bool should_update_smoother{true};
+};
+
+inline bool isImuPredictionCorrectionGuardTripped(
+  const ImuPreintegrationGuardParams & params,
+  const ImuPredictionCorrectionGuardInput & input)
+{
+  if (input.fallback_mode || !input.imu_prediction_ready) {
+    return false;
+  }
+  const bool translation_guard_tripped =
+    std::isfinite(input.correction_translation_m) &&
+    input.correction_translation_m > params.prediction_correction_guard_translation_m;
+  const bool yaw_guard_tripped =
+    std::isfinite(input.correction_yaw_deg) &&
+    input.correction_yaw_deg > params.prediction_correction_guard_yaw_deg;
+  return translation_guard_tripped || yaw_guard_tripped;
+}
+
+inline ImuPreintegrationBackendState beginImuPreintegrationBackendState(
+  const ImuPreintegrationGuardParams & params,
+  const ImuPredictionCorrectionGuardInput & input)
+{
+  ImuPreintegrationBackendState state;
+  state.correction_guard_tripped =
+    isImuPredictionCorrectionGuardTripped(params, input);
+  state.fallback_mode = input.fallback_mode || state.correction_guard_tripped;
+  state.state_reset = state.correction_guard_tripped;
+  state.should_update_smoother = !state.fallback_mode;
+  return state;
+}
+
+inline bool isImuSmootherDiverged(
+  const ImuPreintegrationGuardParams & params,
+  const ImuSmootherDivergenceInput & input)
+{
+  return !input.pose_all_finite ||
+         !std::isfinite(input.measurement_translation_delta_m) ||
+         !std::isfinite(input.measurement_rotation_delta_deg) ||
+         input.measurement_translation_delta_m >
+         params.smoother_measurement_translation_guard_m ||
+         input.measurement_rotation_delta_deg >
+         params.smoother_measurement_rotation_guard_deg;
+}
+
+inline ImuPreintegrationBackendState applyImuSmootherDivergenceDecision(
+  const ImuPreintegrationBackendState & current,
+  const ImuPreintegrationGuardParams & params,
+  const ImuSmootherDivergenceInput & input)
+{
+  if (current.fallback_mode) {
+    return current;
+  }
+
+  ImuPreintegrationBackendState next = current;
+  next.smoother_diverged = isImuSmootherDiverged(params, input);
+  if (next.smoother_diverged) {
+    next.fallback_mode = true;
+    next.state_reset = true;
+    next.should_update_smoother = false;
+  }
+  return next;
+}
+
+inline bool shouldUseImuMeasurementPose(const ImuPreintegrationBackendState & state)
+{
+  return state.fallback_mode;
+}
+
+inline ImuPreintegrationStatusDecision decideImuPreintegrationStatus(
+  bool imu_state_reset,
+  bool imu_correction_guard_tripped,
+  bool imu_updated)
+{
+  if (imu_state_reset) {
+    return {
+      true,
+      imu_correction_guard_tripped ?
+      "imu_prediction_correction_guard_imu_disabled" :
+      "imu_smoother_diverged_imu_disabled"};
+  }
+  if (!imu_updated) {
+    return {true, "imu_smoother_update_rejected"};
+  }
+  return {};
+}
+
+inline ImuPreintegrationStatusDecision decideImuPreintegrationStatus(
+  const ImuPreintegrationBackendState & state,
+  bool imu_updated)
+{
+  return decideImuPreintegrationStatus(
+    state.state_reset, state.correction_guard_tripped, imu_updated);
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_IMU_PREINTEGRATION_GUARD_POLICY_HPP_

--- a/include/lidar_localization/lidar_localization_component.hpp
+++ b/include/lidar_localization/lidar_localization_component.hpp
@@ -54,6 +54,18 @@
 #include "lidar_localization/twist_ekf.hpp"
 #include "lidar_localization/twist_gtsam_smoother.hpp"
 #include "lidar_localization/imu_gtsam_smoother.hpp"
+#include "lidar_localization/alignment_retry_policy.hpp"
+#include "lidar_localization/alignment_pipeline_policy.hpp"
+#include "lidar_localization/alignment_status_policy.hpp"
+#include "lidar_localization/imu_preintegration_guard_policy.hpp"
+#include "lidar_localization/measurement_gate_policy.hpp"
+#include "lidar_localization/localization_update_policy.hpp"
+#include "lidar_localization/pose_backend_result_policy.hpp"
+#include "lidar_localization/pose_backend_selection_policy.hpp"
+#include "lidar_localization/registration_observation_policy.hpp"
+#include "lidar_localization/registration_seed_policy.hpp"
+#include "lidar_localization/recovery_supervisor.hpp"
+#include "lidar_localization/scan_preprocessing_policy.hpp"
 
 #ifdef LIDAR_LOCALIZATION_HAVE_NAV2_BOND
 #include "bondcpp/bond.hpp"
@@ -68,6 +80,9 @@ public:
   ~PCLLocalization() override;
 
   using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+  using RecoverySupervisorState = lidar_localization::RecoverySupervisorState;
+  using ReinitializationRequestDecision =
+    lidar_localization::ReinitializationRequestDecision;
 
   CallbackReturn on_configure(const rclcpp_lifecycle::State &);
   CallbackReturn on_activate(const rclcpp_lifecycle::State &);
@@ -153,6 +168,7 @@ public:
 
   // IMU preintegration smoother
   bool use_imu_preintegration_{false};
+  bool imu_preintegration_use_base_frame_transform_{false};
   double imu_prediction_correction_guard_translation_m_{2.0};
   double imu_prediction_correction_guard_yaw_deg_{4.0};
   ImuGtsamSmoother imu_smoother_;
@@ -177,7 +193,6 @@ public:
   int cloud_queue_depth_{1};
   double min_scan_interval_sec_{0.0};
   rclcpp::Time last_cloud_process_time_{0, 0, RCL_ROS_TIME};
-  double score_threshold_;
   double ndt_resolution_;
   double ndt_step_size_;
   double transform_epsilon_;
@@ -210,37 +225,10 @@ public:
   bool viz_downsample_{false};
   double viz_voxel_leaf_size_{0.5};
   bool predict_pose_from_previous_delta_{true};
-  bool reject_above_score_threshold_{true};
-  bool enable_consistency_recovery_gate_{false};
-  int consistency_recovery_min_rejections_{10};
-  double consistency_recovery_score_margin_{2.0};
-  double consistency_recovery_max_translation_m_{0.05};
-  double consistency_recovery_max_yaw_deg_{0.5};
-  bool enable_post_reject_strict_score_threshold_{false};
-  int post_reject_strict_min_rejections_{100};
-  double post_reject_strict_score_threshold_{5.5};
-  bool enable_open_loop_strict_score_threshold_{false};
-  double open_loop_strict_min_accepted_gap_sec_{15.0};
-  double open_loop_strict_min_seed_translation_m_{100.0};
-  double open_loop_strict_score_threshold_{5.25};
-  bool enable_borderline_seed_rejection_gate_{false};
-  double borderline_seed_gate_score_threshold_{5.25};
-  double borderline_seed_gate_min_seed_translation_m_{1.0};
-  bool enable_rejected_seed_update_{false};
-  int rejected_seed_update_min_rejections_{0};
-  double rejected_seed_update_max_fitness_{10.0};
-  double rejected_seed_update_max_correction_translation_m_{2.0};
-  double rejected_seed_update_max_correction_yaw_deg_{2.0};
-  bool enable_recovery_retry_from_last_pose_{false};
-  int recovery_retry_from_last_pose_min_rejections_{1};
-  double recovery_retry_from_last_pose_max_accepted_gap_sec_{1.0};
-  double recovery_retry_from_last_pose_max_seed_translation_m_{1000000000.0};
+  lidar_localization::MeasurementGateParamConfig measurement_gate_config_;
+  lidar_localization::RecoveryRetryFromLastPoseParams recovery_retry_from_last_pose_config_;
   bool enable_reinitialization_request_output_{true};
-  double reinitialization_trigger_threshold_{0.95};
-  double reinitialization_trigger_gap_scale_sec_{30.0};
-  double reinitialization_trigger_seed_translation_scale_m_{100.0};
-  double reinitialization_trigger_reject_streak_scale_{200.0};
-  double reinitialization_trigger_fitness_explosion_threshold_{1000.0};
+  lidar_localization::ReinitializationTriggerParams reinitialization_trigger_config_;
 
   int ndt_num_threads_;
   int ndt_max_iterations_;
@@ -275,20 +263,114 @@ public:
   double reinitialization_request_latch_score_{0.0};
   double reinitialization_request_latch_stamp_sec_{0.0};
 
-  enum class RecoverySupervisorState : uint8_t
-  {
-    kTracking = 0,
-    kDegraded = 1,
-    kRecovering = 2,
-    kReinitializationRequested = 3,
-  };
   RecoverySupervisorState recovery_supervisor_state_{RecoverySupervisorState::kTracking};
   std::string recovery_supervisor_action_{"idle"};
   double recovery_supervisor_state_entered_stamp_sec_{0.0};
   std::size_t recovery_supervisor_transition_count_{0};
 
   rclcpp::TimerBase::SharedPtr pose_publish_timer_;
+  struct PreparedScanCloud
+  {
+    lidar_localization::ScanPreparationStatus status{
+      lidar_localization::ScanPreparationStatus::kReady};
+    pcl::PointCloud<pcl::PointXYZI>::Ptr cloud;
+    std::size_t filtered_point_count{0};
+  };
+  struct SelectedRegistrationSeed
+  {
+    Eigen::Matrix4f init_guess{Eigen::Matrix4f::Identity()};
+    bool imu_prediction_ready{false};
+  };
+  struct ImuPreintegrationBackendUpdate
+  {
+    Eigen::Matrix4f pose{Eigen::Matrix4f::Identity()};
+    bool updated{true};
+    lidar_localization::ImuPreintegrationBackendState state;
+    double smoother_measurement_translation_delta_m{std::numeric_limits<double>::quiet_NaN()};
+    double smoother_measurement_rotation_delta_deg{std::numeric_limits<double>::quiet_NaN()};
+  };
+  struct PlanarSmootherBackendUpdate
+  {
+    Eigen::Matrix4f pose{Eigen::Matrix4f::Identity()};
+    bool updated{true};
+    const char * rejected_status_message{"smoother_update_rejected"};
+  };
+  struct PoseBackendApplyContext
+  {
+    const lidar_localization::RegistrationObservation & observation;
+    const lidar_localization::AlignmentAttempt & attempt;
+    const lidar_localization::MeasurementGateDecision & gate_result;
+    const builtin_interfaces::msg::Time & stamp;
+    std::size_t filtered_point_count;
+    double stamp_sec;
+    bool imu_prediction_ready;
+  };
+  struct AlignmentStatusPublishInput
+  {
+    const builtin_interfaces::msg::Time & stamp;
+    uint8_t level;
+    const std::string & message;
+    bool has_converged;
+    double fitness_score;
+    double alignment_time_sec;
+    std::size_t filtered_point_count;
+    double correction_translation_m;
+    double correction_yaw_deg;
+    double seed_translation_since_accept_m;
+    double seed_yaw_since_accept_deg;
+    double accepted_gap_sec;
+    bool imu_prediction_active;
+  };
+  struct AlignmentStatusEvaluation
+  {
+    lidar_localization::AlignmentStatusInput status_input;
+    lidar_localization::AlignmentStatusPreparation status_preparation;
+    ReinitializationRequestDecision reinitialization_request;
+  };
   void timerPublishPose();
+  bool admitScanMessage(
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg,
+    double * scan_stamp_sec);
+  PreparedScanCloud prepareScanForRegistration(
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg,
+    double scan_stamp_sec);
+  void handleScanPreparationFailure(
+    const builtin_interfaces::msg::Time & stamp,
+    const PreparedScanCloud & prepared_scan,
+    double scan_stamp_sec);
+  SelectedRegistrationSeed selectRegistrationSeed(double scan_stamp_sec);
+  Eigen::Matrix4f refineSeedWithNdtInitializer(
+    const pcl::PointCloud<pcl::PointXYZI>::Ptr & source_cloud,
+    const Eigen::Matrix4f & init_guess);
+  bool setInputTargetForPose(const Eigen::Matrix4f & center_pose_matrix);
+  lidar_localization::AlignmentAttempt runAlignmentAttempt(
+    const Eigen::Matrix4f & attempt_init_guess,
+    const Eigen::Matrix4f & crop_center_pose_matrix,
+    double scan_stamp_sec);
+  lidar_localization::AlignmentPipelineResult runAlignmentPipelineForScan(
+    const Eigen::Matrix4f & init_guess,
+    double scan_stamp_sec);
+  lidar_localization::MeasurementGateDecision evaluateMeasurementGateForAttempt(
+    const lidar_localization::AlignmentAttempt & attempt);
+  void logAlignmentPipelineRecovery(
+    const lidar_localization::AlignmentPipelineResult & pipeline_result);
+  bool handleTerminalAlignmentPipelineResult(
+    const builtin_interfaces::msg::Time & stamp,
+    const lidar_localization::AlignmentPipelineResult & pipeline_result,
+    std::size_t filtered_point_count,
+    double scan_stamp_sec,
+    bool imu_prediction_ready);
+  bool applyAcceptedAlignmentPipelineResult(
+    const builtin_interfaces::msg::Time & stamp,
+    const lidar_localization::AlignmentPipelineResult & pipeline_result,
+    std::size_t filtered_point_count,
+    double scan_stamp_sec,
+    bool imu_prediction_ready);
+  void setRegistrationSourceCloud(const pcl::PointCloud<pcl::PointXYZI>::Ptr & source_cloud);
+  void printAlignmentDebugInfo(
+    const Eigen::Matrix4f & init_guess,
+    const lidar_localization::AlignmentAttempt & selected_attempt,
+    std::size_t filtered_point_count) const;
   Eigen::Matrix4f currentPoseMatrix() const;
   Eigen::Matrix4f applyTwistPrediction(const Eigen::Matrix4f & pose_matrix, double dt_sec) const;
   void resetPredictionState(const Eigen::Matrix4f & pose_matrix, double stamp_sec);
@@ -297,45 +379,91 @@ public:
   void updatePredictionFromRejectedMeasurement(
     const Eigen::Matrix4f & rejected_pose_matrix,
     double stamp_sec);
+  bool applyRegistrationPoseBackend(
+    const lidar_localization::RegistrationObservation & observation,
+    const lidar_localization::AlignmentAttempt & attempt,
+    const lidar_localization::MeasurementGateDecision & gate_result,
+    const builtin_interfaces::msg::Time & stamp,
+    std::size_t filtered_point_count,
+    double stamp_sec,
+    bool imu_prediction_ready);
+  lidar_localization::PoseBackendKind selectRegistrationPoseBackend() const;
+  bool dispatchRegistrationPoseBackend(
+    lidar_localization::PoseBackendKind backend,
+    const PoseBackendApplyContext & context);
+  bool applyGtsamPoseBackend(const PoseBackendApplyContext & context);
+  void updateBackendRollPitch(
+    const lidar_localization::RegistrationObservation & observation);
+  PlanarSmootherBackendUpdate updateGtsamPoseBackend(
+    const lidar_localization::RegistrationObservation & observation,
+    const lidar_localization::AlignmentAttempt & attempt,
+    double stamp_sec);
+  PlanarSmootherBackendUpdate updateTwistEkfPoseBackend(
+    const lidar_localization::RegistrationObservation & observation,
+    const lidar_localization::AlignmentAttempt & attempt,
+    double stamp_sec);
+  bool applyPlanarSmootherPoseBackendUpdate(
+    const PlanarSmootherBackendUpdate & update,
+    const PoseBackendApplyContext & context);
+  bool applyImuPreintegrationPoseBackend(const PoseBackendApplyContext & context);
+  lidar_localization::ImuPreintegrationGuardParams imuPreintegrationGuardParams() const;
+  void initializeImuPreintegrationSmootherIfNeeded(
+    const lidar_localization::RegistrationObservation & observation,
+    double stamp_sec);
+  ImuPreintegrationBackendUpdate updateImuPreintegrationBackend(
+    const lidar_localization::RegistrationObservation & observation,
+    const lidar_localization::AlignmentAttempt & attempt,
+    double stamp_sec,
+    bool imu_prediction_ready);
+  void logImuPreintegrationBackendWarnings(
+    const ImuPreintegrationBackendUpdate & update,
+    const lidar_localization::AlignmentAttempt & attempt);
+  lidar_localization::PoseBackendResult makeImuPreintegrationPoseBackendResult(
+    const ImuPreintegrationBackendUpdate & update,
+    uint8_t status_level,
+    const std::string & status_message) const;
+  bool applyTwistEkfPoseBackend(const PoseBackendApplyContext & context);
+  bool applyRawRegistrationPoseBackend(const PoseBackendApplyContext & context);
+  bool applyPoseBackendResult(
+    const lidar_localization::PoseBackendResult & result,
+    const builtin_interfaces::msg::Time & stamp,
+    double stamp_sec,
+    double fitness_score);
+  bool applyPoseBackendPredictionOnlyResult(
+    const lidar_localization::PoseBackendResult & result,
+    double stamp_sec);
+  void applyAcceptedPoseBackendResult(
+    const lidar_localization::PoseBackendResult & result,
+    const builtin_interfaces::msg::Time & stamp,
+    double stamp_sec,
+    double fitness_score);
   void setCurrentPoseFromMatrix(
     const Eigen::Matrix4f & pose_matrix,
     const builtin_interfaces::msg::Time & stamp);
   void publishCurrentPose(const builtin_interfaces::msg::Time & stamp);
-  void fillPoseCovariance(double fitness_score);
-  double computeEffectiveScoreThreshold(
-    double accepted_gap_sec,
-    double seed_translation_since_accept_m,
-    bool * post_reject_strict_active = nullptr,
-    bool * open_loop_strict_active = nullptr) const;
-  bool computeBorderlineSeedGateActive(
-    double fitness_score,
-    double seed_translation_since_accept_m,
-    double effective_score_threshold) const;
-  struct ReinitializationRequestDecision
-  {
-    bool requested{false};
-    std::string reason{"not_requested"};
-    double score{0.0};
-  };
-  ReinitializationRequestDecision computeReinitializationRequest(
+  void publishPoseMessage(
+    const geometry_msgs::msg::PoseWithCovarianceStamped & pose);
+  void appendCurrentPoseToPath(
     const builtin_interfaces::msg::Time & stamp,
-    const std::string & status_message,
-    double fitness_score,
-    double seed_translation_since_accept_m,
-    double accepted_gap_sec) const;
+    const geometry_msgs::msg::Pose & pose);
+  void publishPathMessage();
+  bool publishPoseTransform(
+    const builtin_interfaces::msg::Time & stamp,
+    const geometry_msgs::msg::Pose & pose);
+  bool publishMapToOdomTransform(
+    const builtin_interfaces::msg::Time & stamp,
+    const geometry_msgs::msg::TransformStamped & map_to_base_link_stamped);
+  void fillPoseCovariance(double fitness_score);
+  void publishAlignmentStatusForAttempt(
+    const builtin_interfaces::msg::Time & stamp,
+    uint8_t level,
+    const std::string & message,
+    const lidar_localization::AlignmentAttempt & attempt,
+    std::size_t filtered_point_count,
+    bool imu_prediction_active);
   ReinitializationRequestDecision applyReinitializationRequestLatch(
     const builtin_interfaces::msg::Time & stamp,
     const ReinitializationRequestDecision & decision);
-  const char * recoverySupervisorStateName(RecoverySupervisorState state) const;
-  bool isRecoveryFailureStatus(const std::string & status_message) const;
-  RecoverySupervisorState classifyRecoverySupervisorState(
-    uint8_t level,
-    const std::string & status_message,
-    const ReinitializationRequestDecision & reinitialization_request) const;
-  std::string classifyRecoverySupervisorAction(
-    uint8_t level,
-    const std::string & status_message,
-    const ReinitializationRequestDecision & reinitialization_request) const;
   void updateRecoverySupervisorState(
     const builtin_interfaces::msg::Time & stamp,
     RecoverySupervisorState next_state,
@@ -343,6 +471,31 @@ public:
   void publishReinitializationRequest(
     const builtin_interfaces::msg::Time & stamp,
     const ReinitializationRequestDecision & decision);
+  lidar_localization::MeasurementGateParams measurementGateParams() const;
+  lidar_localization::ReinitializationTriggerParams reinitializationTriggerParams() const;
+  lidar_localization::RecoveryRetryFromLastPoseParams recoveryRetryFromLastPoseParams() const;
+  lidar_localization::AlignmentStatusInput makeAlignmentStatusInput(
+    const AlignmentStatusPublishInput & input) const;
+  lidar_localization::AlignmentStatusRuntimeContext makeAlignmentStatusRuntimeContext(
+    double stamp_sec) const;
+  diagnostic_msgs::msg::DiagnosticStatus makeAlignmentDiagnosticStatus(
+    const lidar_localization::AlignmentStatusInput & status_input) const;
+  AlignmentStatusEvaluation evaluateAlignmentStatus(
+    const builtin_interfaces::msg::Time & stamp,
+    const AlignmentStatusPublishInput & publish_input);
+  lidar_localization::AlignmentDiagnosticValuesInput prepareAlignmentDiagnosticValuesInput(
+    const lidar_localization::AlignmentStatusInput & status_input,
+    const lidar_localization::AlignmentStatusPreparation & status_preparation,
+    const ReinitializationRequestDecision & reinitialization_request) const;
+  void appendAlignmentDiagnosticValues(
+    diagnostic_msgs::msg::DiagnosticStatus & status,
+    const lidar_localization::AlignmentDiagnosticValuesInput & diagnostic_values_input) const;
+  diagnostic_msgs::msg::DiagnosticArray makeAlignmentDiagnosticArray(
+    const builtin_interfaces::msg::Time & stamp,
+    const diagnostic_msgs::msg::DiagnosticStatus & status) const;
+  void publishAlignmentDiagnosticStatus(
+    const builtin_interfaces::msg::Time & stamp,
+    const diagnostic_msgs::msg::DiagnosticStatus & status);
   void publishAlignmentStatus(
     const builtin_interfaces::msg::Time & stamp,
     uint8_t level,

--- a/include/lidar_localization/local_map_target_policy.hpp
+++ b/include/lidar_localization/local_map_target_policy.hpp
@@ -1,0 +1,239 @@
+#ifndef LIDAR_LOCALIZATION_LOCAL_MAP_TARGET_POLICY_HPP_
+#define LIDAR_LOCALIZATION_LOCAL_MAP_TARGET_POLICY_HPP_
+
+#include <chrono>
+#include <cstddef>
+#include <limits>
+
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+namespace lidar_localization
+{
+
+struct LocalMapBounds2d
+{
+  bool valid{false};
+  float min_x{0.0f};
+  float max_x{0.0f};
+  float min_y{0.0f};
+  float max_y{0.0f};
+};
+
+struct LocalMapCropRequest
+{
+  float center_x{0.0f};
+  float center_y{0.0f};
+  double radius_m{0.0};
+  std::size_t min_points{1};
+  LocalMapBounds2d bounds;
+};
+
+enum class LocalMapTargetCloud
+{
+  kRawLocalMap = 0,
+  kFilteredLocalMap,
+};
+
+enum class LocalMapTargetFailure
+{
+  kNone = 0,
+  kCropCenterOutsideBounds,
+  kCropTooSmall,
+};
+
+struct LocalMapCropValidationDecision
+{
+  bool can_crop{true};
+  LocalMapTargetFailure failure{LocalMapTargetFailure::kNone};
+};
+
+struct LocalMapTargetSelectionDecision
+{
+  bool target_ready{true};
+  LocalMapTargetFailure failure{LocalMapTargetFailure::kNone};
+  LocalMapTargetCloud target_cloud{LocalMapTargetCloud::kRawLocalMap};
+};
+
+struct LocalMapTargetFailureHandlingInput
+{
+  LocalMapTargetFailure failure{LocalMapTargetFailure::kNone};
+  int consecutive_crop_failures{0};
+  bool has_last_failure_streak_log{false};
+  std::chrono::steady_clock::duration elapsed_since_failure_streak_log{
+    std::chrono::steady_clock::duration::zero()};
+  bool has_last_out_of_bounds_log{false};
+  std::chrono::steady_clock::duration elapsed_since_out_of_bounds_log{
+    std::chrono::steady_clock::duration::zero()};
+  int failure_streak_log_threshold{100};
+  std::chrono::steady_clock::duration min_log_interval{std::chrono::seconds(5)};
+};
+
+struct LocalMapTargetFailureHandlingDecision
+{
+  int consecutive_crop_failures{0};
+  bool should_log_failure_streak{false};
+  bool should_log_out_of_bounds{false};
+};
+
+struct LocalMapTargetSuccessDecision
+{
+  int consecutive_crop_failures{0};
+  bool crop_failure_guard_active{false};
+};
+
+inline bool isCropCenterOutsideLocalMapBounds(const LocalMapCropRequest & request)
+{
+  if (!request.bounds.valid) {
+    return false;
+  }
+  const float radius = static_cast<float>(request.radius_m);
+  return request.center_x < request.bounds.min_x - radius ||
+         request.center_x > request.bounds.max_x + radius ||
+         request.center_y < request.bounds.min_y - radius ||
+         request.center_y > request.bounds.max_y + radius;
+}
+
+inline LocalMapCropValidationDecision validateLocalMapCropRequest(
+  const LocalMapCropRequest & request)
+{
+  if (isCropCenterOutsideLocalMapBounds(request)) {
+    return {false, LocalMapTargetFailure::kCropCenterOutsideBounds};
+  }
+  return {};
+}
+
+inline bool isLocalMapCropTooSmall(std::size_t local_map_points, std::size_t min_points)
+{
+  return local_map_points < min_points;
+}
+
+inline LocalMapTargetSelectionDecision validateLocalMapCropSize(
+  std::size_t local_map_points,
+  std::size_t min_points)
+{
+  if (isLocalMapCropTooSmall(local_map_points, min_points)) {
+    return {false, LocalMapTargetFailure::kCropTooSmall, LocalMapTargetCloud::kRawLocalMap};
+  }
+  return {};
+}
+
+inline std::size_t localMapReserveCapacity(std::size_t full_map_points)
+{
+  return full_map_points / 10;
+}
+
+inline pcl::PointCloud<pcl::PointXYZI>::Ptr cropLocalMapByRadius(
+  const pcl::PointCloud<pcl::PointXYZI> & full_map,
+  float center_x,
+  float center_y,
+  double radius_m)
+{
+  const float radius_squared = static_cast<float>(radius_m * radius_m);
+  pcl::PointCloud<pcl::PointXYZI>::Ptr local_map(new pcl::PointCloud<pcl::PointXYZI>());
+  local_map->reserve(localMapReserveCapacity(full_map.size()));
+  for (const auto & point : full_map.points) {
+    const float dx = point.x - center_x;
+    const float dy = point.y - center_y;
+    if (dx * dx + dy * dy <= radius_squared) {
+      local_map->push_back(point);
+    }
+  }
+  return local_map;
+}
+
+inline LocalMapTargetCloud chooseLocalMapTargetCloud(
+  std::size_t filtered_local_map_points,
+  std::size_t min_points)
+{
+  if (filtered_local_map_points >= min_points) {
+    return LocalMapTargetCloud::kFilteredLocalMap;
+  }
+  return LocalMapTargetCloud::kRawLocalMap;
+}
+
+inline LocalMapTargetSelectionDecision chooseTargetAfterLocalMapCrop(
+  std::size_t local_map_points,
+  std::size_t filtered_local_map_points,
+  std::size_t min_points)
+{
+  const auto crop_size_decision = validateLocalMapCropSize(local_map_points, min_points);
+  if (!crop_size_decision.target_ready) {
+    return crop_size_decision;
+  }
+  return {
+    true,
+    LocalMapTargetFailure::kNone,
+    chooseLocalMapTargetCloud(filtered_local_map_points, min_points)};
+}
+
+inline LocalMapTargetCloud chooseMapSubscriptionTargetCloud(bool backend_uses_filtered_target)
+{
+  return backend_uses_filtered_target ?
+         LocalMapTargetCloud::kFilteredLocalMap :
+         LocalMapTargetCloud::kRawLocalMap;
+}
+
+inline int incrementCropFailureCount(int current_count)
+{
+  if (current_count == std::numeric_limits<int>::max()) {
+    return current_count;
+  }
+  return current_count + 1;
+}
+
+inline bool shouldLogCropFailureStreak(
+  int consecutive_crop_failures,
+  bool has_last_log_time,
+  std::chrono::steady_clock::duration elapsed_since_last_log,
+  int failure_threshold = 100,
+  std::chrono::steady_clock::duration min_log_interval = std::chrono::seconds(5))
+{
+  if (consecutive_crop_failures <= failure_threshold) {
+    return false;
+  }
+  return !has_last_log_time || elapsed_since_last_log >= min_log_interval;
+}
+
+inline bool shouldLogCropOutOfBounds(
+  bool has_last_log_time,
+  std::chrono::steady_clock::duration elapsed_since_last_log,
+  std::chrono::steady_clock::duration min_log_interval = std::chrono::seconds(5))
+{
+  return !has_last_log_time || elapsed_since_last_log >= min_log_interval;
+}
+
+inline LocalMapTargetFailureHandlingDecision handleLocalMapTargetFailure(
+  const LocalMapTargetFailureHandlingInput & input)
+{
+  if (input.failure == LocalMapTargetFailure::kNone) {
+    return {input.consecutive_crop_failures, false, false};
+  }
+
+  LocalMapTargetFailureHandlingDecision decision;
+  decision.consecutive_crop_failures =
+    incrementCropFailureCount(input.consecutive_crop_failures);
+  decision.should_log_failure_streak =
+    shouldLogCropFailureStreak(
+    decision.consecutive_crop_failures,
+    input.has_last_failure_streak_log,
+    input.elapsed_since_failure_streak_log,
+    input.failure_streak_log_threshold,
+    input.min_log_interval);
+  decision.should_log_out_of_bounds =
+    input.failure == LocalMapTargetFailure::kCropCenterOutsideBounds &&
+    shouldLogCropOutOfBounds(
+    input.has_last_out_of_bounds_log,
+    input.elapsed_since_out_of_bounds_log,
+    input.min_log_interval);
+  return decision;
+}
+
+inline LocalMapTargetSuccessDecision handleLocalMapTargetSuccess()
+{
+  return {};
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_LOCAL_MAP_TARGET_POLICY_HPP_

--- a/include/lidar_localization/localization_update_policy.hpp
+++ b/include/lidar_localization/localization_update_policy.hpp
@@ -1,0 +1,69 @@
+#ifndef LIDAR_LOCALIZATION_LOCALIZATION_UPDATE_POLICY_HPP_
+#define LIDAR_LOCALIZATION_LOCALIZATION_UPDATE_POLICY_HPP_
+
+#include "lidar_localization/measurement_gate_policy.hpp"
+
+namespace lidar_localization
+{
+
+enum class LocalizationUpdateAction
+{
+  kAcceptMeasurement = 0,
+  kAdvancePredictionWithoutMeasurement,
+  kUpdatePredictionFromRejectedMeasurement,
+};
+
+struct LocalizationUpdateDecision
+{
+  LocalizationUpdateAction action{LocalizationUpdateAction::kAcceptMeasurement};
+  bool update_current_pose{true};
+  bool update_prediction_from_accepted_measurement{true};
+  bool advance_prediction_without_measurement{false};
+  bool update_prediction_from_rejected_measurement{false};
+  bool continue_to_pose_publish{true};
+};
+
+inline LocalizationUpdateDecision makeAcceptedLocalizationUpdateDecision()
+{
+  return {};
+}
+
+inline LocalizationUpdateDecision makePredictionAdvanceLocalizationUpdateDecision()
+{
+  LocalizationUpdateDecision decision;
+  decision.action = LocalizationUpdateAction::kAdvancePredictionWithoutMeasurement;
+  decision.update_current_pose = false;
+  decision.update_prediction_from_accepted_measurement = false;
+  decision.advance_prediction_without_measurement = true;
+  decision.continue_to_pose_publish = false;
+  return decision;
+}
+
+inline LocalizationUpdateDecision makeRejectedSeedLocalizationUpdateDecision()
+{
+  LocalizationUpdateDecision decision;
+  decision.action = LocalizationUpdateAction::kUpdatePredictionFromRejectedMeasurement;
+  decision.update_current_pose = false;
+  decision.update_prediction_from_accepted_measurement = false;
+  decision.update_prediction_from_rejected_measurement = true;
+  decision.continue_to_pose_publish = false;
+  return decision;
+}
+
+inline LocalizationUpdateDecision decideLocalizationUpdate(
+  const MeasurementGateDecision & gate_decision)
+{
+  if (!gate_decision.reject_measurement) {
+    return makeAcceptedLocalizationUpdateDecision();
+  }
+
+  if (gate_decision.rejected_seed_update_applied) {
+    return makeRejectedSeedLocalizationUpdateDecision();
+  }
+
+  return makePredictionAdvanceLocalizationUpdateDecision();
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_LOCALIZATION_UPDATE_POLICY_HPP_

--- a/include/lidar_localization/map_initialization_policy.hpp
+++ b/include/lidar_localization/map_initialization_policy.hpp
@@ -1,0 +1,99 @@
+#ifndef LIDAR_LOCALIZATION_MAP_INITIALIZATION_POLICY_HPP_
+#define LIDAR_LOCALIZATION_MAP_INITIALIZATION_POLICY_HPP_
+
+#include <memory>
+#include <string>
+
+#include <pcl/PCLPointCloud2.h>
+#include <pcl/common/common.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#include "sensor_msgs/msg/point_cloud2.hpp"
+
+#include "lidar_localization/registration_backend_policy.hpp"
+
+namespace lidar_localization
+{
+
+enum class MapFileFormat
+{
+  kUnsupported = 0,
+  kPcd,
+  kPly,
+};
+
+struct MapBounds3d
+{
+  bool valid{false};
+  pcl::PointXYZI min_point{};
+  pcl::PointXYZI max_point{};
+};
+
+struct InitialMapTargetSetupPlan
+{
+  bool use_local_map_crop{false};
+  bool create_ndt_initializer{false};
+  bool set_full_map_as_registration_target{true};
+};
+
+inline MapFileFormat detectMapFileFormat(const std::string & map_path)
+{
+  if (map_path.find(".pcd") != std::string::npos) {
+    return MapFileFormat::kPcd;
+  }
+  if (map_path.find(".ply") != std::string::npos) {
+    return MapFileFormat::kPly;
+  }
+  return MapFileFormat::kUnsupported;
+}
+
+inline MapBounds3d computeMapBounds(const pcl::PointCloud<pcl::PointXYZI> & map_cloud)
+{
+  MapBounds3d bounds;
+  if (map_cloud.empty()) {
+    return bounds;
+  }
+  pcl::getMinMax3D(map_cloud, bounds.min_point, bounds.max_point);
+  bounds.valid = true;
+  return bounds;
+}
+
+inline sensor_msgs::msg::PointCloud2 makeInitialMapMessage(
+  pcl::PCLPointCloud2 & raw_map_cloud,
+  const std::string & frame_id,
+  bool downsample,
+  double voxel_leaf_size)
+{
+  sensor_msgs::msg::PointCloud2 map_msg;
+  if (downsample) {
+    pcl::PCLPointCloud2 filtered_map_cloud;
+    pcl::VoxelGrid<pcl::PCLPointCloud2> voxel_filter;
+    voxel_filter.setInputCloud(std::make_shared<pcl::PCLPointCloud2>(raw_map_cloud));
+    voxel_filter.setLeafSize(voxel_leaf_size, voxel_leaf_size, voxel_leaf_size);
+    voxel_filter.filter(filtered_map_cloud);
+    pcl_conversions::moveFromPCL(filtered_map_cloud, map_msg);
+  } else {
+    pcl_conversions::moveFromPCL(raw_map_cloud, map_msg);
+  }
+  map_msg.header.frame_id = frame_id;
+  return map_msg;
+}
+
+inline InitialMapTargetSetupPlan planInitialMapTargetSetup(
+  bool enable_local_map_crop,
+  const std::string & registration_method)
+{
+  const RegistrationBackend backend = parseRegistrationBackend(registration_method);
+  InitialMapTargetSetupPlan plan;
+  plan.use_local_map_crop = enable_local_map_crop || usesFilteredTarget(backend);
+  plan.create_ndt_initializer = plan.use_local_map_crop && supportsNdtInitializer(backend);
+  plan.set_full_map_as_registration_target = !plan.use_local_map_crop;
+  return plan;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_MAP_INITIALIZATION_POLICY_HPP_

--- a/include/lidar_localization/measurement_gate_policy.hpp
+++ b/include/lidar_localization/measurement_gate_policy.hpp
@@ -1,0 +1,282 @@
+#ifndef LIDAR_LOCALIZATION_MEASUREMENT_GATE_POLICY_HPP_
+#define LIDAR_LOCALIZATION_MEASUREMENT_GATE_POLICY_HPP_
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace lidar_localization
+{
+
+constexpr std::uint8_t kMeasurementGateOk = 0;
+constexpr std::uint8_t kMeasurementGateWarn = 1;
+
+struct MeasurementGateParams
+{
+  double score_threshold{2.0};
+  bool reject_above_score_threshold{true};
+
+  bool enable_consistency_recovery_gate{false};
+  int consistency_recovery_min_rejections{10};
+  double consistency_recovery_score_margin{2.0};
+  double consistency_recovery_max_translation_m{0.05};
+  double consistency_recovery_max_yaw_deg{0.5};
+
+  bool enable_post_reject_strict_score_threshold{false};
+  int post_reject_strict_min_rejections{100};
+  double post_reject_strict_score_threshold{5.5};
+
+  bool enable_open_loop_strict_score_threshold{false};
+  double open_loop_strict_min_accepted_gap_sec{15.0};
+  double open_loop_strict_min_seed_translation_m{100.0};
+  double open_loop_strict_score_threshold{5.25};
+
+  bool enable_borderline_seed_rejection_gate{false};
+  double borderline_seed_gate_score_threshold{5.25};
+  double borderline_seed_gate_min_seed_translation_m{1.0};
+
+  bool enable_rejected_seed_update{false};
+  int rejected_seed_update_min_rejections{0};
+  double rejected_seed_update_max_fitness{10.0};
+  double rejected_seed_update_max_correction_translation_m{2.0};
+  double rejected_seed_update_max_correction_yaw_deg{2.0};
+};
+
+struct MeasurementGateInput
+{
+  double fitness_score{0.0};
+  double accepted_gap_sec{0.0};
+  double seed_translation_since_accept_m{0.0};
+  double correction_translation_m{0.0};
+  double correction_yaw_deg{0.0};
+  std::size_t consecutive_rejected_updates{0};
+};
+
+struct MeasurementGateParamConfig
+{
+  double score_threshold{2.0};
+  bool reject_above_score_threshold{true};
+
+  bool enable_consistency_recovery_gate{false};
+  int consistency_recovery_min_rejections{10};
+  double consistency_recovery_score_margin{2.0};
+  double consistency_recovery_max_translation_m{0.05};
+  double consistency_recovery_max_yaw_deg{0.5};
+
+  bool enable_post_reject_strict_score_threshold{false};
+  int post_reject_strict_min_rejections{100};
+  double post_reject_strict_score_threshold{5.5};
+
+  bool enable_open_loop_strict_score_threshold{false};
+  double open_loop_strict_min_accepted_gap_sec{15.0};
+  double open_loop_strict_min_seed_translation_m{100.0};
+  double open_loop_strict_score_threshold{5.25};
+
+  bool enable_borderline_seed_rejection_gate{false};
+  double borderline_seed_gate_score_threshold{5.25};
+  double borderline_seed_gate_min_seed_translation_m{1.0};
+
+  bool enable_rejected_seed_update{false};
+  int rejected_seed_update_min_rejections{0};
+  double rejected_seed_update_max_fitness{10.0};
+  double rejected_seed_update_max_correction_translation_m{2.0};
+  double rejected_seed_update_max_correction_yaw_deg{2.0};
+};
+
+struct EffectiveScoreThresholdDecision
+{
+  double effective_score_threshold{0.0};
+  bool post_reject_strict_active{false};
+  bool open_loop_strict_active{false};
+};
+
+struct MeasurementGateDecision
+{
+  std::uint8_t status_level{kMeasurementGateOk};
+  std::string status_message{"ok"};
+  bool reject_measurement{false};
+  bool post_reject_strict_active{false};
+  bool open_loop_strict_active{false};
+  bool borderline_seed_gate_active{false};
+  bool rejected_seed_update_applied{false};
+  double effective_score_threshold{0.0};
+};
+
+inline MeasurementGateParams makeMeasurementGateParams(
+  const MeasurementGateParamConfig & config)
+{
+  MeasurementGateParams params;
+  params.score_threshold = config.score_threshold;
+  params.reject_above_score_threshold = config.reject_above_score_threshold;
+  params.enable_consistency_recovery_gate = config.enable_consistency_recovery_gate;
+  params.consistency_recovery_min_rejections =
+    config.consistency_recovery_min_rejections;
+  params.consistency_recovery_score_margin = config.consistency_recovery_score_margin;
+  params.consistency_recovery_max_translation_m =
+    config.consistency_recovery_max_translation_m;
+  params.consistency_recovery_max_yaw_deg =
+    config.consistency_recovery_max_yaw_deg;
+  params.enable_post_reject_strict_score_threshold =
+    config.enable_post_reject_strict_score_threshold;
+  params.post_reject_strict_min_rejections =
+    config.post_reject_strict_min_rejections;
+  params.post_reject_strict_score_threshold =
+    config.post_reject_strict_score_threshold;
+  params.enable_open_loop_strict_score_threshold =
+    config.enable_open_loop_strict_score_threshold;
+  params.open_loop_strict_min_accepted_gap_sec =
+    config.open_loop_strict_min_accepted_gap_sec;
+  params.open_loop_strict_min_seed_translation_m =
+    config.open_loop_strict_min_seed_translation_m;
+  params.open_loop_strict_score_threshold =
+    config.open_loop_strict_score_threshold;
+  params.enable_borderline_seed_rejection_gate =
+    config.enable_borderline_seed_rejection_gate;
+  params.borderline_seed_gate_score_threshold =
+    config.borderline_seed_gate_score_threshold;
+  params.borderline_seed_gate_min_seed_translation_m =
+    config.borderline_seed_gate_min_seed_translation_m;
+  params.enable_rejected_seed_update = config.enable_rejected_seed_update;
+  params.rejected_seed_update_min_rejections =
+    config.rejected_seed_update_min_rejections;
+  params.rejected_seed_update_max_fitness = config.rejected_seed_update_max_fitness;
+  params.rejected_seed_update_max_correction_translation_m =
+    config.rejected_seed_update_max_correction_translation_m;
+  params.rejected_seed_update_max_correction_yaw_deg =
+    config.rejected_seed_update_max_correction_yaw_deg;
+  return params;
+}
+
+inline MeasurementGateInput makeMeasurementGateInput(
+  double fitness_score,
+  double accepted_gap_sec,
+  double seed_translation_since_accept_m,
+  double correction_translation_m,
+  double correction_yaw_deg,
+  std::size_t consecutive_rejected_updates)
+{
+  return {
+    fitness_score,
+    accepted_gap_sec,
+    seed_translation_since_accept_m,
+    correction_translation_m,
+    correction_yaw_deg,
+    consecutive_rejected_updates};
+}
+
+inline EffectiveScoreThresholdDecision computeEffectiveScoreThreshold(
+  const MeasurementGateParams & params,
+  const MeasurementGateInput & input)
+{
+  EffectiveScoreThresholdDecision decision;
+  decision.post_reject_strict_active =
+    params.enable_post_reject_strict_score_threshold &&
+    static_cast<int>(input.consecutive_rejected_updates) >=
+    params.post_reject_strict_min_rejections &&
+    params.post_reject_strict_score_threshold < params.score_threshold;
+  decision.open_loop_strict_active =
+    params.enable_open_loop_strict_score_threshold &&
+    input.accepted_gap_sec >= params.open_loop_strict_min_accepted_gap_sec &&
+    input.seed_translation_since_accept_m >= params.open_loop_strict_min_seed_translation_m &&
+    params.open_loop_strict_score_threshold < params.score_threshold;
+
+  decision.effective_score_threshold = params.score_threshold;
+  if (
+    decision.post_reject_strict_active &&
+    params.post_reject_strict_score_threshold < decision.effective_score_threshold)
+  {
+    decision.effective_score_threshold = params.post_reject_strict_score_threshold;
+  }
+  if (
+    decision.open_loop_strict_active &&
+    params.open_loop_strict_score_threshold < decision.effective_score_threshold)
+  {
+    decision.effective_score_threshold = params.open_loop_strict_score_threshold;
+  }
+  return decision;
+}
+
+inline bool isBorderlineSeedGateActive(
+  const MeasurementGateParams & params,
+  const MeasurementGateInput & input,
+  double effective_score_threshold)
+{
+  return params.enable_borderline_seed_rejection_gate &&
+         params.borderline_seed_gate_score_threshold < effective_score_threshold &&
+         input.fitness_score > params.borderline_seed_gate_score_threshold &&
+         input.fitness_score <= effective_score_threshold &&
+         input.seed_translation_since_accept_m >=
+         params.borderline_seed_gate_min_seed_translation_m;
+}
+
+inline MeasurementGateDecision evaluateMeasurementGate(
+  const MeasurementGateParams & params,
+  const MeasurementGateInput & input)
+{
+  MeasurementGateDecision gate;
+  const auto threshold_decision = computeEffectiveScoreThreshold(params, input);
+  gate.effective_score_threshold = threshold_decision.effective_score_threshold;
+  gate.post_reject_strict_active = threshold_decision.post_reject_strict_active;
+  gate.open_loop_strict_active = threshold_decision.open_loop_strict_active;
+  gate.borderline_seed_gate_active =
+    isBorderlineSeedGateActive(params, input, gate.effective_score_threshold);
+
+  const bool threshold_exceeded = input.fitness_score > gate.effective_score_threshold;
+  if (!threshold_exceeded && !gate.borderline_seed_gate_active) {
+    return gate;
+  }
+
+  gate.status_level = kMeasurementGateWarn;
+  if (gate.borderline_seed_gate_active) {
+    gate.status_message = params.reject_above_score_threshold ?
+      "fitness_score_over_borderline_seed_gate_rejected" :
+      "fitness_score_over_borderline_seed_gate";
+  } else if (
+    gate.open_loop_strict_active &&
+    gate.effective_score_threshold == params.open_loop_strict_score_threshold)
+  {
+    gate.status_message = params.reject_above_score_threshold ?
+      "fitness_score_over_open_loop_strict_threshold_rejected" :
+      "fitness_score_over_open_loop_strict_threshold";
+  } else if (gate.post_reject_strict_active) {
+    gate.status_message = params.reject_above_score_threshold ?
+      "fitness_score_over_post_reject_strict_threshold_rejected" :
+      "fitness_score_over_post_reject_strict_threshold";
+  } else {
+    gate.status_message = params.reject_above_score_threshold ?
+      "fitness_score_over_threshold_rejected" :
+      "fitness_score_over_threshold";
+  }
+  gate.reject_measurement = params.reject_above_score_threshold;
+
+  const bool recovery_candidate =
+    params.enable_consistency_recovery_gate &&
+    gate.reject_measurement &&
+    static_cast<int>(input.consecutive_rejected_updates) >=
+    params.consistency_recovery_min_rejections &&
+    input.fitness_score <= params.score_threshold + params.consistency_recovery_score_margin &&
+    input.correction_translation_m <= params.consistency_recovery_max_translation_m &&
+    input.correction_yaw_deg <= params.consistency_recovery_max_yaw_deg;
+  if (recovery_candidate) {
+    gate.reject_measurement = false;
+    gate.status_message = "fitness_score_over_threshold_consistency_recovered";
+  }
+
+  const bool rejected_seed_update_candidate =
+    params.enable_rejected_seed_update &&
+    gate.reject_measurement &&
+    static_cast<int>(input.consecutive_rejected_updates) >=
+    params.rejected_seed_update_min_rejections &&
+    input.fitness_score <= params.rejected_seed_update_max_fitness &&
+    input.correction_translation_m <= params.rejected_seed_update_max_correction_translation_m &&
+    input.correction_yaw_deg <= params.rejected_seed_update_max_correction_yaw_deg;
+  if (rejected_seed_update_candidate) {
+    gate.rejected_seed_update_applied = true;
+    gate.status_message += "_seeded";
+  }
+  return gate;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_MEASUREMENT_GATE_POLICY_HPP_

--- a/include/lidar_localization/ndt_initializer_policy.hpp
+++ b/include/lidar_localization/ndt_initializer_policy.hpp
@@ -1,0 +1,59 @@
+#ifndef LIDAR_LOCALIZATION_NDT_INITIALIZER_POLICY_HPP_
+#define LIDAR_LOCALIZATION_NDT_INITIALIZER_POLICY_HPP_
+
+#include <algorithm>
+
+namespace lidar_localization
+{
+
+struct NdtInitializerRunInput
+{
+  bool enabled{false};
+  bool initializer_available{false};
+  int scan_count{0};
+  int scans_required{0};
+};
+
+struct NdtInitializerProgressInput
+{
+  NdtInitializerRunInput run_input;
+  bool has_converged{false};
+};
+
+struct NdtInitializerProgressDecision
+{
+  bool should_run{false};
+  bool should_accept_refined_seed{false};
+  int next_scan_count{0};
+  bool completed{false};
+  bool should_reset_initializer{false};
+};
+
+inline bool shouldRunNdtInitializer(const NdtInitializerRunInput & input)
+{
+  return input.enabled &&
+         input.initializer_available &&
+         input.scans_required > 0 &&
+         input.scan_count < input.scans_required;
+}
+
+inline NdtInitializerProgressDecision updateNdtInitializerProgress(
+  const NdtInitializerProgressInput & input)
+{
+  NdtInitializerProgressDecision decision;
+  decision.should_run = shouldRunNdtInitializer(input.run_input);
+  decision.next_scan_count = input.run_input.scan_count;
+  if (!decision.should_run || !input.has_converged) {
+    return decision;
+  }
+
+  decision.should_accept_refined_seed = true;
+  decision.next_scan_count = std::max(0, input.run_input.scan_count) + 1;
+  decision.completed = decision.next_scan_count >= input.run_input.scans_required;
+  decision.should_reset_initializer = decision.completed;
+  return decision;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_NDT_INITIALIZER_POLICY_HPP_

--- a/include/lidar_localization/parameter_validation_policy.hpp
+++ b/include/lidar_localization/parameter_validation_policy.hpp
@@ -1,0 +1,64 @@
+#ifndef LIDAR_LOCALIZATION_PARAMETER_VALIDATION_POLICY_HPP_
+#define LIDAR_LOCALIZATION_PARAMETER_VALIDATION_POLICY_HPP_
+
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+
+namespace lidar_localization
+{
+
+constexpr int kMinimumPositiveIntParameter = 1;
+constexpr double kDefaultPosePublishFrequencyHz = 10.0;
+
+template<typename T>
+struct NormalizedParameterValue
+{
+  T value{};
+  bool was_adjusted{false};
+};
+
+inline NormalizedParameterValue<int> normalizePositiveIntParameter(
+  int requested,
+  int fallback = kMinimumPositiveIntParameter)
+{
+  const int valid_fallback = fallback > 0 ? fallback : kMinimumPositiveIntParameter;
+  if (requested > 0) {
+    return {requested, false};
+  }
+  return {valid_fallback, true};
+}
+
+inline NormalizedParameterValue<std::size_t> normalizeLocalMapMinPoints(int requested)
+{
+  const auto normalized = normalizePositiveIntParameter(requested);
+  return {static_cast<std::size_t>(normalized.value), normalized.was_adjusted};
+}
+
+inline NormalizedParameterValue<double> normalizePositiveFiniteDoubleParameter(
+  double requested,
+  double fallback)
+{
+  const double valid_fallback =
+    std::isfinite(fallback) && fallback > 0.0 ? fallback : kDefaultPosePublishFrequencyHz;
+  if (std::isfinite(requested) && requested > 0.0) {
+    return {requested, false};
+  }
+  return {valid_fallback, true};
+}
+
+inline NormalizedParameterValue<double> normalizePosePublishFrequencyHz(double requested)
+{
+  return normalizePositiveFiniteDoubleParameter(requested, kDefaultPosePublishFrequencyHz);
+}
+
+inline std::chrono::nanoseconds posePublishPeriodFromFrequencyHz(double frequency_hz)
+{
+  const auto normalized = normalizePosePublishFrequencyHz(frequency_hz);
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+    std::chrono::duration<double>(1.0 / normalized.value));
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_PARAMETER_VALIDATION_POLICY_HPP_

--- a/include/lidar_localization/point_cloud_conversion.hpp
+++ b/include/lidar_localization/point_cloud_conversion.hpp
@@ -1,0 +1,174 @@
+#ifndef LIDAR_LOCALIZATION_POINT_CLOUD_CONVERSION_HPP_
+#define LIDAR_LOCALIZATION_POINT_CLOUD_CONVERSION_HPP_
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <pcl/PCLPointCloud2.h>
+#include <pcl/conversions.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/msg/point_field.hpp>
+
+namespace lidar_localization
+{
+
+template<typename FieldContainerT>
+bool hasPointField(const FieldContainerT & fields, const std::string & field_name)
+{
+  return std::any_of(
+    fields.begin(), fields.end(),
+    [&field_name](const auto & field) {
+      return field.name == field_name;
+    });
+}
+
+inline const sensor_msgs::msg::PointField * findPointField(
+  const std::vector<sensor_msgs::msg::PointField> & fields,
+  const std::string & field_name)
+{
+  const auto it = std::find_if(
+    fields.begin(), fields.end(),
+    [&field_name](const auto & field) {
+      return field.name == field_name;
+    });
+  return it == fields.end() ? nullptr : &(*it);
+}
+
+inline bool readPointFieldAsFloat(
+  const uint8_t * point_data,
+  const sensor_msgs::msg::PointField & field,
+  float * value)
+{
+  const uint8_t * field_ptr = point_data + field.offset;
+  switch (field.datatype) {
+    case sensor_msgs::msg::PointField::INT8:
+      *value = static_cast<float>(*reinterpret_cast<const int8_t *>(field_ptr));
+      return true;
+    case sensor_msgs::msg::PointField::UINT8:
+      *value = static_cast<float>(*reinterpret_cast<const uint8_t *>(field_ptr));
+      return true;
+    case sensor_msgs::msg::PointField::INT16: {
+      int16_t raw;
+      std::memcpy(&raw, field_ptr, sizeof(raw));
+      *value = static_cast<float>(raw);
+      return true;
+    }
+    case sensor_msgs::msg::PointField::UINT16: {
+      uint16_t raw;
+      std::memcpy(&raw, field_ptr, sizeof(raw));
+      *value = static_cast<float>(raw);
+      return true;
+    }
+    case sensor_msgs::msg::PointField::INT32: {
+      int32_t raw;
+      std::memcpy(&raw, field_ptr, sizeof(raw));
+      *value = static_cast<float>(raw);
+      return true;
+    }
+    case sensor_msgs::msg::PointField::UINT32: {
+      uint32_t raw;
+      std::memcpy(&raw, field_ptr, sizeof(raw));
+      *value = static_cast<float>(raw);
+      return true;
+    }
+    case sensor_msgs::msg::PointField::FLOAT32:
+      std::memcpy(value, field_ptr, sizeof(float));
+      return true;
+    case sensor_msgs::msg::PointField::FLOAT64: {
+      double raw;
+      std::memcpy(&raw, field_ptr, sizeof(raw));
+      *value = static_cast<float>(raw);
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+
+inline void copyXyzToXyzi(
+  const pcl::PointCloud<pcl::PointXYZ> & input,
+  pcl::PointCloud<pcl::PointXYZI> & output)
+{
+  output.clear();
+  output.reserve(input.size());
+  output.header = input.header;
+  output.width = input.width;
+  output.height = input.height;
+  output.is_dense = input.is_dense;
+
+  for (const auto & point : input.points) {
+    pcl::PointXYZI converted;
+    converted.x = point.x;
+    converted.y = point.y;
+    converted.z = point.z;
+    converted.intensity = 0.0f;
+    output.push_back(converted);
+  }
+}
+
+inline void convertSensorCloudToXyzi(
+  const sensor_msgs::msg::PointCloud2 & input,
+  pcl::PointCloud<pcl::PointXYZI> & output)
+{
+  const auto * x_field = findPointField(input.fields, "x");
+  const auto * y_field = findPointField(input.fields, "y");
+  const auto * z_field = findPointField(input.fields, "z");
+  const auto * intensity_field = findPointField(input.fields, "intensity");
+  if (!x_field || !y_field || !z_field) {
+    output.clear();
+    output.width = 0;
+    output.height = 1;
+    output.is_dense = false;
+    pcl_conversions::toPCL(input.header, output.header);
+    return;
+  }
+
+  output.clear();
+  output.reserve(static_cast<std::size_t>(input.width) * static_cast<std::size_t>(input.height));
+  pcl_conversions::toPCL(input.header, output.header);
+  output.is_dense = input.is_dense;
+
+  const std::size_t point_count =
+    static_cast<std::size_t>(input.width) * static_cast<std::size_t>(input.height);
+  for (std::size_t point_idx = 0; point_idx < point_count; ++point_idx) {
+    const uint8_t * point_data = input.data.data() + point_idx * input.point_step;
+    pcl::PointXYZI point;
+    float intensity = 0.0f;
+    if (!readPointFieldAsFloat(point_data, *x_field, &point.x) ||
+      !readPointFieldAsFloat(point_data, *y_field, &point.y) ||
+      !readPointFieldAsFloat(point_data, *z_field, &point.z))
+    {
+      continue;
+    }
+    if (intensity_field) {
+      readPointFieldAsFloat(point_data, *intensity_field, &intensity);
+    }
+    point.intensity = intensity;
+    output.push_back(point);
+  }
+}
+
+inline bool convertPclCloudToXyzi(
+  const pcl::PCLPointCloud2 & input,
+  pcl::PointCloud<pcl::PointXYZI> & output)
+{
+  if (hasPointField(input.fields, "intensity")) {
+    pcl::fromPCLPointCloud2(input, output);
+    return true;
+  }
+
+  pcl::PointCloud<pcl::PointXYZ> xyz_cloud;
+  pcl::fromPCLPointCloud2(input, xyz_cloud);
+  copyXyzToXyzi(xyz_cloud, output);
+  return false;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_POINT_CLOUD_CONVERSION_HPP_

--- a/include/lidar_localization/pose_backend_result_policy.hpp
+++ b/include/lidar_localization/pose_backend_result_policy.hpp
@@ -1,0 +1,89 @@
+#ifndef LIDAR_LOCALIZATION_POSE_BACKEND_RESULT_POLICY_HPP_
+#define LIDAR_LOCALIZATION_POSE_BACKEND_RESULT_POLICY_HPP_
+
+#include <cstdint>
+#include <string>
+
+#include <Eigen/Dense>
+
+#include "lidar_localization/localization_update_policy.hpp"
+
+namespace lidar_localization
+{
+
+struct PoseBackendResult
+{
+  Eigen::Matrix4f pose_matrix{Eigen::Matrix4f::Identity()};
+  std::uint8_t status_level{0};
+  std::string status_message{"ok"};
+  bool update_current_pose{true};
+  bool update_prediction_state{true};
+  bool advance_prediction_without_measurement{false};
+  bool update_prediction_from_rejected_measurement{false};
+  bool fill_pose_covariance{true};
+  bool continue_to_pose_publish{true};
+};
+
+inline PoseBackendResult makePoseBackendResult(
+  const Eigen::Matrix4f & pose_matrix,
+  std::uint8_t status_level,
+  const std::string & status_message)
+{
+  PoseBackendResult result;
+  result.pose_matrix = pose_matrix;
+  result.status_level = status_level;
+  result.status_message = status_message;
+  return result;
+}
+
+inline PoseBackendResult makePoseBackendResultFromLocalizationUpdate(
+  const Eigen::Matrix4f & pose_matrix,
+  std::uint8_t status_level,
+  const std::string & status_message,
+  const LocalizationUpdateDecision & localization_update)
+{
+  PoseBackendResult result =
+    makePoseBackendResult(pose_matrix, status_level, status_message);
+  result.update_current_pose = localization_update.update_current_pose;
+  result.update_prediction_state =
+    localization_update.update_prediction_from_accepted_measurement;
+  result.advance_prediction_without_measurement =
+    localization_update.advance_prediction_without_measurement;
+  result.update_prediction_from_rejected_measurement =
+    localization_update.update_prediction_from_rejected_measurement;
+  result.fill_pose_covariance =
+    localization_update.update_current_pose ||
+    localization_update.update_prediction_from_accepted_measurement;
+  result.continue_to_pose_publish = localization_update.continue_to_pose_publish;
+  return result;
+}
+
+inline PoseBackendResult applyPoseBackendWarningStatus(
+  const PoseBackendResult & current,
+  bool warning,
+  std::uint8_t warning_level,
+  const std::string & warning_message)
+{
+  if (!warning) {
+    return current;
+  }
+
+  PoseBackendResult result = current;
+  result.status_level = warning_level;
+  result.status_message = warning_message;
+  return result;
+}
+
+inline PoseBackendResult applyPoseBackendUpdateStatus(
+  const PoseBackendResult & current,
+  bool backend_updated,
+  std::uint8_t warning_level,
+  const std::string & rejected_status_message)
+{
+  return applyPoseBackendWarningStatus(
+    current, !backend_updated, warning_level, rejected_status_message);
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_POSE_BACKEND_RESULT_POLICY_HPP_

--- a/include/lidar_localization/pose_backend_selection_policy.hpp
+++ b/include/lidar_localization/pose_backend_selection_policy.hpp
@@ -1,0 +1,39 @@
+#ifndef LIDAR_LOCALIZATION_POSE_BACKEND_SELECTION_POLICY_HPP_
+#define LIDAR_LOCALIZATION_POSE_BACKEND_SELECTION_POLICY_HPP_
+
+namespace lidar_localization
+{
+
+enum class PoseBackendKind
+{
+  kGtsamSmoother = 0,
+  kImuPreintegration,
+  kTwistEkf,
+  kRawRegistration,
+};
+
+struct PoseBackendSelectionInput
+{
+  bool use_gtsam_smoother{false};
+  bool use_imu_preintegration{false};
+  bool has_imu_stamp{false};
+  bool use_twist_ekf{false};
+};
+
+inline PoseBackendKind selectPoseBackend(const PoseBackendSelectionInput & input)
+{
+  if (input.use_gtsam_smoother) {
+    return PoseBackendKind::kGtsamSmoother;
+  }
+  if (input.use_imu_preintegration && input.has_imu_stamp) {
+    return PoseBackendKind::kImuPreintegration;
+  }
+  if (input.use_twist_ekf) {
+    return PoseBackendKind::kTwistEkf;
+  }
+  return PoseBackendKind::kRawRegistration;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_POSE_BACKEND_SELECTION_POLICY_HPP_

--- a/include/lidar_localization/pose_covariance_policy.hpp
+++ b/include/lidar_localization/pose_covariance_policy.hpp
@@ -1,0 +1,53 @@
+#ifndef LIDAR_LOCALIZATION_POSE_COVARIANCE_POLICY_HPP_
+#define LIDAR_LOCALIZATION_POSE_COVARIANCE_POLICY_HPP_
+
+#include <algorithm>
+#include <array>
+
+#include <Eigen/Core>
+
+namespace lidar_localization
+{
+
+using PoseCovariance = std::array<double, 36>;
+using EkfStateCovariance = Eigen::Matrix<double, 9, 9>;
+
+inline double poseCovarianceScale(double fitness_score)
+{
+  return std::max(1.0, fitness_score);
+}
+
+inline PoseCovariance makeFitnessPoseCovariance(double fitness_score)
+{
+  PoseCovariance covariance{};
+  const double scale = poseCovarianceScale(fitness_score);
+  covariance[0] = 0.01 * scale;
+  covariance[7] = 0.01 * scale;
+  covariance[14] = 0.05 * scale;
+  covariance[21] = 0.001 * scale;
+  covariance[28] = 0.001 * scale;
+  covariance[35] = 0.0005 * scale;
+  return covariance;
+}
+
+inline PoseCovariance makeEkfPoseCovariance(
+  const EkfStateCovariance & ekf_covariance,
+  double fitness_score)
+{
+  PoseCovariance covariance{};
+  covariance[0] = ekf_covariance(0, 0);
+  covariance[1] = ekf_covariance(0, 1);
+  covariance[6] = ekf_covariance(1, 0);
+  covariance[7] = ekf_covariance(1, 1);
+  covariance[14] = ekf_covariance(2, 2);
+  covariance[35] = ekf_covariance(6, 6);
+
+  const double scale = poseCovarianceScale(fitness_score);
+  covariance[21] = 0.001 * scale;
+  covariance[28] = 0.001 * scale;
+  return covariance;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_POSE_COVARIANCE_POLICY_HPP_

--- a/include/lidar_localization/pose_publish_policy.hpp
+++ b/include/lidar_localization/pose_publish_policy.hpp
@@ -1,0 +1,101 @@
+#ifndef LIDAR_LOCALIZATION_POSE_PUBLISH_POLICY_HPP_
+#define LIDAR_LOCALIZATION_POSE_PUBLISH_POLICY_HPP_
+
+#include <string>
+
+#include <Eigen/Geometry>
+#include <builtin_interfaces/msg/time.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <nav_msgs/msg/path.hpp>
+#include <tf2/transform_datatypes.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+namespace lidar_localization
+{
+
+inline geometry_msgs::msg::Pose poseFromMatrix(const Eigen::Matrix4f & pose_matrix)
+{
+  geometry_msgs::msg::Pose pose;
+  const Eigen::Matrix3d rot_mat = pose_matrix.block<3, 3>(0, 0).cast<double>();
+  const Eigen::Quaterniond quat_eig(rot_mat);
+  pose.position.x = static_cast<double>(pose_matrix(0, 3));
+  pose.position.y = static_cast<double>(pose_matrix(1, 3));
+  pose.position.z = static_cast<double>(pose_matrix(2, 3));
+  pose.orientation.x = quat_eig.x();
+  pose.orientation.y = quat_eig.y();
+  pose.orientation.z = quat_eig.z();
+  pose.orientation.w = quat_eig.w();
+  return pose;
+}
+
+inline geometry_msgs::msg::PoseStamped makePoseStamped(
+  const builtin_interfaces::msg::Time & stamp,
+  const std::string & frame_id,
+  const geometry_msgs::msg::Pose & pose)
+{
+  geometry_msgs::msg::PoseStamped pose_stamped;
+  pose_stamped.header.stamp = stamp;
+  pose_stamped.header.frame_id = frame_id;
+  pose_stamped.pose = pose;
+  return pose_stamped;
+}
+
+inline geometry_msgs::msg::PoseWithCovarianceStamped stampPoseWithCovariance(
+  const geometry_msgs::msg::PoseWithCovarianceStamped & pose,
+  const builtin_interfaces::msg::Time & stamp)
+{
+  geometry_msgs::msg::PoseWithCovarianceStamped stamped_pose = pose;
+  stamped_pose.header.stamp = stamp;
+  return stamped_pose;
+}
+
+inline void appendPoseToPath(
+  nav_msgs::msg::Path & path,
+  const geometry_msgs::msg::PoseStamped & pose_stamped)
+{
+  path.poses.push_back(pose_stamped);
+}
+
+inline geometry_msgs::msg::TransformStamped makeMapToBaseTransform(
+  const builtin_interfaces::msg::Time & stamp,
+  const std::string & global_frame_id,
+  const std::string & base_frame_id,
+  const geometry_msgs::msg::Pose & pose)
+{
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.stamp = stamp;
+  transform.header.frame_id = global_frame_id;
+  transform.child_frame_id = base_frame_id;
+  transform.transform.translation.x = pose.position.x;
+  transform.transform.translation.y = pose.position.y;
+  transform.transform.translation.z = pose.position.z;
+  transform.transform.rotation = pose.orientation;
+  return transform;
+}
+
+inline geometry_msgs::msg::TransformStamped composeMapToOdomTransform(
+  const builtin_interfaces::msg::Time & stamp,
+  const std::string & global_frame_id,
+  const std::string & odom_frame_id,
+  const geometry_msgs::msg::TransformStamped & map_to_base_link,
+  const geometry_msgs::msg::TransformStamped & odom_to_base_link)
+{
+  tf2::Transform map_to_base_link_tf;
+  tf2::Transform odom_to_base_link_tf;
+  tf2::fromMsg(map_to_base_link.transform, map_to_base_link_tf);
+  tf2::fromMsg(odom_to_base_link.transform, odom_to_base_link_tf);
+
+  geometry_msgs::msg::TransformStamped map_to_odom;
+  map_to_odom.header.stamp = stamp;
+  map_to_odom.header.frame_id = global_frame_id;
+  map_to_odom.child_frame_id = odom_frame_id;
+  map_to_odom.transform = tf2::toMsg(map_to_base_link_tf * odom_to_base_link_tf.inverse());
+  return map_to_odom;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_POSE_PUBLISH_POLICY_HPP_

--- a/include/lidar_localization/prediction_state_policy.hpp
+++ b/include/lidar_localization/prediction_state_policy.hpp
@@ -1,0 +1,126 @@
+#ifndef LIDAR_LOCALIZATION_PREDICTION_STATE_POLICY_HPP_
+#define LIDAR_LOCALIZATION_PREDICTION_STATE_POLICY_HPP_
+
+#include <cstddef>
+
+#include <Eigen/Geometry>
+
+namespace lidar_localization
+{
+
+enum class PredictionAdvanceMode
+{
+  kNone = 0,
+  kTwistPrediction,
+  kPreviousDelta,
+};
+
+struct PredictionStateSnapshot
+{
+  bool have_last_accepted_pose{false};
+  Eigen::Matrix4f last_accepted_pose_matrix{Eigen::Matrix4f::Identity()};
+  Eigen::Matrix4f predicted_pose_matrix{Eigen::Matrix4f::Identity()};
+  Eigen::Matrix4f last_relative_motion_matrix{Eigen::Matrix4f::Identity()};
+  std::size_t consecutive_rejected_updates{0};
+  double last_accepted_pose_time_sec{0.0};
+  double predicted_pose_time_sec{0.0};
+};
+
+inline PredictionStateSnapshot resetPredictionState(
+  const Eigen::Matrix4f & pose_matrix,
+  double stamp_sec)
+{
+  PredictionStateSnapshot state;
+  state.have_last_accepted_pose = true;
+  state.last_accepted_pose_matrix = pose_matrix;
+  state.predicted_pose_matrix = pose_matrix;
+  state.last_relative_motion_matrix = Eigen::Matrix4f::Identity();
+  state.consecutive_rejected_updates = 0;
+  state.last_accepted_pose_time_sec = stamp_sec;
+  state.predicted_pose_time_sec = stamp_sec;
+  return state;
+}
+
+inline PredictionStateSnapshot updatePredictionStateFromAcceptedMeasurement(
+  const PredictionStateSnapshot & current,
+  const Eigen::Matrix4f & accepted_pose_matrix,
+  double stamp_sec)
+{
+  if (!current.have_last_accepted_pose) {
+    return resetPredictionState(accepted_pose_matrix, stamp_sec);
+  }
+
+  PredictionStateSnapshot next = current;
+  if (current.consecutive_rejected_updates == 0) {
+    next.last_relative_motion_matrix =
+      current.last_accepted_pose_matrix.inverse() * accepted_pose_matrix;
+  }
+
+  next.last_accepted_pose_matrix = accepted_pose_matrix;
+  next.predicted_pose_matrix = accepted_pose_matrix * next.last_relative_motion_matrix;
+  next.have_last_accepted_pose = true;
+  next.consecutive_rejected_updates = 0;
+  next.last_accepted_pose_time_sec = stamp_sec;
+  next.predicted_pose_time_sec = stamp_sec;
+  return next;
+}
+
+inline PredictionAdvanceMode choosePredictionAdvanceMode(
+  bool have_last_accepted_pose,
+  bool use_twist_prediction,
+  bool has_latest_twist,
+  bool predict_pose_from_previous_delta)
+{
+  if (!have_last_accepted_pose) {
+    return PredictionAdvanceMode::kNone;
+  }
+  if (use_twist_prediction && has_latest_twist) {
+    return PredictionAdvanceMode::kTwistPrediction;
+  }
+  if (predict_pose_from_previous_delta) {
+    return PredictionAdvanceMode::kPreviousDelta;
+  }
+  return PredictionAdvanceMode::kNone;
+}
+
+inline PredictionStateSnapshot advancePredictionWithoutMeasurement(
+  const PredictionStateSnapshot & current,
+  double stamp_sec,
+  PredictionAdvanceMode mode,
+  const Eigen::Matrix4f & twist_predicted_pose_matrix = Eigen::Matrix4f::Identity())
+{
+  if (!current.have_last_accepted_pose || mode == PredictionAdvanceMode::kNone) {
+    return current;
+  }
+
+  PredictionStateSnapshot next = current;
+  if (mode == PredictionAdvanceMode::kTwistPrediction) {
+    next.predicted_pose_matrix = twist_predicted_pose_matrix;
+  } else if (mode == PredictionAdvanceMode::kPreviousDelta) {
+    next.predicted_pose_matrix =
+      current.predicted_pose_matrix * current.last_relative_motion_matrix;
+  }
+  next.predicted_pose_time_sec = stamp_sec;
+  ++next.consecutive_rejected_updates;
+  return next;
+}
+
+inline PredictionStateSnapshot updatePredictionFromRejectedMeasurement(
+  const PredictionStateSnapshot & current,
+  const Eigen::Matrix4f & rejected_pose_matrix,
+  double stamp_sec)
+{
+  if (!current.have_last_accepted_pose) {
+    return current;
+  }
+
+  PredictionStateSnapshot next = current;
+  next.predicted_pose_matrix = rejected_pose_matrix;
+  next.predicted_pose_time_sec = stamp_sec;
+  ++next.consecutive_rejected_updates;
+  return next;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_PREDICTION_STATE_POLICY_HPP_

--- a/include/lidar_localization/recovery_supervisor.hpp
+++ b/include/lidar_localization/recovery_supervisor.hpp
@@ -1,0 +1,249 @@
+#ifndef LIDAR_LOCALIZATION_RECOVERY_SUPERVISOR_HPP_
+#define LIDAR_LOCALIZATION_RECOVERY_SUPERVISOR_HPP_
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string>
+
+namespace lidar_localization
+{
+
+enum class RecoverySupervisorState : uint8_t
+{
+  kTracking = 0,
+  kDegraded = 1,
+  kRecovering = 2,
+  kReinitializationRequested = 3,
+};
+
+struct ReinitializationRequestDecision
+{
+  bool requested{false};
+  std::string reason{"not_requested"};
+  double score{0.0};
+};
+
+struct ReinitializationTriggerParams
+{
+  double threshold{0.95};
+  double gap_scale_sec{30.0};
+  double seed_translation_scale_m{100.0};
+  double reject_streak_scale{200.0};
+  double fitness_explosion_threshold{1000.0};
+};
+
+struct ReinitializationTriggerInput
+{
+  std::string status_message;
+  double fitness_score{std::numeric_limits<double>::quiet_NaN()};
+  double seed_translation_since_accept_m{std::numeric_limits<double>::quiet_NaN()};
+  double accepted_gap_sec{std::numeric_limits<double>::quiet_NaN()};
+  std::size_t consecutive_rejected_updates{0};
+};
+
+struct RecoverySupervisorEvaluation
+{
+  RecoverySupervisorState state{RecoverySupervisorState::kTracking};
+  std::string action{"accept_measurement"};
+};
+
+inline ReinitializationTriggerParams makeReinitializationTriggerParams(
+  double threshold,
+  double gap_scale_sec,
+  double seed_translation_scale_m,
+  double reject_streak_scale,
+  double fitness_explosion_threshold)
+{
+  return {
+    threshold,
+    gap_scale_sec,
+    seed_translation_scale_m,
+    reject_streak_scale,
+    fitness_explosion_threshold};
+}
+
+inline ReinitializationTriggerInput makeReinitializationTriggerInput(
+  const std::string & status_message,
+  double fitness_score,
+  double seed_translation_since_accept_m,
+  double accepted_gap_sec,
+  std::size_t consecutive_rejected_updates)
+{
+  return {
+    status_message,
+    fitness_score,
+    seed_translation_since_accept_m,
+    accepted_gap_sec,
+    consecutive_rejected_updates};
+}
+
+inline bool isRecoveryFailureStatus(const std::string & status_message)
+{
+  return status_message == "local_map_crop_too_small" ||
+         status_message == "registration_not_converged" ||
+         status_message == "filtered_scan_empty" ||
+         status_message == "scan_missing_xyz_field" ||
+         status_message.rfind("fitness_score_over_", 0) == 0;
+}
+
+inline ReinitializationRequestDecision computeReinitializationRequest(
+  const ReinitializationTriggerParams & params,
+  const ReinitializationTriggerInput & input)
+{
+  ReinitializationRequestDecision decision;
+  const bool target_unavailable = input.status_message == "local_map_crop_too_small";
+  const bool not_converged = input.status_message == "registration_not_converged";
+  const bool rejected_measurement = input.status_message.rfind("fitness_score_over_", 0) == 0;
+  const bool failure = target_unavailable || not_converged || rejected_measurement;
+
+  if (!failure) {
+    decision.reason = "not_failure";
+    return decision;
+  }
+
+  const double gap_component =
+    std::isfinite(input.accepted_gap_sec) && params.gap_scale_sec > 0.0 ?
+    std::min(1.0, input.accepted_gap_sec / params.gap_scale_sec) : 0.0;
+  const double seed_component =
+    std::isfinite(input.seed_translation_since_accept_m) &&
+    params.seed_translation_scale_m > 0.0 ?
+    std::min(1.0, input.seed_translation_since_accept_m / params.seed_translation_scale_m) : 0.0;
+  const double streak_component =
+    params.reject_streak_scale > 0.0 ?
+    std::min(
+      1.0,
+      static_cast<double>(input.consecutive_rejected_updates) /
+      params.reject_streak_scale) : 0.0;
+  const bool fitness_exploded =
+    std::isfinite(input.fitness_score) &&
+    input.fitness_score >= params.fitness_explosion_threshold;
+
+  decision.score =
+    0.45 * gap_component +
+    0.30 * seed_component +
+    0.20 * streak_component +
+    (target_unavailable ? 0.15 : 0.0) +
+    (fitness_exploded ? 0.15 : 0.0);
+
+  if (decision.score < params.threshold) {
+    decision.reason = "reinit_not_requested";
+    return decision;
+  }
+
+  decision.requested = true;
+  if (target_unavailable) {
+    decision.reason = "target_unavailable_reinit_requested";
+  } else if (fitness_exploded) {
+    decision.reason = "fitness_exploded_reinit_requested";
+  } else if (gap_component >= 1.0) {
+    decision.reason = "accepted_gap_reinit_requested";
+  } else if (streak_component >= 1.0) {
+    decision.reason = "reject_streak_reinit_requested";
+  } else {
+    decision.reason = "reinit_score_exceeded";
+  }
+  return decision;
+}
+
+inline const char * recoverySupervisorStateName(RecoverySupervisorState state)
+{
+  switch (state) {
+    case RecoverySupervisorState::kTracking:
+      return "tracking";
+    case RecoverySupervisorState::kDegraded:
+      return "degraded";
+    case RecoverySupervisorState::kRecovering:
+      return "recovering";
+    case RecoverySupervisorState::kReinitializationRequested:
+      return "reinitialization_requested";
+  }
+  return "unknown";
+}
+
+inline RecoverySupervisorState classifyRecoverySupervisorState(
+  uint8_t level,
+  const std::string & status_message,
+  const ReinitializationRequestDecision & reinitialization_request,
+  std::size_t consecutive_rejected_updates)
+{
+  constexpr uint8_t kDiagnosticOk = 0;
+  if (reinitialization_request.requested) {
+    return RecoverySupervisorState::kReinitializationRequested;
+  }
+  if (
+    status_message == "recovery_retry_from_last_pose_recovered" ||
+    isRecoveryFailureStatus(status_message) ||
+    consecutive_rejected_updates > 0)
+  {
+    return RecoverySupervisorState::kRecovering;
+  }
+  if (level != kDiagnosticOk) {
+    return RecoverySupervisorState::kDegraded;
+  }
+  return RecoverySupervisorState::kTracking;
+}
+
+inline std::string classifyRecoverySupervisorAction(
+  uint8_t level,
+  const std::string & status_message,
+  const ReinitializationRequestDecision & reinitialization_request,
+  std::size_t consecutive_rejected_updates)
+{
+  constexpr uint8_t kDiagnosticOk = 0;
+  if (reinitialization_request.requested) {
+    return "request_reinitialization";
+  }
+  if (status_message == "recovery_retry_from_last_pose_recovered") {
+    return "retry_from_last_pose";
+  }
+  if (status_message.find("_seeded") != std::string::npos) {
+    return "reuse_rejected_seed_for_prediction";
+  }
+  if (
+    status_message == "local_map_crop_too_small" ||
+    status_message == "registration_not_converged" ||
+    status_message == "filtered_scan_empty" ||
+    status_message == "scan_missing_xyz_field")
+  {
+    return "advance_prediction_without_measurement";
+  }
+  if (
+    status_message.rfind("fitness_score_over_", 0) == 0 &&
+    status_message.find("_rejected") != std::string::npos)
+  {
+    return "reject_measurement";
+  }
+  if (consecutive_rejected_updates > 0) {
+    return "accept_measurement_after_recovery";
+  }
+  if (level != kDiagnosticOk) {
+    return "accept_measurement_with_warning";
+  }
+  return "accept_measurement";
+}
+
+inline RecoverySupervisorEvaluation evaluateRecoverySupervisor(
+  uint8_t level,
+  const std::string & status_message,
+  const ReinitializationRequestDecision & reinitialization_request,
+  std::size_t consecutive_rejected_updates)
+{
+  return {
+    classifyRecoverySupervisorState(
+      level,
+      status_message,
+      reinitialization_request,
+      consecutive_rejected_updates),
+    classifyRecoverySupervisorAction(
+      level,
+      status_message,
+      reinitialization_request,
+      consecutive_rejected_updates)};
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_RECOVERY_SUPERVISOR_HPP_

--- a/include/lidar_localization/recovery_supervisor_state_policy.hpp
+++ b/include/lidar_localization/recovery_supervisor_state_policy.hpp
@@ -1,0 +1,57 @@
+#ifndef LIDAR_LOCALIZATION_RECOVERY_SUPERVISOR_STATE_POLICY_HPP_
+#define LIDAR_LOCALIZATION_RECOVERY_SUPERVISOR_STATE_POLICY_HPP_
+
+#include "lidar_localization/recovery_supervisor.hpp"
+
+#include <cstddef>
+#include <string>
+
+namespace lidar_localization
+{
+
+struct RecoverySupervisorRuntimeState
+{
+  RecoverySupervisorState state{RecoverySupervisorState::kTracking};
+  std::string action{"accept_measurement"};
+  double entered_stamp_sec{0.0};
+  std::size_t transition_count{0};
+};
+
+struct RecoverySupervisorStateUpdateInput
+{
+  RecoverySupervisorRuntimeState current;
+  RecoverySupervisorState next_state{RecoverySupervisorState::kTracking};
+  std::string next_action{"accept_measurement"};
+  double stamp_sec{0.0};
+};
+
+struct RecoverySupervisorStateUpdate
+{
+  RecoverySupervisorRuntimeState state;
+  RecoverySupervisorState previous_state{RecoverySupervisorState::kTracking};
+  bool transitioned{false};
+};
+
+inline RecoverySupervisorStateUpdate updateRecoverySupervisorRuntimeState(
+  const RecoverySupervisorStateUpdateInput & input)
+{
+  RecoverySupervisorRuntimeState state = input.current;
+  if (state.entered_stamp_sec <= 0.0) {
+    state.entered_stamp_sec = input.stamp_sec;
+  }
+
+  const RecoverySupervisorState previous_state = state.state;
+  const bool transitioned = input.next_state != state.state;
+  if (transitioned) {
+    state.state = input.next_state;
+    state.entered_stamp_sec = input.stamp_sec;
+    ++state.transition_count;
+  }
+  state.action = input.next_action;
+
+  return {state, previous_state, transitioned};
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_RECOVERY_SUPERVISOR_STATE_POLICY_HPP_

--- a/include/lidar_localization/registration_backend_policy.hpp
+++ b/include/lidar_localization/registration_backend_policy.hpp
@@ -1,0 +1,92 @@
+#ifndef LIDAR_LOCALIZATION_REGISTRATION_BACKEND_POLICY_HPP_
+#define LIDAR_LOCALIZATION_REGISTRATION_BACKEND_POLICY_HPP_
+
+#include <string>
+
+namespace lidar_localization
+{
+
+enum class RegistrationBackend
+{
+  kInvalid = 0,
+  kPclGicp,
+  kPclNdt,
+  kNdtOmp,
+  kGicpOmp,
+  kSmallGicp,
+  kSmallVgicp,
+};
+
+inline RegistrationBackend parseRegistrationBackend(const std::string & registration_method)
+{
+  if (registration_method == "GICP") {
+    return RegistrationBackend::kPclGicp;
+  }
+  if (registration_method == "NDT") {
+    return RegistrationBackend::kPclNdt;
+  }
+  if (registration_method == "NDT_OMP") {
+    return RegistrationBackend::kNdtOmp;
+  }
+  if (registration_method == "GICP_OMP") {
+    return RegistrationBackend::kGicpOmp;
+  }
+  if (registration_method == "SMALL_GICP") {
+    return RegistrationBackend::kSmallGicp;
+  }
+  if (registration_method == "SMALL_VGICP") {
+    return RegistrationBackend::kSmallVgicp;
+  }
+  return RegistrationBackend::kInvalid;
+}
+
+inline bool isValidRegistrationBackend(RegistrationBackend backend)
+{
+  return backend != RegistrationBackend::kInvalid;
+}
+
+inline bool usesFilteredTarget(RegistrationBackend backend)
+{
+  return backend == RegistrationBackend::kPclGicp ||
+         backend == RegistrationBackend::kGicpOmp ||
+         backend == RegistrationBackend::kSmallGicp ||
+         backend == RegistrationBackend::kSmallVgicp;
+}
+
+inline bool usesFilteredTarget(const std::string & registration_method)
+{
+  return usesFilteredTarget(parseRegistrationBackend(registration_method));
+}
+
+inline bool supportsNdtInitializer(RegistrationBackend backend)
+{
+  return usesFilteredTarget(backend);
+}
+
+inline bool supportsNdtInitializer(const std::string & registration_method)
+{
+  return supportsNdtInitializer(parseRegistrationBackend(registration_method));
+}
+
+inline bool isSmallGicpBackend(RegistrationBackend backend)
+{
+  return backend == RegistrationBackend::kSmallGicp ||
+         backend == RegistrationBackend::kSmallVgicp;
+}
+
+inline const char * smallGicpRegistrationType(RegistrationBackend backend)
+{
+  return backend == RegistrationBackend::kSmallVgicp ? "VGICP" : "GICP";
+}
+
+inline int resolveRegistrationThreadCount(int requested_threads, int fallback_threads)
+{
+  if (requested_threads > 0) {
+    return requested_threads;
+  }
+  return fallback_threads > 0 ? fallback_threads : 1;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_REGISTRATION_BACKEND_POLICY_HPP_

--- a/include/lidar_localization/registration_observation_policy.hpp
+++ b/include/lidar_localization/registration_observation_policy.hpp
@@ -1,0 +1,85 @@
+#ifndef LIDAR_LOCALIZATION_REGISTRATION_OBSERVATION_POLICY_HPP_
+#define LIDAR_LOCALIZATION_REGISTRATION_OBSERVATION_POLICY_HPP_
+
+#include <algorithm>
+#include <cmath>
+
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+
+namespace lidar_localization
+{
+
+constexpr double kRegistrationObservationPi = 3.14159265358979323846;
+
+struct RegistrationObservation
+{
+  Eigen::Matrix4f pose_matrix{Eigen::Matrix4f::Identity()};
+  double x{0.0};
+  double y{0.0};
+  double z{0.0};
+  double roll{0.0};
+  double pitch{0.0};
+  double yaw{0.0};
+};
+
+inline RegistrationObservation makeRegistrationObservation(const Eigen::Matrix4f & pose_matrix)
+{
+  const Eigen::Matrix3f rotation = pose_matrix.block<3, 3>(0, 0);
+
+  RegistrationObservation observation;
+  observation.pose_matrix = pose_matrix;
+  observation.x = static_cast<double>(pose_matrix(0, 3));
+  observation.y = static_cast<double>(pose_matrix(1, 3));
+  observation.z = static_cast<double>(pose_matrix(2, 3));
+  observation.roll = static_cast<double>(std::atan2(rotation(2, 1), rotation(2, 2)));
+  observation.pitch = static_cast<double>(
+    std::asin(-std::clamp(rotation(2, 0), -1.0f, 1.0f)));
+  observation.yaw = static_cast<double>(std::atan2(rotation(1, 0), rotation(0, 0)));
+  return observation;
+}
+
+inline double rotationDeltaDeg(
+  const Eigen::Matrix3f & reference_rotation,
+  const Eigen::Matrix3f & candidate_rotation)
+{
+  const Eigen::Matrix3d relative_rotation =
+    reference_rotation.cast<double>().transpose() * candidate_rotation.cast<double>();
+  const double trace =
+    std::clamp((relative_rotation.trace() - 1.0) * 0.5, -1.0, 1.0);
+  return std::acos(trace) * 180.0 / kRegistrationObservationPi;
+}
+
+inline double rotationDeltaDeg(
+  const Eigen::Matrix4f & reference_pose,
+  const Eigen::Matrix4f & candidate_pose)
+{
+  const Eigen::Matrix3f reference_rotation = reference_pose.block<3, 3>(0, 0);
+  const Eigen::Matrix3f candidate_rotation = candidate_pose.block<3, 3>(0, 0);
+  return rotationDeltaDeg(reference_rotation, candidate_rotation);
+}
+
+inline Eigen::Matrix4f makePoseMatrix(
+  double x,
+  double y,
+  double z,
+  double roll,
+  double pitch,
+  double yaw)
+{
+  Eigen::Affine3f affine = Eigen::Affine3f::Identity();
+  affine.translation() = Eigen::Vector3f(
+    static_cast<float>(x),
+    static_cast<float>(y),
+    static_cast<float>(z));
+  affine.linear() = (
+    Eigen::AngleAxisf(static_cast<float>(yaw), Eigen::Vector3f::UnitZ()) *
+    Eigen::AngleAxisf(static_cast<float>(pitch), Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(static_cast<float>(roll), Eigen::Vector3f::UnitX())
+  ).toRotationMatrix();
+  return affine.matrix();
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_REGISTRATION_OBSERVATION_POLICY_HPP_

--- a/include/lidar_localization/registration_seed_policy.hpp
+++ b/include/lidar_localization/registration_seed_policy.hpp
@@ -1,0 +1,125 @@
+#ifndef LIDAR_LOCALIZATION_REGISTRATION_SEED_POLICY_HPP_
+#define LIDAR_LOCALIZATION_REGISTRATION_SEED_POLICY_HPP_
+
+#include <algorithm>
+#include <cmath>
+
+namespace lidar_localization
+{
+
+enum class RegistrationSeedSource
+{
+  kCurrentPose = 0,
+  kImuPreintegration,
+  kGtsamSmoother,
+  kTwistEkf,
+  kTwistPrediction,
+  kPreviousDelta,
+};
+
+struct RegistrationSeedPolicyInput
+{
+  bool use_imu_preintegration{false};
+  bool imu_preintegration_fallback_mode{false};
+  bool imu_smoother_initialized{false};
+  bool imu_has_new_samples{false};
+  bool imu_prediction_finite{false};
+  bool use_gtsam_smoother{false};
+  bool gtsam_smoother_initialized{false};
+  bool use_twist_ekf{false};
+  bool twist_ekf_initialized{false};
+  bool use_twist_prediction{false};
+  bool have_last_accepted_pose{false};
+  bool has_latest_twist{false};
+  bool predict_pose_from_previous_delta{false};
+};
+
+struct RegistrationSeedPolicyDecision
+{
+  RegistrationSeedSource source{RegistrationSeedSource::kCurrentPose};
+  bool uses_prediction_state{false};
+  bool imu_prediction_ready{false};
+  bool ignored_non_finite_imu_prediction{false};
+};
+
+inline bool hasNewImuSamples(double last_imu_stamp, double last_scan_stamp_for_imu)
+{
+  return last_imu_stamp > last_scan_stamp_for_imu;
+}
+
+inline bool isImuSeedCandidateReady(const RegistrationSeedPolicyInput & input)
+{
+  return input.use_imu_preintegration &&
+         !input.imu_preintegration_fallback_mode &&
+         input.imu_smoother_initialized &&
+         input.imu_has_new_samples;
+}
+
+inline double clampPredictionDt(
+  double scan_stamp_sec,
+  double predicted_pose_time_sec,
+  double max_prediction_dt_sec)
+{
+  const double raw_dt = scan_stamp_sec - predicted_pose_time_sec;
+  if (!std::isfinite(raw_dt) || max_prediction_dt_sec <= 0.0) {
+    return 0.0;
+  }
+  return std::clamp(raw_dt, 0.0, max_prediction_dt_sec);
+}
+
+inline RegistrationSeedPolicyDecision chooseRegistrationSeed(
+  const RegistrationSeedPolicyInput & input)
+{
+  const bool imu_candidate_ready = isImuSeedCandidateReady(input);
+  if (imu_candidate_ready) {
+    if (input.imu_prediction_finite) {
+      return {
+        RegistrationSeedSource::kImuPreintegration,
+        false,
+        true,
+        false};
+    }
+    return {
+      RegistrationSeedSource::kCurrentPose,
+      false,
+      false,
+      true};
+  }
+  if (input.use_gtsam_smoother && input.gtsam_smoother_initialized) {
+    return {
+      RegistrationSeedSource::kGtsamSmoother,
+      false,
+      false,
+      false};
+  }
+  if (input.use_twist_ekf && input.twist_ekf_initialized) {
+    return {
+      RegistrationSeedSource::kTwistEkf,
+      false,
+      false,
+      false};
+  }
+  if (
+    input.use_twist_prediction &&
+    input.have_last_accepted_pose &&
+    input.has_latest_twist)
+  {
+    return {
+      RegistrationSeedSource::kTwistPrediction,
+      true,
+      false,
+      false};
+  }
+  if (input.predict_pose_from_previous_delta && input.have_last_accepted_pose) {
+    return {
+      RegistrationSeedSource::kPreviousDelta,
+      true,
+      false,
+      false};
+  }
+  return {};
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_REGISTRATION_SEED_POLICY_HPP_

--- a/include/lidar_localization/reinitialization_latch_policy.hpp
+++ b/include/lidar_localization/reinitialization_latch_policy.hpp
@@ -1,0 +1,64 @@
+#ifndef LIDAR_LOCALIZATION_REINITIALIZATION_LATCH_POLICY_HPP_
+#define LIDAR_LOCALIZATION_REINITIALIZATION_LATCH_POLICY_HPP_
+
+#include "lidar_localization/recovery_supervisor.hpp"
+
+#include <algorithm>
+#include <string>
+
+namespace lidar_localization
+{
+
+struct ReinitializationRequestLatchState
+{
+  bool latched{false};
+  std::string reason{"not_requested"};
+  double score{0.0};
+  double stamp_sec{0.0};
+};
+
+struct ReinitializationRequestLatchInput
+{
+  bool enabled{false};
+  ReinitializationRequestLatchState state;
+  ReinitializationRequestDecision decision;
+  double stamp_sec{0.0};
+};
+
+struct ReinitializationRequestLatchResult
+{
+  ReinitializationRequestLatchState state;
+  ReinitializationRequestDecision decision;
+};
+
+inline ReinitializationRequestLatchResult applyReinitializationRequestLatch(
+  const ReinitializationRequestLatchInput & input)
+{
+  if (!input.enabled) {
+    return {input.state, input.decision};
+  }
+
+  ReinitializationRequestLatchState state = input.state;
+  if (input.decision.requested) {
+    if (!state.latched) {
+      state.stamp_sec = input.stamp_sec;
+      state.reason = input.decision.reason;
+    }
+    state.latched = true;
+    state.score = std::max(state.score, input.decision.score);
+  }
+
+  if (!state.latched) {
+    return {state, input.decision};
+  }
+
+  ReinitializationRequestDecision decision = input.decision;
+  decision.requested = true;
+  decision.reason = state.reason;
+  decision.score = std::max(state.score, input.decision.score);
+  return {state, decision};
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_REINITIALIZATION_LATCH_POLICY_HPP_

--- a/include/lidar_localization/reinitialization_request_output_policy.hpp
+++ b/include/lidar_localization/reinitialization_request_output_policy.hpp
@@ -1,0 +1,46 @@
+#ifndef LIDAR_LOCALIZATION_REINITIALIZATION_REQUEST_OUTPUT_POLICY_HPP_
+#define LIDAR_LOCALIZATION_REINITIALIZATION_REQUEST_OUTPUT_POLICY_HPP_
+
+#include "lidar_localization/recovery_supervisor.hpp"
+
+#include <string>
+
+namespace lidar_localization
+{
+
+struct ReinitializationRequestOutputInput
+{
+  bool output_enabled{false};
+  bool publisher_ready{false};
+  ReinitializationRequestDecision decision;
+};
+
+struct ReinitializationRequestOutputState
+{
+  bool requested{false};
+  std::string reason{"not_requested"};
+  double score{0.0};
+};
+
+struct ReinitializationRequestOutput
+{
+  ReinitializationRequestOutputState state;
+  bool should_publish{false};
+  bool message_value{false};
+};
+
+inline ReinitializationRequestOutput prepareReinitializationRequestOutput(
+  const ReinitializationRequestOutputInput & input)
+{
+  return {
+    ReinitializationRequestOutputState{
+      input.decision.requested,
+      input.decision.reason,
+      input.decision.score},
+    input.output_enabled && input.publisher_ready,
+    input.decision.requested};
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_REINITIALIZATION_REQUEST_OUTPUT_POLICY_HPP_

--- a/include/lidar_localization/scan_admission_policy.hpp
+++ b/include/lidar_localization/scan_admission_policy.hpp
@@ -1,0 +1,96 @@
+#ifndef LIDAR_LOCALIZATION_SCAN_ADMISSION_POLICY_HPP_
+#define LIDAR_LOCALIZATION_SCAN_ADMISSION_POLICY_HPP_
+
+namespace lidar_localization
+{
+
+enum class ScanAdmissionStatus
+{
+  kAccepted = 0,
+  kShuttingDown,
+  kNullScan,
+  kWaitingForMapOrInitialPose,
+  kThrottledByMinScanInterval,
+  kCropFailureGuard,
+};
+
+struct ScanAdmissionInput
+{
+  bool shutting_down{false};
+  bool has_scan_message{false};
+  bool map_received{false};
+  bool initial_pose_received{false};
+  double min_scan_interval_sec{0.0};
+  bool has_last_process_time{false};
+  double elapsed_since_last_process_sec{0.0};
+  int consecutive_crop_failures{0};
+  bool crop_failure_guard_active{false};
+  bool have_last_accepted_pose{false};
+  int crop_failure_threshold{100};
+};
+
+struct ScanAdmissionDecision
+{
+  ScanAdmissionStatus status{ScanAdmissionStatus::kAccepted};
+  bool accepted{true};
+  bool should_store_last_scan{true};
+  bool should_warn_null_scan{false};
+  bool should_update_last_process_time{true};
+  bool should_activate_crop_failure_guard{false};
+  bool should_reset_prediction_to_last_accepted_pose{false};
+  bool should_log_crop_failure_guard_activation{false};
+};
+
+inline ScanAdmissionDecision rejectScanAdmission(
+  ScanAdmissionStatus status,
+  bool should_store_last_scan,
+  bool should_warn_null_scan = false,
+  bool should_update_last_process_time = false)
+{
+  ScanAdmissionDecision decision;
+  decision.status = status;
+  decision.accepted = false;
+  decision.should_store_last_scan = should_store_last_scan;
+  decision.should_warn_null_scan = should_warn_null_scan;
+  decision.should_update_last_process_time = should_update_last_process_time;
+  return decision;
+}
+
+inline ScanAdmissionDecision decideScanAdmission(const ScanAdmissionInput & input)
+{
+  if (input.shutting_down) {
+    return rejectScanAdmission(ScanAdmissionStatus::kShuttingDown, false);
+  }
+  if (!input.has_scan_message) {
+    return rejectScanAdmission(ScanAdmissionStatus::kNullScan, false, true);
+  }
+  if (!input.map_received || !input.initial_pose_received) {
+    return rejectScanAdmission(ScanAdmissionStatus::kWaitingForMapOrInitialPose, true);
+  }
+  if (
+    input.min_scan_interval_sec > 0.0 &&
+    input.has_last_process_time &&
+    input.elapsed_since_last_process_sec < input.min_scan_interval_sec)
+  {
+    return rejectScanAdmission(ScanAdmissionStatus::kThrottledByMinScanInterval, true);
+  }
+  if (input.consecutive_crop_failures > input.crop_failure_threshold) {
+    ScanAdmissionDecision decision =
+      rejectScanAdmission(ScanAdmissionStatus::kCropFailureGuard, true, false, true);
+    decision.should_activate_crop_failure_guard = !input.crop_failure_guard_active;
+    decision.should_log_crop_failure_guard_activation = decision.should_activate_crop_failure_guard;
+    decision.should_reset_prediction_to_last_accepted_pose =
+      decision.should_activate_crop_failure_guard && input.have_last_accepted_pose;
+    return decision;
+  }
+  return {};
+}
+
+inline bool isScanAdmissionAccepted(ScanAdmissionStatus status)
+{
+  return status == ScanAdmissionStatus::kAccepted;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_SCAN_ADMISSION_POLICY_HPP_

--- a/include/lidar_localization/scan_preprocessing_policy.hpp
+++ b/include/lidar_localization/scan_preprocessing_policy.hpp
@@ -1,0 +1,114 @@
+#ifndef LIDAR_LOCALIZATION_SCAN_PREPROCESSING_POLICY_HPP_
+#define LIDAR_LOCALIZATION_SCAN_PREPROCESSING_POLICY_HPP_
+
+#include <cmath>
+#include <string>
+
+namespace lidar_localization
+{
+
+struct ScanPreprocessingPathInput
+{
+  bool enable_scan_voxel_filter{true};
+  bool use_imu_undistortion{false};
+  std::string scan_frame_id;
+  std::string base_frame_id;
+};
+
+struct ScanXyzFieldAvailability
+{
+  bool has_x{false};
+  bool has_y{false};
+  bool has_z{false};
+};
+
+enum class ScanPreparationStatus
+{
+  kReady = 0,
+  kMissingXyzField,
+  kTransformUnavailable,
+  kFilteredScanEmpty,
+};
+
+inline bool shouldUseDirectRangeFilter(const ScanPreprocessingPathInput & input)
+{
+  return !input.enable_scan_voxel_filter &&
+         !input.use_imu_undistortion &&
+         input.scan_frame_id == input.base_frame_id;
+}
+
+inline bool hasRequiredXyzFields(const ScanXyzFieldAvailability & fields)
+{
+  return fields.has_x && fields.has_y && fields.has_z;
+}
+
+inline ScanPreparationStatus classifyPreparedScan(
+  bool has_required_xyz_fields,
+  bool transform_available,
+  bool filtered_scan_empty)
+{
+  if (!has_required_xyz_fields) {
+    return ScanPreparationStatus::kMissingXyzField;
+  }
+  if (!transform_available) {
+    return ScanPreparationStatus::kTransformUnavailable;
+  }
+  if (filtered_scan_empty) {
+    return ScanPreparationStatus::kFilteredScanEmpty;
+  }
+  return ScanPreparationStatus::kReady;
+}
+
+inline bool isPreparedScanReady(ScanPreparationStatus status)
+{
+  return status == ScanPreparationStatus::kReady;
+}
+
+inline bool shouldAdvancePredictionAfterScanPreparationFailure(ScanPreparationStatus status)
+{
+  return status == ScanPreparationStatus::kMissingXyzField ||
+         status == ScanPreparationStatus::kFilteredScanEmpty;
+}
+
+inline const char * scanPreparationStatusMessage(ScanPreparationStatus status)
+{
+  switch (status) {
+    case ScanPreparationStatus::kReady:
+      return "ok";
+    case ScanPreparationStatus::kMissingXyzField:
+      return "scan_missing_xyz_field";
+    case ScanPreparationStatus::kTransformUnavailable:
+      return "scan_transform_unavailable";
+    case ScanPreparationStatus::kFilteredScanEmpty:
+      return "filtered_scan_empty";
+  }
+  return "unknown_scan_preparation_status";
+}
+
+inline bool isFinitePoint(float x, float y, float z)
+{
+  return std::isfinite(x) && std::isfinite(y) && std::isfinite(z);
+}
+
+inline double horizontalRange(float x, float y)
+{
+  return std::hypot(static_cast<double>(x), static_cast<double>(y));
+}
+
+inline bool isPointInScanRange(
+  float x,
+  float y,
+  float z,
+  double scan_min_range,
+  double scan_max_range)
+{
+  if (!isFinitePoint(x, y, z)) {
+    return false;
+  }
+  const double range = horizontalRange(x, y);
+  return scan_min_range < range && range < scan_max_range;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_SCAN_PREPROCESSING_POLICY_HPP_

--- a/launch/mid360_legged_localization.launch.py
+++ b/launch/mid360_legged_localization.launch.py
@@ -1,0 +1,221 @@
+import os
+
+import launch
+import launch.actions
+import launch.events
+import launch_ros
+import launch_ros.events
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import TimerAction
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import LifecycleNode
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+import lifecycle_msgs.msg
+
+
+def generate_launch_description():
+    """Launch preset for Jetson + Livox MID-360 on legged robots."""
+
+    default_param = os.path.join(
+        get_package_share_directory('lidar_localization_ros2'),
+        'param',
+        'mid360_legged.yaml')
+
+    localization_param_dir = LaunchConfiguration(
+        'localization_param_dir', default=default_param)
+    map_path = LaunchConfiguration('map_path', default='/map/map.pcd')
+    registration_method = LaunchConfiguration('registration_method', default='NDT_OMP')
+    ndt_num_threads = LaunchConfiguration('ndt_num_threads', default='4')
+
+    global_frame_id = LaunchConfiguration('global_frame_id', default='map')
+    odom_frame_id = LaunchConfiguration('odom_frame_id', default='odom')
+    base_frame_id = LaunchConfiguration('base_frame_id', default='base_link')
+    use_sim_time = LaunchConfiguration('use_sim_time', default='false')
+    enable_map_odom_tf = LaunchConfiguration('enable_map_odom_tf', default='true')
+
+    cloud_topic = LaunchConfiguration('cloud_topic', default='/livox/points')
+    twist_topic = LaunchConfiguration('twist_topic', default='/twist')
+    imu_topic = LaunchConfiguration('imu_topic', default='/livox/imu')
+    use_imu_preintegration = LaunchConfiguration(
+        'use_imu_preintegration', default='true')
+    imu_preintegration_use_base_frame_transform = LaunchConfiguration(
+        'imu_preintegration_use_base_frame_transform', default='true')
+
+    set_initial_pose = LaunchConfiguration('set_initial_pose', default='false')
+    initial_pose_x = LaunchConfiguration('initial_pose_x', default='0.0')
+    initial_pose_y = LaunchConfiguration('initial_pose_y', default='0.0')
+    initial_pose_z = LaunchConfiguration('initial_pose_z', default='0.0')
+    initial_pose_qx = LaunchConfiguration('initial_pose_qx', default='0.0')
+    initial_pose_qy = LaunchConfiguration('initial_pose_qy', default='0.0')
+    initial_pose_qz = LaunchConfiguration('initial_pose_qz', default='0.0')
+    initial_pose_qw = LaunchConfiguration('initial_pose_qw', default='1.0')
+
+    publish_lidar_tf = LaunchConfiguration('publish_lidar_tf', default='true')
+    lidar_frame_id = LaunchConfiguration('lidar_frame_id', default='livox_frame')
+    lidar_tf_x = LaunchConfiguration('lidar_tf_x', default='0.0')
+    lidar_tf_y = LaunchConfiguration('lidar_tf_y', default='0.0')
+    lidar_tf_z = LaunchConfiguration('lidar_tf_z', default='0.0')
+    lidar_tf_roll = LaunchConfiguration('lidar_tf_roll', default='0.0')
+    lidar_tf_pitch = LaunchConfiguration('lidar_tf_pitch', default='0.0')
+    lidar_tf_yaw = LaunchConfiguration('lidar_tf_yaw', default='0.0')
+
+    publish_imu_tf = LaunchConfiguration('publish_imu_tf', default='false')
+    imu_frame_id = LaunchConfiguration('imu_frame_id', default='livox_imu_frame')
+    imu_tf_x = LaunchConfiguration('imu_tf_x', default='0.0')
+    imu_tf_y = LaunchConfiguration('imu_tf_y', default='0.0')
+    imu_tf_z = LaunchConfiguration('imu_tf_z', default='0.0')
+    imu_tf_roll = LaunchConfiguration('imu_tf_roll', default='0.0')
+    imu_tf_pitch = LaunchConfiguration('imu_tf_pitch', default='0.0')
+    imu_tf_yaw = LaunchConfiguration('imu_tf_yaw', default='0.0')
+
+    lidar_tf = Node(
+        name='mid360_lidar_tf',
+        package='tf2_ros',
+        executable='static_transform_publisher',
+        arguments=[
+            '--x', lidar_tf_x,
+            '--y', lidar_tf_y,
+            '--z', lidar_tf_z,
+            '--roll', lidar_tf_roll,
+            '--pitch', lidar_tf_pitch,
+            '--yaw', lidar_tf_yaw,
+            '--frame-id', base_frame_id,
+            '--child-frame-id', lidar_frame_id,
+        ],
+        condition=IfCondition(publish_lidar_tf))
+
+    imu_tf = Node(
+        name='mid360_imu_tf',
+        package='tf2_ros',
+        executable='static_transform_publisher',
+        arguments=[
+            '--x', imu_tf_x,
+            '--y', imu_tf_y,
+            '--z', imu_tf_z,
+            '--roll', imu_tf_roll,
+            '--pitch', imu_tf_pitch,
+            '--yaw', imu_tf_yaw,
+            '--frame-id', base_frame_id,
+            '--child-frame-id', imu_frame_id,
+        ],
+        condition=IfCondition(publish_imu_tf))
+
+    lidar_localization = LifecycleNode(
+        name='lidar_localization',
+        namespace='',
+        package='lidar_localization_ros2',
+        executable='lidar_localization_node',
+        parameters=[
+            localization_param_dir,
+            {
+                'use_sim_time': ParameterValue(use_sim_time, value_type=bool),
+                'map_path': map_path,
+                'registration_method': registration_method,
+                'ndt_num_threads': ParameterValue(ndt_num_threads, value_type=int),
+                'global_frame_id': global_frame_id,
+                'odom_frame_id': odom_frame_id,
+                'base_frame_id': base_frame_id,
+                'enable_map_odom_tf': ParameterValue(enable_map_odom_tf, value_type=bool),
+                'use_imu_preintegration': ParameterValue(
+                    use_imu_preintegration, value_type=bool),
+                'imu_preintegration_use_base_frame_transform': ParameterValue(
+                    imu_preintegration_use_base_frame_transform, value_type=bool),
+                'set_initial_pose': ParameterValue(set_initial_pose, value_type=bool),
+                'initial_pose_x': ParameterValue(initial_pose_x, value_type=float),
+                'initial_pose_y': ParameterValue(initial_pose_y, value_type=float),
+                'initial_pose_z': ParameterValue(initial_pose_z, value_type=float),
+                'initial_pose_qx': ParameterValue(initial_pose_qx, value_type=float),
+                'initial_pose_qy': ParameterValue(initial_pose_qy, value_type=float),
+                'initial_pose_qz': ParameterValue(initial_pose_qz, value_type=float),
+                'initial_pose_qw': ParameterValue(initial_pose_qw, value_type=float),
+            },
+        ],
+        remappings=[
+            ('/cloud', cloud_topic),
+            ('/twist', twist_topic),
+            ('/imu', imu_topic),
+            ('/pcl_pose', '/localization/pose_with_covariance'),
+        ],
+        output='screen')
+
+    from_inactive_to_active = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=lidar_localization,
+            start_state='configuring',
+            goal_state='inactive',
+            entities=[
+                launch.actions.EmitEvent(
+                    event=launch_ros.events.lifecycle.ChangeState(
+                        lifecycle_node_matcher=launch.events.matches_action(
+                            lidar_localization),
+                        transition_id=(
+                            lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE),
+                    )),
+            ],
+        ))
+
+    configure_localization = TimerAction(
+        period=1.0,
+        actions=[
+            launch.actions.EmitEvent(
+                event=launch_ros.events.lifecycle.ChangeState(
+                    lifecycle_node_matcher=launch.events.matches_action(
+                        lidar_localization),
+                    transition_id=(
+                        lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE),
+                ))
+        ],
+    )
+
+    return LaunchDescription([
+        DeclareLaunchArgument('localization_param_dir', default_value=default_param),
+        DeclareLaunchArgument('map_path', default_value='/map/map.pcd'),
+        DeclareLaunchArgument('registration_method', default_value='NDT_OMP'),
+        DeclareLaunchArgument('ndt_num_threads', default_value='4'),
+        DeclareLaunchArgument('global_frame_id', default_value='map'),
+        DeclareLaunchArgument('odom_frame_id', default_value='odom'),
+        DeclareLaunchArgument('base_frame_id', default_value='base_link'),
+        DeclareLaunchArgument('use_sim_time', default_value='false'),
+        DeclareLaunchArgument('enable_map_odom_tf', default_value='true'),
+        DeclareLaunchArgument('cloud_topic', default_value='/livox/points'),
+        DeclareLaunchArgument('twist_topic', default_value='/twist'),
+        DeclareLaunchArgument('imu_topic', default_value='/livox/imu'),
+        DeclareLaunchArgument('use_imu_preintegration', default_value='true'),
+        DeclareLaunchArgument(
+            'imu_preintegration_use_base_frame_transform', default_value='true'),
+        DeclareLaunchArgument('set_initial_pose', default_value='false'),
+        DeclareLaunchArgument('initial_pose_x', default_value='0.0'),
+        DeclareLaunchArgument('initial_pose_y', default_value='0.0'),
+        DeclareLaunchArgument('initial_pose_z', default_value='0.0'),
+        DeclareLaunchArgument('initial_pose_qx', default_value='0.0'),
+        DeclareLaunchArgument('initial_pose_qy', default_value='0.0'),
+        DeclareLaunchArgument('initial_pose_qz', default_value='0.0'),
+        DeclareLaunchArgument('initial_pose_qw', default_value='1.0'),
+        DeclareLaunchArgument('publish_lidar_tf', default_value='true'),
+        DeclareLaunchArgument('lidar_frame_id', default_value='livox_frame'),
+        DeclareLaunchArgument('lidar_tf_x', default_value='0.0'),
+        DeclareLaunchArgument('lidar_tf_y', default_value='0.0'),
+        DeclareLaunchArgument('lidar_tf_z', default_value='0.0'),
+        DeclareLaunchArgument('lidar_tf_roll', default_value='0.0'),
+        DeclareLaunchArgument('lidar_tf_pitch', default_value='0.0'),
+        DeclareLaunchArgument('lidar_tf_yaw', default_value='0.0'),
+        DeclareLaunchArgument('publish_imu_tf', default_value='false'),
+        DeclareLaunchArgument('imu_frame_id', default_value='livox_imu_frame'),
+        DeclareLaunchArgument('imu_tf_x', default_value='0.0'),
+        DeclareLaunchArgument('imu_tf_y', default_value='0.0'),
+        DeclareLaunchArgument('imu_tf_z', default_value='0.0'),
+        DeclareLaunchArgument('imu_tf_roll', default_value='0.0'),
+        DeclareLaunchArgument('imu_tf_pitch', default_value='0.0'),
+        DeclareLaunchArgument('imu_tf_yaw', default_value='0.0'),
+        from_inactive_to_active,
+        lidar_localization,
+        lidar_tf,
+        imu_tf,
+        configure_localization,
+    ])

--- a/param/hdl_imu_preint.yaml
+++ b/param/hdl_imu_preint.yaml
@@ -42,6 +42,7 @@
     use_gtsam_smoother: false
     # IMU preintegration smoother
     use_imu_preintegration: true
+    imu_preintegration_use_base_frame_transform: false
     imu_prediction_correction_guard_translation_m: 2.0
     imu_prediction_correction_guard_yaw_deg: 4.0
     enable_reinitialization_request_output: true

--- a/param/koide_indoor_ndt.yaml
+++ b/param/koide_indoor_ndt.yaml
@@ -36,6 +36,7 @@
     use_imu: false
     # Disable IMU preintegration: Koide IMU calibration unknown, diverges immediately
     use_imu_preintegration: false
+    imu_preintegration_use_base_frame_transform: false
     enable_reinitialization_request_output: true
     reinitialization_trigger_threshold: 0.95
     reinitialization_trigger_gap_scale_sec: 30.0

--- a/param/koide_indoor_smallgicp.yaml
+++ b/param/koide_indoor_smallgicp.yaml
@@ -35,6 +35,7 @@
     max_twist_prediction_dt: 0.5
     use_imu: false
     use_imu_preintegration: false
+    imu_preintegration_use_base_frame_transform: false
     enable_reinitialization_request_output: false
     enable_debug: false
     predict_pose_from_previous_delta: true

--- a/param/localization.yaml
+++ b/param/localization.yaml
@@ -30,6 +30,7 @@
       max_twist_prediction_dt: 0.5
       use_imu: false
       use_imu_preintegration: true
+      imu_preintegration_use_base_frame_transform: false
       imu_prediction_correction_guard_translation_m: 2.0
       imu_prediction_correction_guard_yaw_deg: 4.0
       enable_reinitialization_request_output: true

--- a/param/mid360_legged.yaml
+++ b/param/mid360_legged.yaml
@@ -1,0 +1,92 @@
+# Jetson + Livox MID-360 preset for quadruped/biped robots.
+# Runtime launch should override map_path and measured sensor extrinsics.
+/**:
+  ros__parameters:
+    registration_method: NDT_OMP
+    score_threshold: 6.0
+    ndt_resolution: 1.0
+    ndt_step_size: 0.1
+    ndt_num_threads: 4
+    ndt_max_iterations: 30
+    gicp_corr_randomness: 20
+    gicp_max_correspondence_distance: 2.0
+    vgicp_voxel_resolution: 1.0
+    transform_epsilon: 0.01
+
+    voxel_leaf_size: 0.25
+    enable_scan_voxel_filter: true
+    scan_max_range: 60.0
+    scan_min_range: 0.8
+    scan_period: 0.1
+    cloud_queue_depth: 1
+    min_scan_interval_sec: 0.0
+
+    use_pcd_map: true
+    map_path: ""
+    set_initial_pose: false
+    initial_pose_x: 0.0
+    initial_pose_y: 0.0
+    initial_pose_z: 0.0
+    initial_pose_qx: 0.0
+    initial_pose_qy: 0.0
+    initial_pose_qz: 0.0
+    initial_pose_qw: 1.0
+
+    use_odom: false
+    use_twist_prediction: true
+    twist_prediction_use_angular_velocity: false
+    max_twist_prediction_dt: 0.25
+    use_twist_ekf: false
+    use_gtsam_smoother: false
+
+    use_imu: false
+    use_imu_preintegration: true
+    imu_preintegration_use_base_frame_transform: true
+    imu_prediction_correction_guard_translation_m: 1.0
+    imu_prediction_correction_guard_yaw_deg: 6.0
+    imu_gyro_noise_density: 0.01
+    imu_accel_noise_density: 0.1
+    imu_gyro_random_walk: 0.0001
+    imu_accel_random_walk: 0.001
+    imu_bias_prior_sigma_gyro: 0.01
+    imu_bias_prior_sigma_accel: 0.1
+    imu_ndt_sigma_z: 0.1
+    imu_ndt_sigma_roll: 0.05
+    imu_ndt_sigma_pitch: 0.05
+
+    gtsam_ndt_sigma_x: 0.1
+    gtsam_ndt_sigma_y: 0.1
+    gtsam_ndt_sigma_yaw: 0.02
+    gtsam_fitness_nominal: 1.0
+    gtsam_fitness_scale_factor: 2.0
+    gtsam_fitness_reject: 50.0
+    gtsam_huber_k: 1.345
+
+    enable_debug: false
+    predict_pose_from_previous_delta: true
+    enable_local_map_crop: true
+    local_map_radius: 80.0
+    local_map_min_points: 100
+    reject_above_score_threshold: true
+    enable_borderline_seed_rejection_gate: true
+    borderline_seed_gate_score_threshold: 5.25
+    borderline_seed_gate_min_seed_translation_m: 0.8
+    enable_rejected_seed_update: false
+    enable_recovery_retry_from_last_pose: false
+
+    enable_reinitialization_request_output: true
+    enable_reinitialization_request_latch: true
+    reinitialization_trigger_threshold: 0.95
+    reinitialization_trigger_gap_scale_sec: 15.0
+    reinitialization_trigger_seed_translation_scale_m: 30.0
+    reinitialization_trigger_reject_streak_scale: 50.0
+    reinitialization_trigger_fitness_explosion_threshold: 1000.0
+
+    enable_map_odom_tf: true
+    global_frame_id: map
+    odom_frame_id: odom
+    base_frame_id: base_link
+    enable_timer_publishing: true
+    pose_publish_frequency: 20.0
+    viz_downsample: true
+    viz_voxel_leaf_size: 0.5

--- a/param/nav2_ndt_urban.yaml
+++ b/param/nav2_ndt_urban.yaml
@@ -31,6 +31,7 @@
     max_twist_prediction_dt: 0.5
     use_imu: false
     use_imu_preintegration: true
+    imu_preintegration_use_base_frame_transform: false
     imu_prediction_correction_guard_translation_m: 2.0
     imu_prediction_correction_guard_yaw_deg: 4.0
     enable_reinitialization_request_output: true

--- a/param/nav2_ndt_urban_borderline_only.yaml
+++ b/param/nav2_ndt_urban_borderline_only.yaml
@@ -31,6 +31,7 @@
     max_twist_prediction_dt: 0.5
     use_imu: false
     use_imu_preintegration: true
+    imu_preintegration_use_base_frame_transform: false
     imu_prediction_correction_guard_translation_m: 2.0
     imu_prediction_correction_guard_yaw_deg: 4.0
     enable_debug: false

--- a/param/nav2_ndt_urban_recovery_retry_from_last_pose.yaml
+++ b/param/nav2_ndt_urban_recovery_retry_from_last_pose.yaml
@@ -31,6 +31,7 @@
     max_twist_prediction_dt: 0.5
     use_imu: false
     use_imu_preintegration: false
+    imu_preintegration_use_base_frame_transform: false
     enable_debug: false
     predict_pose_from_previous_delta: true
     enable_local_map_crop: true

--- a/param/nav2_ndt_urban_recovery_retry_from_last_pose_r3.yaml
+++ b/param/nav2_ndt_urban_recovery_retry_from_last_pose_r3.yaml
@@ -31,6 +31,7 @@
     max_twist_prediction_dt: 0.5
     use_imu: false
     use_imu_preintegration: false
+    imu_preintegration_use_base_frame_transform: false
     enable_debug: false
     predict_pose_from_previous_delta: true
     enable_local_map_crop: true

--- a/param/nav2_ndt_urban_recovery_retry_from_last_pose_r3_gap1_seed15.yaml
+++ b/param/nav2_ndt_urban_recovery_retry_from_last_pose_r3_gap1_seed15.yaml
@@ -31,6 +31,7 @@
     max_twist_prediction_dt: 0.5
     use_imu: false
     use_imu_preintegration: false
+    imu_preintegration_use_base_frame_transform: false
     enable_debug: false
     predict_pose_from_previous_delta: true
     enable_local_map_crop: true

--- a/param/nav2_ndt_urban_rejected_seed_update.yaml
+++ b/param/nav2_ndt_urban_rejected_seed_update.yaml
@@ -31,6 +31,7 @@
     max_twist_prediction_dt: 0.5
     use_imu: false
     use_imu_preintegration: false
+    imu_preintegration_use_base_frame_transform: false
     enable_debug: false
     predict_pose_from_previous_delta: true
     enable_local_map_crop: true

--- a/param/nav2_ndt_urban_rejected_seed_update_r1.yaml
+++ b/param/nav2_ndt_urban_rejected_seed_update_r1.yaml
@@ -31,6 +31,7 @@
     max_twist_prediction_dt: 0.5
     use_imu: false
     use_imu_preintegration: false
+    imu_preintegration_use_base_frame_transform: false
     enable_debug: false
     predict_pose_from_previous_delta: true
     enable_local_map_crop: true

--- a/param/nav2_replay_safe.yaml
+++ b/param/nav2_replay_safe.yaml
@@ -31,6 +31,7 @@
     max_twist_prediction_dt: 0.5
     use_imu: false
     use_imu_preintegration: true
+    imu_preintegration_use_base_frame_transform: false
     imu_prediction_correction_guard_translation_m: 2.0
     imu_prediction_correction_guard_yaw_deg: 4.0
     enable_debug: false

--- a/param/public_istanbul_60s_benchmark.yaml
+++ b/param/public_istanbul_60s_benchmark.yaml
@@ -31,6 +31,7 @@
     max_twist_prediction_dt: 0.5
     use_imu: false
     use_imu_preintegration: true
+    imu_preintegration_use_base_frame_transform: false
     imu_prediction_correction_guard_translation_m: 2.0
     imu_prediction_correction_guard_yaw_deg: 4.0
     enable_debug: false

--- a/scripts/check_mid360_legged_bringup.py
+++ b/scripts/check_mid360_legged_bringup.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import sys
+
+from lidar_localization_mid360.bringup_cli import main
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lidar_localization_mid360/__init__.py
+++ b/scripts/lidar_localization_mid360/__init__.py
@@ -1,0 +1,1 @@
+"""MID-360 legged-robot bringup helpers for lidar_localization_ros2."""

--- a/scripts/lidar_localization_mid360/bringup_cli.py
+++ b/scripts/lidar_localization_mid360/bringup_cli.py
@@ -1,0 +1,72 @@
+import argparse
+import sys
+import time
+from typing import Optional
+from typing import Sequence
+
+import rclpy
+
+from lidar_localization_mid360.bringup_model import BringupCheckConfig
+from lidar_localization_mid360.bringup_model import evaluate_snapshot
+from lidar_localization_mid360.bringup_model import exit_code
+from lidar_localization_mid360.bringup_model import report_lines
+from lidar_localization_mid360.ros_doctor import Mid360BringupDoctor
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Check MID-360 legged-robot localization bringup topics and TF."
+    )
+    parser.add_argument("--duration-sec", type=float, default=5.0)
+    parser.add_argument("--cloud-topic", default="/livox/points")
+    parser.add_argument("--imu-topic", default="/livox/imu")
+    parser.add_argument("--pose-topic", default="/localization/pose_with_covariance")
+    parser.add_argument("--alignment-status-topic", default="/alignment_status")
+    parser.add_argument("--global-frame", default="map")
+    parser.add_argument("--odom-frame", default="odom")
+    parser.add_argument("--base-frame", default="base_link")
+    parser.add_argument("--lidar-frame", default="livox_frame")
+    parser.add_argument("--require-imu", action="store_true")
+    parser.add_argument("--require-map-odom-tf", action="store_true")
+    parser.add_argument("--require-localization-output", action="store_true")
+    return parser
+
+
+def config_from_args(args: argparse.Namespace) -> BringupCheckConfig:
+    return BringupCheckConfig(
+        cloud_topic=args.cloud_topic,
+        imu_topic=args.imu_topic,
+        pose_topic=args.pose_topic,
+        alignment_status_topic=args.alignment_status_topic,
+        global_frame=args.global_frame,
+        odom_frame=args.odom_frame,
+        base_frame=args.base_frame,
+        lidar_frame=args.lidar_frame,
+        require_imu=args.require_imu,
+        require_map_odom_tf=args.require_map_odom_tf,
+        require_localization_output=args.require_localization_output,
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    config = config_from_args(args)
+    rclpy.init()
+    node = Mid360BringupDoctor(config)
+    try:
+        deadline = time.monotonic() + max(args.duration_sec, 0.1)
+        while rclpy.ok() and time.monotonic() < deadline:
+            rclpy.spin_once(node, timeout_sec=0.1)
+
+        snapshot = node.snapshot()
+        results = evaluate_snapshot(config, snapshot)
+        for line in report_lines(config, snapshot, results):
+            print(line)
+        return exit_code(results)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lidar_localization_mid360/bringup_model.py
+++ b/scripts/lidar_localization_mid360/bringup_model.py
@@ -1,0 +1,213 @@
+from dataclasses import dataclass
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Sequence
+
+
+OK = "OK"
+WARN = "WARN"
+FAIL = "FAIL"
+
+
+@dataclass
+class TopicStats:
+    count: int = 0
+    first_wall_time: Optional[float] = None
+    last_wall_time: Optional[float] = None
+    last_frame_id: str = ""
+    last_stamp_sec: Optional[float] = None
+    last_point_count: Optional[int] = None
+    has_xyz_fields: Optional[bool] = None
+    last_status_level: Optional[int] = None
+    last_status_message: str = ""
+
+    def mark(self, frame_id: str, stamp_sec: float, wall_time: float) -> None:
+        if self.first_wall_time is None:
+            self.first_wall_time = wall_time
+        self.last_wall_time = wall_time
+        self.last_frame_id = frame_id
+        self.last_stamp_sec = stamp_sec
+        self.count += 1
+
+    def hz(self) -> Optional[float]:
+        if self.count < 2 or self.first_wall_time is None or self.last_wall_time is None:
+            return None
+        elapsed = self.last_wall_time - self.first_wall_time
+        if elapsed <= 0.0:
+            return None
+        return float(self.count - 1) / elapsed
+
+
+@dataclass(frozen=True)
+class BringupCheckConfig:
+    cloud_topic: str = "/livox/points"
+    imu_topic: str = "/livox/imu"
+    pose_topic: str = "/localization/pose_with_covariance"
+    alignment_status_topic: str = "/alignment_status"
+    global_frame: str = "map"
+    odom_frame: str = "odom"
+    base_frame: str = "base_link"
+    lidar_frame: str = "livox_frame"
+    require_imu: bool = False
+    require_map_odom_tf: bool = False
+    require_localization_output: bool = False
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    level: str
+    message: str
+
+
+@dataclass(frozen=True)
+class TfCheck:
+    name: str
+    available: bool
+
+
+@dataclass(frozen=True)
+class BringupSnapshot:
+    cloud: TopicStats
+    imu: TopicStats
+    pose: TopicStats
+    status: TopicStats
+    tf_checks: Sequence[TfCheck]
+
+
+def build_tf_checks(config: BringupCheckConfig, availability: Dict[str, bool]) -> List[TfCheck]:
+    return [
+        TfCheck(
+            f"{config.base_frame} <- {config.lidar_frame}",
+            availability.get(f"{config.base_frame} <- {config.lidar_frame}", False),
+        ),
+        TfCheck(
+            f"{config.odom_frame} <- {config.base_frame}",
+            availability.get(f"{config.odom_frame} <- {config.base_frame}", False),
+        ),
+        TfCheck(
+            f"{config.global_frame} <- {config.odom_frame}",
+            availability.get(f"{config.global_frame} <- {config.odom_frame}", False),
+        ),
+    ]
+
+
+def evaluate_snapshot(
+    config: BringupCheckConfig,
+    snapshot: BringupSnapshot,
+) -> List[CheckResult]:
+    results: List[CheckResult] = []
+    _evaluate_cloud(config, snapshot.cloud, results)
+    _evaluate_imu(config, snapshot.imu, results)
+    _evaluate_tf(config, snapshot.tf_checks, results)
+    _evaluate_pose(config, snapshot.pose, results)
+    _evaluate_status(config, snapshot.status, results)
+    return results
+
+
+def exit_code(results: Sequence[CheckResult]) -> int:
+    return 1 if any(result.level == FAIL for result in results) else 0
+
+
+def topic_summary(name: str, stats: TopicStats) -> str:
+    hz = stats.hz()
+    hz_text = "n/a" if hz is None else f"{hz:.1f} Hz"
+    detail = f"{name}: count={stats.count} rate={hz_text} frame={stats.last_frame_id or 'n/a'}"
+    if stats.last_point_count is not None:
+        detail += f" points={stats.last_point_count}"
+    if stats.has_xyz_fields is not None:
+        detail += f" xyz_fields={str(stats.has_xyz_fields).lower()}"
+    if stats.last_status_level is not None:
+        detail += (
+            f" status_level={stats.last_status_level}"
+            f" message={stats.last_status_message or 'n/a'}"
+        )
+    return detail
+
+
+def report_lines(
+    config: BringupCheckConfig,
+    snapshot: BringupSnapshot,
+    results: Sequence[CheckResult],
+) -> List[str]:
+    lines = [
+        topic_summary(config.cloud_topic, snapshot.cloud),
+        topic_summary(config.imu_topic, snapshot.imu),
+        topic_summary(config.pose_topic, snapshot.pose),
+        topic_summary(config.alignment_status_topic, snapshot.status),
+        "",
+    ]
+    lines.extend(f"[{result.level}] {result.message}" for result in results)
+    return lines
+
+
+def _evaluate_cloud(
+    config: BringupCheckConfig,
+    cloud: TopicStats,
+    results: List[CheckResult],
+) -> None:
+    if cloud.count == 0:
+        results.append(CheckResult(FAIL, f"no pointcloud received on {config.cloud_topic}"))
+    elif cloud.has_xyz_fields is False:
+        results.append(CheckResult(FAIL, f"{config.cloud_topic} is missing x/y/z fields"))
+    else:
+        results.append(CheckResult(OK, f"pointcloud received on {config.cloud_topic}"))
+
+
+def _evaluate_imu(
+    config: BringupCheckConfig,
+    imu: TopicStats,
+    results: List[CheckResult],
+) -> None:
+    if imu.count == 0:
+        level = FAIL if config.require_imu else WARN
+        results.append(CheckResult(level, f"no IMU received on {config.imu_topic}"))
+    else:
+        results.append(CheckResult(OK, f"IMU received on {config.imu_topic}"))
+
+
+def _evaluate_tf(
+    config: BringupCheckConfig,
+    tf_checks: Sequence[TfCheck],
+    results: List[CheckResult],
+) -> None:
+    map_odom_name = f"{config.global_frame} <- {config.odom_frame}"
+    for tf_check in tf_checks:
+        if tf_check.available:
+            results.append(CheckResult(OK, f"TF available: {tf_check.name}"))
+            continue
+        level = FAIL if tf_check.name != map_odom_name or config.require_map_odom_tf else WARN
+        results.append(CheckResult(level, f"TF missing: {tf_check.name}"))
+
+
+def _evaluate_pose(
+    config: BringupCheckConfig,
+    pose: TopicStats,
+    results: List[CheckResult],
+) -> None:
+    if pose.count == 0:
+        level = FAIL if config.require_localization_output else WARN
+        results.append(CheckResult(level, f"no localization pose received on {config.pose_topic}"))
+    else:
+        results.append(CheckResult(OK, f"localization pose received on {config.pose_topic}"))
+
+
+def _evaluate_status(
+    config: BringupCheckConfig,
+    status: TopicStats,
+    results: List[CheckResult],
+) -> None:
+    if status.count == 0:
+        level = FAIL if config.require_localization_output else WARN
+        results.append(
+            CheckResult(level, f"no alignment status received on {config.alignment_status_topic}")
+        )
+        return
+    if status.last_status_level is not None and status.last_status_level >= 2:
+        results.append(
+            CheckResult(FAIL, f"alignment status error: {status.last_status_message or 'n/a'}")
+        )
+    else:
+        results.append(
+            CheckResult(OK, f"alignment status observed: {status.last_status_message or 'n/a'}")
+        )

--- a/scripts/lidar_localization_mid360/ros_doctor.py
+++ b/scripts/lidar_localization_mid360/ros_doctor.py
@@ -1,0 +1,111 @@
+import time
+from typing import Dict
+
+import rclpy
+from diagnostic_msgs.msg import DiagnosticArray
+from geometry_msgs.msg import PoseWithCovarianceStamped
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy
+from rclpy.qos import QoSProfile
+from rclpy.qos import ReliabilityPolicy
+from rclpy.qos import qos_profile_sensor_data
+from sensor_msgs.msg import Imu
+from sensor_msgs.msg import PointCloud2
+from tf2_ros import Buffer
+from tf2_ros import TransformListener
+
+from lidar_localization_mid360.bringup_model import BringupCheckConfig
+from lidar_localization_mid360.bringup_model import BringupSnapshot
+from lidar_localization_mid360.bringup_model import TopicStats
+from lidar_localization_mid360.bringup_model import build_tf_checks
+
+
+def stamp_to_sec(stamp) -> float:
+    return float(stamp.sec) + float(stamp.nanosec) * 1e-9
+
+
+class Mid360BringupDoctor(Node):
+    def __init__(self, config: BringupCheckConfig):
+        super().__init__("mid360_legged_bringup_doctor")
+        self.config = config
+        self.cloud = TopicStats()
+        self.imu = TopicStats()
+        self.pose = TopicStats()
+        self.status = TopicStats()
+        self.tf_buffer = Buffer()
+        self.tf_listener = TransformListener(self.tf_buffer, self, spin_thread=False)
+        latched_qos = QoSProfile(
+            depth=10,
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        )
+
+        self.create_subscription(
+            PointCloud2,
+            config.cloud_topic,
+            self.on_cloud,
+            qos_profile_sensor_data,
+        )
+        self.create_subscription(
+            Imu,
+            config.imu_topic,
+            self.on_imu,
+            qos_profile_sensor_data,
+        )
+        self.create_subscription(
+            PoseWithCovarianceStamped,
+            config.pose_topic,
+            self.on_pose,
+            latched_qos,
+        )
+        self.create_subscription(
+            DiagnosticArray,
+            config.alignment_status_topic,
+            self.on_status,
+            latched_qos,
+        )
+
+    def on_cloud(self, msg: PointCloud2) -> None:
+        self.cloud.mark(msg.header.frame_id, stamp_to_sec(msg.header.stamp), time.monotonic())
+        self.cloud.last_point_count = int(msg.width) * int(msg.height)
+        field_names = {field.name for field in msg.fields}
+        self.cloud.has_xyz_fields = {"x", "y", "z"}.issubset(field_names)
+
+    def on_imu(self, msg: Imu) -> None:
+        self.imu.mark(msg.header.frame_id, stamp_to_sec(msg.header.stamp), time.monotonic())
+
+    def on_pose(self, msg: PoseWithCovarianceStamped) -> None:
+        self.pose.mark(msg.header.frame_id, stamp_to_sec(msg.header.stamp), time.monotonic())
+
+    def on_status(self, msg: DiagnosticArray) -> None:
+        self.status.mark(msg.header.frame_id, stamp_to_sec(msg.header.stamp), time.monotonic())
+        if msg.status:
+            latest = msg.status[0]
+            self.status.last_status_level = int(latest.level)
+            self.status.last_status_message = latest.message
+
+    def have_tf(self, target: str, source: str) -> bool:
+        try:
+            return self.tf_buffer.can_transform(target, source, rclpy.time.Time())
+        except Exception:
+            return False
+
+    def snapshot(self) -> BringupSnapshot:
+        availability: Dict[str, bool] = {
+            f"{self.config.base_frame} <- {self.config.lidar_frame}": self.have_tf(
+                self.config.base_frame, self.config.lidar_frame
+            ),
+            f"{self.config.odom_frame} <- {self.config.base_frame}": self.have_tf(
+                self.config.odom_frame, self.config.base_frame
+            ),
+            f"{self.config.global_frame} <- {self.config.odom_frame}": self.have_tf(
+                self.config.global_frame, self.config.odom_frame
+            ),
+        }
+        return BringupSnapshot(
+            cloud=self.cloud,
+            imu=self.imu,
+            pose=self.pose,
+            status=self.status,
+            tf_checks=build_tf_checks(self.config, availability),
+        )

--- a/src/lidar_localization_component.cpp
+++ b/src/lidar_localization_component.cpp
@@ -1,6 +1,32 @@
 #include <lidar_localization/lidar_localization_component.hpp>
+
+#include "lidar_localization/alignment_attempt_policy.hpp"
+#include "lidar_localization/alignment_diagnostic_ros_adapter.hpp"
+#include "lidar_localization/alignment_pipeline_policy.hpp"
+#include "lidar_localization/alignment_retry_policy.hpp"
+#include "lidar_localization/alignment_diagnostics_policy.hpp"
+#include "lidar_localization/alignment_status_policy.hpp"
+#include "lidar_localization/imu_preintegration_guard_policy.hpp"
+#include "lidar_localization/local_map_target_policy.hpp"
+#include "lidar_localization/localization_update_policy.hpp"
+#include "lidar_localization/map_initialization_policy.hpp"
+#include "lidar_localization/measurement_gate_policy.hpp"
+#include "lidar_localization/ndt_initializer_policy.hpp"
+#include "lidar_localization/parameter_validation_policy.hpp"
+#include "lidar_localization/point_cloud_conversion.hpp"
+#include "lidar_localization/pose_covariance_policy.hpp"
+#include "lidar_localization/pose_publish_policy.hpp"
+#include "lidar_localization/pose_backend_selection_policy.hpp"
+#include "lidar_localization/pose_backend_result_policy.hpp"
+#include "lidar_localization/recovery_supervisor_state_policy.hpp"
+#include "lidar_localization/reinitialization_latch_policy.hpp"
+#include "lidar_localization/reinitialization_request_output_policy.hpp"
+#include "lidar_localization/registration_backend_policy.hpp"
+#include "lidar_localization/registration_observation_policy.hpp"
+#include "lidar_localization/prediction_state_policy.hpp"
+#include "lidar_localization/scan_admission_policy.hpp"
+
 #include <chrono>
-#include <cstring>
 
 #include <pcl/common/common.h>
 
@@ -11,22 +37,8 @@ double stamp_to_sec(const builtin_interfaces::msg::Time & stamp)
   return static_cast<double>(stamp.sec) + static_cast<double>(stamp.nanosec) * 1e-9;
 }
 
-bool uses_filtered_target(const std::string & registration_method)
-{
-  return registration_method == "GICP" || registration_method == "GICP_OMP" ||
-         registration_method == "SMALL_GICP" || registration_method == "SMALL_VGICP";
-}
-
-bool supports_ndt_initializer(const std::string & registration_method)
-{
-  return registration_method == "GICP" || registration_method == "GICP_OMP" ||
-         registration_method == "SMALL_GICP" || registration_method == "SMALL_VGICP";
-}
-
 constexpr std::size_t kRegistrationSourceCloudKeepAliveCount = 4096;
 constexpr std::size_t kRegistrationTargetCloudKeepAliveCount = 4096;
-constexpr double kImuSmootherMeasurementTranslationGuardM = 2.0;
-constexpr double kImuSmootherMeasurementRotationGuardDeg = 10.0;
 
 void keep_cloud_alive(
   std::deque<pcl::PointCloud<pcl::PointXYZI>::Ptr> * recent_clouds,
@@ -42,167 +54,25 @@ void keep_cloud_alive(
   }
 }
 
-double rotation_delta_deg(
-  const Eigen::Matrix3f & reference_rotation,
-  const Eigen::Matrix3f & candidate_rotation)
+lidar_localization::PredictionStateSnapshot make_prediction_state_snapshot(
+  bool have_last_accepted_pose,
+  const Eigen::Matrix4f & last_accepted_pose_matrix,
+  const Eigen::Matrix4f & predicted_pose_matrix,
+  const Eigen::Matrix4f & last_relative_motion_matrix,
+  std::size_t consecutive_rejected_updates,
+  double last_accepted_pose_time_sec,
+  double predicted_pose_time_sec)
 {
-  const Eigen::Matrix3d relative_rotation =
-    reference_rotation.cast<double>().transpose() * candidate_rotation.cast<double>();
-  const double trace =
-    std::clamp((relative_rotation.trace() - 1.0) * 0.5, -1.0, 1.0);
-  return std::acos(trace) * 180.0 / M_PI;
+  return {
+    have_last_accepted_pose,
+    last_accepted_pose_matrix,
+    predicted_pose_matrix,
+    last_relative_motion_matrix,
+    consecutive_rejected_updates,
+    last_accepted_pose_time_sec,
+    predicted_pose_time_sec};
 }
 
-template<typename FieldContainerT>
-bool has_field(const FieldContainerT & fields, const std::string & field_name)
-{
-  return std::any_of(
-    fields.begin(), fields.end(),
-    [&field_name](const auto & field) {
-      return field.name == field_name;
-    });
-}
-
-const sensor_msgs::msg::PointField * find_field(
-  const std::vector<sensor_msgs::msg::PointField> & fields,
-  const std::string & field_name)
-{
-  const auto it = std::find_if(
-    fields.begin(), fields.end(),
-    [&field_name](const auto & field) {
-      return field.name == field_name;
-    });
-  return it == fields.end() ? nullptr : &(*it);
-}
-
-bool read_field_as_float(
-  const uint8_t * point_data,
-  const sensor_msgs::msg::PointField & field,
-  float * value)
-{
-  const uint8_t * field_ptr = point_data + field.offset;
-  switch (field.datatype) {
-    case sensor_msgs::msg::PointField::INT8:
-      *value = static_cast<float>(*reinterpret_cast<const int8_t *>(field_ptr));
-      return true;
-    case sensor_msgs::msg::PointField::UINT8:
-      *value = static_cast<float>(*reinterpret_cast<const uint8_t *>(field_ptr));
-      return true;
-    case sensor_msgs::msg::PointField::INT16: {
-      int16_t raw;
-      std::memcpy(&raw, field_ptr, sizeof(raw));
-      *value = static_cast<float>(raw);
-      return true;
-    }
-    case sensor_msgs::msg::PointField::UINT16: {
-      uint16_t raw;
-      std::memcpy(&raw, field_ptr, sizeof(raw));
-      *value = static_cast<float>(raw);
-      return true;
-    }
-    case sensor_msgs::msg::PointField::INT32: {
-      int32_t raw;
-      std::memcpy(&raw, field_ptr, sizeof(raw));
-      *value = static_cast<float>(raw);
-      return true;
-    }
-    case sensor_msgs::msg::PointField::UINT32: {
-      uint32_t raw;
-      std::memcpy(&raw, field_ptr, sizeof(raw));
-      *value = static_cast<float>(raw);
-      return true;
-    }
-    case sensor_msgs::msg::PointField::FLOAT32:
-      std::memcpy(value, field_ptr, sizeof(float));
-      return true;
-    case sensor_msgs::msg::PointField::FLOAT64: {
-      double raw;
-      std::memcpy(&raw, field_ptr, sizeof(raw));
-      *value = static_cast<float>(raw);
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-
-void copy_xyz_to_xyzi(
-  const pcl::PointCloud<pcl::PointXYZ> & input,
-  pcl::PointCloud<pcl::PointXYZI> & output)
-{
-  output.clear();
-  output.reserve(input.size());
-  output.header = input.header;
-  output.width = input.width;
-  output.height = input.height;
-  output.is_dense = input.is_dense;
-
-  for (const auto & point : input.points) {
-    pcl::PointXYZI converted;
-    converted.x = point.x;
-    converted.y = point.y;
-    converted.z = point.z;
-    converted.intensity = 0.0f;
-    output.push_back(converted);
-  }
-}
-
-void convert_sensor_cloud_to_xyzi(
-  const sensor_msgs::msg::PointCloud2 & input,
-  pcl::PointCloud<pcl::PointXYZI> & output)
-{
-  const auto * x_field = find_field(input.fields, "x");
-  const auto * y_field = find_field(input.fields, "y");
-  const auto * z_field = find_field(input.fields, "z");
-  const auto * intensity_field = find_field(input.fields, "intensity");
-  if (!x_field || !y_field || !z_field) {
-    output.clear();
-    output.width = 0;
-    output.height = 1;
-    output.is_dense = false;
-    pcl_conversions::toPCL(input.header, output.header);
-    return;
-  }
-
-  output.clear();
-  output.reserve(static_cast<std::size_t>(input.width) * static_cast<std::size_t>(input.height));
-  pcl_conversions::toPCL(input.header, output.header);
-  output.is_dense = input.is_dense;
-
-  const std::size_t point_count =
-    static_cast<std::size_t>(input.width) * static_cast<std::size_t>(input.height);
-  for (std::size_t point_idx = 0; point_idx < point_count; ++point_idx) {
-    const uint8_t * point_data = input.data.data() + point_idx * input.point_step;
-    pcl::PointXYZI point;
-    float intensity = 0.0f;
-    if (!read_field_as_float(point_data, *x_field, &point.x) ||
-      !read_field_as_float(point_data, *y_field, &point.y) ||
-      !read_field_as_float(point_data, *z_field, &point.z))
-    {
-      continue;
-    }
-    if (intensity_field) {
-      read_field_as_float(point_data, *intensity_field, &intensity);
-    }
-    point.intensity = intensity;
-    output.push_back(point);
-  }
-}
-
-bool convert_pcl_cloud_to_xyzi(
-  const pcl::PCLPointCloud2 & input,
-  pcl::PointCloud<pcl::PointXYZI> & output)
-{
-  if (has_field(input.fields, "intensity")) {
-    pcl::fromPCLPointCloud2(input, output);
-    return true;
-  }
-
-  pcl::PointCloud<pcl::PointXYZ> xyz_cloud;
-  pcl::fromPCLPointCloud2(input, xyz_cloud);
-  copy_xyz_to_xyzi(xyz_cloud, output);
-  return false;
-}
 }  // namespace
 
 PCLLocalization::PCLLocalization(const rclcpp::NodeOptions & options)
@@ -272,6 +142,7 @@ PCLLocalization::PCLLocalization(const rclcpp::NodeOptions & options)
   declare_parameter("gtsam_huber_k", 1.345);
   // IMU preintegration parameters
   declare_parameter("use_imu_preintegration", true);
+  declare_parameter("imu_preintegration_use_base_frame_transform", false);
   declare_parameter("imu_gyro_noise_density", 0.01);
   declare_parameter("imu_accel_noise_density", 0.1);
   declare_parameter("imu_gyro_random_walk", 0.0001);
@@ -387,14 +258,14 @@ CallbackReturn PCLLocalization::on_activate(const rclcpp_lifecycle::State &)
     pcl::PointCloud<pcl::PointXYZI>::Ptr map_cloud_ptr(new pcl::PointCloud<pcl::PointXYZI>);
     pcl::PCLPointCloud2 raw_map_cloud;
     bool map_has_intensity = true;
-    // load a pcd or ply file
-    if (map_path_.rfind(".pcd") != std::string::npos) {
+    const auto map_file_format = lidar_localization::detectMapFileFormat(map_path_);
+    if (map_file_format == lidar_localization::MapFileFormat::kPcd) {
       RCLCPP_INFO(get_logger(), "Loading pcd map from: %s", map_path_.c_str());
       if (pcl::io::loadPCDFile(map_path_, raw_map_cloud) == -1) {
         RCLCPP_ERROR(get_logger(), "Failed to load pcd file: %s", map_path_.c_str());
         return CallbackReturn::FAILURE;
       }
-    } else if (map_path_.rfind(".ply") != std::string::npos) {
+    } else if (map_file_format == lidar_localization::MapFileFormat::kPly) {
       RCLCPP_INFO(get_logger(), "Loading ply map from: %s", map_path_.c_str());
       if (pcl::io::loadPLYFile(map_path_, raw_map_cloud) == -1) {
         RCLCPP_ERROR(get_logger(), "Failed to load ply file: %s", map_path_.c_str());
@@ -402,12 +273,13 @@ CallbackReturn PCLLocalization::on_activate(const rclcpp_lifecycle::State &)
       }
     } else {
       RCLCPP_ERROR(
-          get_logger(), "Unsupported map file format. Please use .pcd or .ply: %s",
-          map_path_.c_str());
+        get_logger(), "Unsupported map file format. Please use .pcd or .ply: %s",
+        map_path_.c_str());
       return CallbackReturn::FAILURE;
     }
 
-    map_has_intensity = convert_pcl_cloud_to_xyzi(raw_map_cloud, *map_cloud_ptr);
+    map_has_intensity =
+      lidar_localization::convertPclCloudToXyzi(raw_map_cloud, *map_cloud_ptr);
     if (!map_has_intensity) {
       RCLCPP_WARN(
         get_logger(),
@@ -415,36 +287,28 @@ CallbackReturn PCLLocalization::on_activate(const rclcpp_lifecycle::State &)
     }
 
     RCLCPP_INFO(get_logger(), "Map Size %ld", map_cloud_ptr->size());
-    if (!map_cloud_ptr->empty()) {
-      pcl::getMinMax3D(*map_cloud_ptr, map_min_pt_, map_max_pt_);
-      map_bounds_valid_ = true;
-    } else {
-      map_bounds_valid_ = false;
-    }
-    sensor_msgs::msg::PointCloud2::SharedPtr map_msg_ptr(new sensor_msgs::msg::PointCloud2);
-    if (viz_downsample_) {
-      pcl::PCLPointCloud2 map_cloud_viz_filtered;
-      pcl::VoxelGrid<pcl::PCLPointCloud2> voxel_viz;
-      voxel_viz.setInputCloud(std::make_shared<pcl::PCLPointCloud2>(raw_map_cloud));
-      voxel_viz.setLeafSize(viz_voxel_leaf_size_, viz_voxel_leaf_size_, viz_voxel_leaf_size_);
-      voxel_viz.filter(map_cloud_viz_filtered);
-      pcl_conversions::moveFromPCL(map_cloud_viz_filtered, *map_msg_ptr);
-    } else {
-      pcl_conversions::moveFromPCL(raw_map_cloud, *map_msg_ptr);
-    }
-    map_msg_ptr->header.frame_id = global_frame_id_;
-    initial_map_pub_->publish(*map_msg_ptr);
+    const auto map_bounds = lidar_localization::computeMapBounds(*map_cloud_ptr);
+    map_bounds_valid_ = map_bounds.valid;
+    map_min_pt_ = map_bounds.min_point;
+    map_max_pt_ = map_bounds.max_point;
+
+    const auto map_msg = lidar_localization::makeInitialMapMessage(
+      raw_map_cloud, global_frame_id_, viz_downsample_, viz_voxel_leaf_size_);
+    initial_map_pub_->publish(map_msg);
     RCLCPP_INFO(get_logger(), "Initial Map Published");
 
-    // Store full map for local cropping (GICP methods)
-    use_local_map_crop_ = enable_local_map_crop_ || uses_filtered_target(registration_method_);
+    const auto target_setup =
+      lidar_localization::planInitialMapTargetSetup(
+        enable_local_map_crop_, registration_method_);
+    use_local_map_crop_ = target_setup.use_local_map_crop;
     if (use_local_map_crop_) {
       // Keep the raw full map and only voxel-filter the cropped local target per scan.
       full_map_cloud_ptr_ = map_cloud_ptr;
-      RCLCPP_INFO(get_logger(), "Local map cropping enabled. Full map: %ld pts, radius: %.0fm",
-                  full_map_cloud_ptr_->size(), local_map_radius_);
+      RCLCPP_INFO(
+        get_logger(), "Local map cropping enabled. Full map: %ld pts, radius: %.0fm",
+        full_map_cloud_ptr_->size(), local_map_radius_);
       // Avoid building a full-map NDT target here. It can overflow on city-scale maps.
-      if (supports_ndt_initializer(registration_method_)) {
+      if (target_setup.create_ndt_initializer) {
         use_ndt_initializer_ = true;
         ndt_init_scan_count_ = 0;
         ndt_initializer_.reset(
@@ -453,7 +317,8 @@ CallbackReturn PCLLocalization::on_activate(const rclcpp_lifecycle::State &)
         ndt_initializer_->setResolution(ndt_resolution_);
         ndt_initializer_->setTransformationEpsilon(transform_epsilon_);
         ndt_initializer_->setNumThreads(
-          ndt_num_threads_ > 0 ? ndt_num_threads_ : omp_get_max_threads());
+          lidar_localization::resolveRegistrationThreadCount(
+            ndt_num_threads_, omp_get_max_threads()));
         ndt_initializer_->setInputTarget(map_cloud_ptr);
         RCLCPP_INFO(get_logger(), "NDT initializer created (%d scans before GICP switch)",
                     ndt_init_scans_required_);
@@ -461,7 +326,7 @@ CallbackReturn PCLLocalization::on_activate(const rclcpp_lifecycle::State &)
         use_ndt_initializer_ = false;
         ndt_initializer_.reset();
       }
-    } else {
+    } else if (target_setup.set_full_map_as_registration_target) {
       registration_->setInputTarget(map_cloud_ptr);
     }
 
@@ -615,7 +480,7 @@ void PCLLocalization::initializeParameters()
   get_parameter("base_frame_id", base_frame_id_);
   get_parameter("enable_map_odom_tf", enable_map_odom_tf_);
   get_parameter("registration_method", registration_method_);
-  get_parameter("score_threshold", score_threshold_);
+  get_parameter("score_threshold", measurement_gate_config_.score_threshold);
   get_parameter("ndt_resolution", ndt_resolution_);
   get_parameter("ndt_step_size", ndt_step_size_);
   get_parameter("ndt_num_threads", ndt_num_threads_);
@@ -629,7 +494,15 @@ void PCLLocalization::initializeParameters()
   get_parameter("scan_max_range", scan_max_range_);
   get_parameter("scan_min_range", scan_min_range_);
   get_parameter("scan_period", scan_period_);
-  get_parameter("cloud_queue_depth", cloud_queue_depth_);
+  int requested_cloud_queue_depth = cloud_queue_depth_;
+  get_parameter("cloud_queue_depth", requested_cloud_queue_depth);
+  const auto cloud_queue_depth =
+    lidar_localization::normalizePositiveIntParameter(requested_cloud_queue_depth);
+  cloud_queue_depth_ = cloud_queue_depth.value;
+  if (cloud_queue_depth.was_adjusted) {
+    RCLCPP_WARN(
+      get_logger(), "cloud_queue_depth must be positive; using %d", cloud_queue_depth_);
+  }
   get_parameter("min_scan_interval_sec", min_scan_interval_sec_);
   get_parameter("use_pcd_map", use_pcd_map_);
   get_parameter("map_path", map_path_);
@@ -679,6 +552,9 @@ void PCLLocalization::initializeParameters()
     gtsam_smoother_.reset();
   }
   get_parameter("use_imu_preintegration", use_imu_preintegration_);
+  get_parameter(
+    "imu_preintegration_use_base_frame_transform",
+    imu_preintegration_use_base_frame_transform_);
   if (use_imu_preintegration_) {
     ImuGtsamSmoother::Params imu_params;
     // Reuse GTSAM NDT sigmas for x, y, yaw
@@ -713,60 +589,67 @@ void PCLLocalization::initializeParameters()
   get_parameter("predict_pose_from_previous_delta", predict_pose_from_previous_delta_);
   get_parameter("enable_local_map_crop", enable_local_map_crop_);
   get_parameter("local_map_radius", local_map_radius_);
-  int local_map_min_points = static_cast<int>(local_map_min_points_);
-  get_parameter("local_map_min_points", local_map_min_points);
-  local_map_min_points_ = static_cast<std::size_t>(std::max(local_map_min_points, 1));
-  get_parameter("reject_above_score_threshold", reject_above_score_threshold_);
-  get_parameter("enable_consistency_recovery_gate", enable_consistency_recovery_gate_);
-  get_parameter("consistency_recovery_min_rejections", consistency_recovery_min_rejections_);
-  get_parameter("consistency_recovery_score_margin", consistency_recovery_score_margin_);
+  int requested_local_map_min_points = static_cast<int>(local_map_min_points_);
+  get_parameter("local_map_min_points", requested_local_map_min_points);
+  const auto local_map_min_points =
+    lidar_localization::normalizeLocalMapMinPoints(requested_local_map_min_points);
+  local_map_min_points_ = local_map_min_points.value;
+  if (local_map_min_points.was_adjusted) {
+    RCLCPP_WARN(
+      get_logger(), "local_map_min_points must be positive; using %zu",
+      local_map_min_points_);
+  }
+  get_parameter("reject_above_score_threshold", measurement_gate_config_.reject_above_score_threshold);
+  get_parameter("enable_consistency_recovery_gate", measurement_gate_config_.enable_consistency_recovery_gate);
+  get_parameter("consistency_recovery_min_rejections", measurement_gate_config_.consistency_recovery_min_rejections);
+  get_parameter("consistency_recovery_score_margin", measurement_gate_config_.consistency_recovery_score_margin);
   get_parameter(
     "consistency_recovery_max_translation_m",
-    consistency_recovery_max_translation_m_);
-  get_parameter("consistency_recovery_max_yaw_deg", consistency_recovery_max_yaw_deg_);
+    measurement_gate_config_.consistency_recovery_max_translation_m);
+  get_parameter("consistency_recovery_max_yaw_deg", measurement_gate_config_.consistency_recovery_max_yaw_deg);
   get_parameter(
     "enable_post_reject_strict_score_threshold",
-    enable_post_reject_strict_score_threshold_);
-  get_parameter("post_reject_strict_min_rejections", post_reject_strict_min_rejections_);
-  get_parameter("post_reject_strict_score_threshold", post_reject_strict_score_threshold_);
+    measurement_gate_config_.enable_post_reject_strict_score_threshold);
+  get_parameter("post_reject_strict_min_rejections", measurement_gate_config_.post_reject_strict_min_rejections);
+  get_parameter("post_reject_strict_score_threshold", measurement_gate_config_.post_reject_strict_score_threshold);
   get_parameter(
     "enable_open_loop_strict_score_threshold",
-    enable_open_loop_strict_score_threshold_);
+    measurement_gate_config_.enable_open_loop_strict_score_threshold);
   get_parameter(
     "open_loop_strict_min_accepted_gap_sec",
-    open_loop_strict_min_accepted_gap_sec_);
+    measurement_gate_config_.open_loop_strict_min_accepted_gap_sec);
   get_parameter(
     "open_loop_strict_min_seed_translation_m",
-    open_loop_strict_min_seed_translation_m_);
-  get_parameter("open_loop_strict_score_threshold", open_loop_strict_score_threshold_);
+    measurement_gate_config_.open_loop_strict_min_seed_translation_m);
+  get_parameter("open_loop_strict_score_threshold", measurement_gate_config_.open_loop_strict_score_threshold);
   get_parameter(
     "enable_borderline_seed_rejection_gate",
-    enable_borderline_seed_rejection_gate_);
-  get_parameter("borderline_seed_gate_score_threshold", borderline_seed_gate_score_threshold_);
+    measurement_gate_config_.enable_borderline_seed_rejection_gate);
+  get_parameter("borderline_seed_gate_score_threshold", measurement_gate_config_.borderline_seed_gate_score_threshold);
   get_parameter(
     "borderline_seed_gate_min_seed_translation_m",
-    borderline_seed_gate_min_seed_translation_m_);
-  get_parameter("enable_rejected_seed_update", enable_rejected_seed_update_);
-  get_parameter("rejected_seed_update_min_rejections", rejected_seed_update_min_rejections_);
-  get_parameter("rejected_seed_update_max_fitness", rejected_seed_update_max_fitness_);
+    measurement_gate_config_.borderline_seed_gate_min_seed_translation_m);
+  get_parameter("enable_rejected_seed_update", measurement_gate_config_.enable_rejected_seed_update);
+  get_parameter("rejected_seed_update_min_rejections", measurement_gate_config_.rejected_seed_update_min_rejections);
+  get_parameter("rejected_seed_update_max_fitness", measurement_gate_config_.rejected_seed_update_max_fitness);
   get_parameter(
     "rejected_seed_update_max_correction_translation_m",
-    rejected_seed_update_max_correction_translation_m_);
+    measurement_gate_config_.rejected_seed_update_max_correction_translation_m);
   get_parameter(
     "rejected_seed_update_max_correction_yaw_deg",
-    rejected_seed_update_max_correction_yaw_deg_);
+    measurement_gate_config_.rejected_seed_update_max_correction_yaw_deg);
   get_parameter(
     "enable_recovery_retry_from_last_pose",
-    enable_recovery_retry_from_last_pose_);
+    recovery_retry_from_last_pose_config_.enable);
   get_parameter(
     "recovery_retry_from_last_pose_min_rejections",
-    recovery_retry_from_last_pose_min_rejections_);
+    recovery_retry_from_last_pose_config_.min_rejections);
   get_parameter(
     "recovery_retry_from_last_pose_max_accepted_gap_sec",
-    recovery_retry_from_last_pose_max_accepted_gap_sec_);
+    recovery_retry_from_last_pose_config_.max_accepted_gap_sec);
   get_parameter(
     "recovery_retry_from_last_pose_max_seed_translation_m",
-    recovery_retry_from_last_pose_max_seed_translation_m_);
+    recovery_retry_from_last_pose_config_.max_seed_translation_m);
   get_parameter(
     "enable_reinitialization_request_output",
     enable_reinitialization_request_output_);
@@ -775,21 +658,30 @@ void PCLLocalization::initializeParameters()
     enable_reinitialization_request_latch_);
   get_parameter(
     "reinitialization_trigger_threshold",
-    reinitialization_trigger_threshold_);
+    reinitialization_trigger_config_.threshold);
   get_parameter(
     "reinitialization_trigger_gap_scale_sec",
-    reinitialization_trigger_gap_scale_sec_);
+    reinitialization_trigger_config_.gap_scale_sec);
   get_parameter(
     "reinitialization_trigger_seed_translation_scale_m",
-    reinitialization_trigger_seed_translation_scale_m_);
+    reinitialization_trigger_config_.seed_translation_scale_m);
   get_parameter(
     "reinitialization_trigger_reject_streak_scale",
-    reinitialization_trigger_reject_streak_scale_);
+    reinitialization_trigger_config_.reject_streak_scale);
   get_parameter(
     "reinitialization_trigger_fitness_explosion_threshold",
-    reinitialization_trigger_fitness_explosion_threshold_);
+    reinitialization_trigger_config_.fitness_explosion_threshold);
   get_parameter("enable_timer_publishing", enable_timer_publishing_);
-  get_parameter("pose_publish_frequency", pose_publish_frequency_);
+  double requested_pose_publish_frequency = pose_publish_frequency_;
+  get_parameter("pose_publish_frequency", requested_pose_publish_frequency);
+  const auto pose_publish_frequency =
+    lidar_localization::normalizePosePublishFrequencyHz(requested_pose_publish_frequency);
+  pose_publish_frequency_ = pose_publish_frequency.value;
+  if (pose_publish_frequency.was_adjusted) {
+    RCLCPP_WARN(
+      get_logger(), "pose_publish_frequency must be finite and positive; using %lf",
+      pose_publish_frequency_);
+  }
 
   RCLCPP_INFO(get_logger(),"global_frame_id: %s", global_frame_id_.c_str());
   RCLCPP_INFO(get_logger(),"odom_frame_id: %s", odom_frame_id_.c_str());
@@ -820,6 +712,10 @@ void PCLLocalization::initializeParameters()
     twist_prediction_use_angular_velocity_);
   RCLCPP_INFO(get_logger(),"max_twist_prediction_dt: %lf", max_twist_prediction_dt_);
   RCLCPP_INFO(get_logger(),"use_imu: %d", use_imu_);
+  RCLCPP_INFO(get_logger(),"use_imu_preintegration: %d", use_imu_preintegration_);
+  RCLCPP_INFO(
+    get_logger(), "imu_preintegration_use_base_frame_transform: %d",
+    imu_preintegration_use_base_frame_transform_);
   RCLCPP_INFO(get_logger(),"use_twist_ekf: %d", use_twist_ekf_);
   RCLCPP_INFO(get_logger(),"use_gtsam_smoother: %d", use_gtsam_smoother_);
   RCLCPP_INFO(get_logger(),"enable_debug: %d", enable_debug_);
@@ -830,77 +726,77 @@ void PCLLocalization::initializeParameters()
   RCLCPP_INFO(
     get_logger(), "local_map_min_points: %zu", local_map_min_points_);
   RCLCPP_INFO(
-    get_logger(), "reject_above_score_threshold: %d", reject_above_score_threshold_);
+    get_logger(), "reject_above_score_threshold: %d", measurement_gate_config_.reject_above_score_threshold);
   RCLCPP_INFO(
     get_logger(), "enable_consistency_recovery_gate: %d",
-    enable_consistency_recovery_gate_);
+    measurement_gate_config_.enable_consistency_recovery_gate);
   RCLCPP_INFO(
     get_logger(), "consistency_recovery_min_rejections: %d",
-    consistency_recovery_min_rejections_);
+    measurement_gate_config_.consistency_recovery_min_rejections);
   RCLCPP_INFO(
     get_logger(), "consistency_recovery_score_margin: %lf",
-    consistency_recovery_score_margin_);
+    measurement_gate_config_.consistency_recovery_score_margin);
   RCLCPP_INFO(
     get_logger(), "consistency_recovery_max_translation_m: %lf",
-    consistency_recovery_max_translation_m_);
+    measurement_gate_config_.consistency_recovery_max_translation_m);
   RCLCPP_INFO(
     get_logger(), "consistency_recovery_max_yaw_deg: %lf",
-    consistency_recovery_max_yaw_deg_);
+    measurement_gate_config_.consistency_recovery_max_yaw_deg);
   RCLCPP_INFO(
     get_logger(), "enable_post_reject_strict_score_threshold: %d",
-    enable_post_reject_strict_score_threshold_);
+    measurement_gate_config_.enable_post_reject_strict_score_threshold);
   RCLCPP_INFO(
     get_logger(), "post_reject_strict_min_rejections: %d",
-    post_reject_strict_min_rejections_);
+    measurement_gate_config_.post_reject_strict_min_rejections);
   RCLCPP_INFO(
     get_logger(), "post_reject_strict_score_threshold: %lf",
-    post_reject_strict_score_threshold_);
+    measurement_gate_config_.post_reject_strict_score_threshold);
   RCLCPP_INFO(
     get_logger(), "enable_open_loop_strict_score_threshold: %d",
-    enable_open_loop_strict_score_threshold_);
+    measurement_gate_config_.enable_open_loop_strict_score_threshold);
   RCLCPP_INFO(
     get_logger(), "open_loop_strict_min_accepted_gap_sec: %lf",
-    open_loop_strict_min_accepted_gap_sec_);
+    measurement_gate_config_.open_loop_strict_min_accepted_gap_sec);
   RCLCPP_INFO(
     get_logger(), "open_loop_strict_min_seed_translation_m: %lf",
-    open_loop_strict_min_seed_translation_m_);
+    measurement_gate_config_.open_loop_strict_min_seed_translation_m);
   RCLCPP_INFO(
     get_logger(), "open_loop_strict_score_threshold: %lf",
-    open_loop_strict_score_threshold_);
+    measurement_gate_config_.open_loop_strict_score_threshold);
   RCLCPP_INFO(
     get_logger(), "enable_borderline_seed_rejection_gate: %d",
-    enable_borderline_seed_rejection_gate_);
+    measurement_gate_config_.enable_borderline_seed_rejection_gate);
   RCLCPP_INFO(
     get_logger(), "borderline_seed_gate_score_threshold: %lf",
-    borderline_seed_gate_score_threshold_);
+    measurement_gate_config_.borderline_seed_gate_score_threshold);
   RCLCPP_INFO(
     get_logger(), "borderline_seed_gate_min_seed_translation_m: %lf",
-    borderline_seed_gate_min_seed_translation_m_);
-  RCLCPP_INFO(get_logger(), "enable_rejected_seed_update: %d", enable_rejected_seed_update_);
+    measurement_gate_config_.borderline_seed_gate_min_seed_translation_m);
+  RCLCPP_INFO(get_logger(), "enable_rejected_seed_update: %d", measurement_gate_config_.enable_rejected_seed_update);
   RCLCPP_INFO(
     get_logger(), "rejected_seed_update_min_rejections: %d",
-    rejected_seed_update_min_rejections_);
+    measurement_gate_config_.rejected_seed_update_min_rejections);
   RCLCPP_INFO(
     get_logger(), "rejected_seed_update_max_fitness: %lf",
-    rejected_seed_update_max_fitness_);
+    measurement_gate_config_.rejected_seed_update_max_fitness);
   RCLCPP_INFO(
     get_logger(), "rejected_seed_update_max_correction_translation_m: %lf",
-    rejected_seed_update_max_correction_translation_m_);
+    measurement_gate_config_.rejected_seed_update_max_correction_translation_m);
   RCLCPP_INFO(
     get_logger(), "rejected_seed_update_max_correction_yaw_deg: %lf",
-    rejected_seed_update_max_correction_yaw_deg_);
+    measurement_gate_config_.rejected_seed_update_max_correction_yaw_deg);
   RCLCPP_INFO(
     get_logger(), "enable_recovery_retry_from_last_pose: %d",
-    enable_recovery_retry_from_last_pose_);
+    recovery_retry_from_last_pose_config_.enable);
   RCLCPP_INFO(
     get_logger(), "recovery_retry_from_last_pose_min_rejections: %d",
-    recovery_retry_from_last_pose_min_rejections_);
+    recovery_retry_from_last_pose_config_.min_rejections);
   RCLCPP_INFO(
     get_logger(), "recovery_retry_from_last_pose_max_accepted_gap_sec: %lf",
-    recovery_retry_from_last_pose_max_accepted_gap_sec_);
+    recovery_retry_from_last_pose_config_.max_accepted_gap_sec);
   RCLCPP_INFO(
     get_logger(), "recovery_retry_from_last_pose_max_seed_translation_m: %lf",
-    recovery_retry_from_last_pose_max_seed_translation_m_);
+    recovery_retry_from_last_pose_config_.max_seed_translation_m);
   RCLCPP_INFO(
     get_logger(), "enable_reinitialization_request_output: %d",
     enable_reinitialization_request_output_);
@@ -909,19 +805,19 @@ void PCLLocalization::initializeParameters()
     enable_reinitialization_request_latch_);
   RCLCPP_INFO(
     get_logger(), "reinitialization_trigger_threshold: %lf",
-    reinitialization_trigger_threshold_);
+    reinitialization_trigger_config_.threshold);
   RCLCPP_INFO(
     get_logger(), "reinitialization_trigger_gap_scale_sec: %lf",
-    reinitialization_trigger_gap_scale_sec_);
+    reinitialization_trigger_config_.gap_scale_sec);
   RCLCPP_INFO(
     get_logger(), "reinitialization_trigger_seed_translation_scale_m: %lf",
-    reinitialization_trigger_seed_translation_scale_m_);
+    reinitialization_trigger_config_.seed_translation_scale_m);
   RCLCPP_INFO(
     get_logger(), "reinitialization_trigger_reject_streak_scale: %lf",
-    reinitialization_trigger_reject_streak_scale_);
+    reinitialization_trigger_config_.reject_streak_scale);
   RCLCPP_INFO(
     get_logger(), "reinitialization_trigger_fitness_explosion_threshold: %lf",
-    reinitialization_trigger_fitness_explosion_threshold_);
+    reinitialization_trigger_config_.fitness_explosion_threshold);
   RCLCPP_INFO(
     get_logger(), "imu_prediction_correction_guard_translation_m: %lf",
     imu_prediction_correction_guard_translation_m_);
@@ -981,9 +877,8 @@ void PCLLocalization::initializePubSub()
     std::bind(&PCLLocalization::imuReceived, this, std::placeholders::_1));
 
   if (enable_timer_publishing_) {
-    auto period = std::chrono::duration<double>(1.0 / pose_publish_frequency_);
     pose_publish_timer_ = create_wall_timer(
-      std::chrono::duration_cast<std::chrono::nanoseconds>(period),
+      lidar_localization::posePublishPeriodFromFrequencyHz(pose_publish_frequency_),
       std::bind(&PCLLocalization::timerPublishPose, this));
   }
 
@@ -1004,7 +899,9 @@ void PCLLocalization::initializeRegistration()
   recent_source_clouds_.clear();
   recent_target_clouds_.clear();
 
-  if (registration_method_ == "GICP") {
+  const auto registration_backend =
+    lidar_localization::parseRegistrationBackend(registration_method_);
+  if (registration_backend == lidar_localization::RegistrationBackend::kPclGicp) {
     pcl::GeneralizedIterativeClosestPoint<pcl::PointXYZI, pcl::PointXYZI>::Ptr gicp(
       new pcl::GeneralizedIterativeClosestPoint<pcl::PointXYZI, pcl::PointXYZI>());
     gicp->setTransformationEpsilon(transform_epsilon_);
@@ -1013,7 +910,7 @@ void PCLLocalization::initializeRegistration()
     pcl_registration_ = gicp;
     registration_ = pcl_registration_.get();
   }
-  else if (registration_method_ == "NDT") {
+  else if (registration_backend == lidar_localization::RegistrationBackend::kPclNdt) {
     pcl::NormalDistributionsTransform<pcl::PointXYZI, pcl::PointXYZI>::Ptr ndt(
       new pcl::NormalDistributionsTransform<pcl::PointXYZI, pcl::PointXYZI>());
     ndt->setStepSize(ndt_step_size_);
@@ -1022,21 +919,19 @@ void PCLLocalization::initializeRegistration()
     pcl_registration_ = ndt;
     registration_ = pcl_registration_.get();
   }
-  else if (registration_method_ == "NDT_OMP") {
+  else if (registration_backend == lidar_localization::RegistrationBackend::kNdtOmp) {
     pclomp::NormalDistributionsTransform<pcl::PointXYZI, pcl::PointXYZI>::Ptr ndt_omp(
       new pclomp::NormalDistributionsTransform<pcl::PointXYZI, pcl::PointXYZI>());
     ndt_omp->setStepSize(ndt_step_size_);
     ndt_omp->setResolution(ndt_resolution_);
     ndt_omp->setTransformationEpsilon(transform_epsilon_);
-    if (ndt_num_threads_ > 0) {
-      ndt_omp->setNumThreads(ndt_num_threads_);
-    } else {
-      ndt_omp->setNumThreads(omp_get_max_threads());
-    }
+    ndt_omp->setNumThreads(
+      lidar_localization::resolveRegistrationThreadCount(
+        ndt_num_threads_, omp_get_max_threads()));
     ndt_omp_registration_ = ndt_omp;
     registration_ = ndt_omp_registration_.get();
   }
-  else if (registration_method_ == "GICP_OMP") {
+  else if (registration_backend == lidar_localization::RegistrationBackend::kGicpOmp) {
     pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZI, pcl::PointXYZI>::Ptr gicp_omp(
       new pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZI, pcl::PointXYZI>());
     gicp_omp->setTransformationEpsilon(transform_epsilon_);
@@ -1046,24 +941,23 @@ void PCLLocalization::initializeRegistration()
     registration_ = gicp_omp_registration_.get();
   }
 #ifdef LIDAR_LOCALIZATION_HAVE_SMALL_GICP
-  else if (registration_method_ == "SMALL_GICP" || registration_method_ == "SMALL_VGICP") {
+  else if (lidar_localization::isSmallGicpBackend(registration_backend)) {
     small_gicp::RegistrationPCL<pcl::PointXYZI, pcl::PointXYZI>::Ptr reg(
       new small_gicp::RegistrationPCL<pcl::PointXYZI, pcl::PointXYZI>());
     reg->setTransformationEpsilon(transform_epsilon_);
     reg->setCorrespondenceRandomness(gicp_corr_randomness_);
     reg->setMaxCorrespondenceDistance(gicp_max_correspondence_distance_);
     reg->setVoxelResolution(vgicp_voxel_resolution_);
-    reg->setRegistrationType(registration_method_ == "SMALL_VGICP" ? "VGICP" : "GICP");
-    if (ndt_num_threads_ > 0) {
-      reg->setNumThreads(ndt_num_threads_);
-    } else {
-      reg->setNumThreads(omp_get_max_threads());
-    }
+    reg->setRegistrationType(
+      lidar_localization::smallGicpRegistrationType(registration_backend));
+    reg->setNumThreads(
+      lidar_localization::resolveRegistrationThreadCount(
+        ndt_num_threads_, omp_get_max_threads()));
     small_gicp_registration_ = reg;
     registration_ = small_gicp_registration_.get();
   }
 #else
-  else if (registration_method_ == "SMALL_GICP" || registration_method_ == "SMALL_VGICP") {
+  else if (lidar_localization::isSmallGicpBackend(registration_backend)) {
     RCLCPP_ERROR(
       get_logger(),
       "small_gicp backend requested but support is not available. Install small_gicp and rebuild.");
@@ -1179,16 +1073,21 @@ void PCLLocalization::mapReceived(const sensor_msgs::msg::PointCloud2::SharedPtr
 
   pcl::fromROSMsg(*msg, *map_cloud_ptr);
 
-  if (uses_filtered_target(registration_method_)) {
-    pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_cloud_ptr(new pcl::PointCloud<pcl::PointXYZI>());
+  const auto map_target_choice = lidar_localization::chooseMapSubscriptionTargetCloud(
+    lidar_localization::usesFilteredTarget(registration_method_));
+  if (map_target_choice == lidar_localization::LocalMapTargetCloud::kFilteredLocalMap) {
+    pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_cloud_ptr(
+      new pcl::PointCloud<pcl::PointXYZI>());
     voxel_grid_filter_.setInputCloud(map_cloud_ptr);
     voxel_grid_filter_.filter(*filtered_cloud_ptr);
     registration_->setInputTarget(filtered_cloud_ptr);
-    keep_cloud_alive(&recent_target_clouds_, filtered_cloud_ptr, kRegistrationTargetCloudKeepAliveCount);
+    keep_cloud_alive(
+      &recent_target_clouds_, filtered_cloud_ptr, kRegistrationTargetCloudKeepAliveCount);
 
   } else {
     registration_->setInputTarget(map_cloud_ptr);
-    keep_cloud_alive(&recent_target_clouds_, map_cloud_ptr, kRegistrationTargetCloudKeepAliveCount);
+    keep_cloud_alive(
+      &recent_target_clouds_, map_cloud_ptr, kRegistrationTargetCloudKeepAliveCount);
   }
 
   map_recieved_ = true;
@@ -1266,18 +1165,61 @@ void PCLLocalization::imuReceived(const sensor_msgs::msg::Imu::ConstSharedPtr ms
 {
   if (shutting_down_) {return;}
   // IMU preintegration buffering (always runs if enabled, independent of use_imu_)
-  if (use_imu_preintegration_ && !imu_preintegration_fallback_mode_) {
+  Eigen::Vector3d preintegration_gyro(
+    msg->angular_velocity.x, msg->angular_velocity.y, msg->angular_velocity.z);
+  Eigen::Vector3d preintegration_accel(
+    msg->linear_acceleration.x, msg->linear_acceleration.y, msg->linear_acceleration.z);
+  bool preintegration_sample_ready = true;
+
+  if (
+    use_imu_preintegration_ &&
+    !imu_preintegration_fallback_mode_ &&
+    imu_preintegration_use_base_frame_transform_ &&
+    msg->header.frame_id != base_frame_id_) {
+    try {
+      const geometry_msgs::msg::TransformStamped transform = tfbuffer_.lookupTransform(
+        base_frame_id_, msg->header.frame_id, tf2::TimePointZero);
+
+      geometry_msgs::msg::Vector3Stamped angular_velocity;
+      geometry_msgs::msg::Vector3Stamped linear_acceleration;
+      geometry_msgs::msg::Vector3Stamped transformed_angular_velocity;
+      geometry_msgs::msg::Vector3Stamped transformed_linear_acceleration;
+      angular_velocity.header = msg->header;
+      angular_velocity.vector = msg->angular_velocity;
+      linear_acceleration.header = msg->header;
+      linear_acceleration.vector = msg->linear_acceleration;
+
+      tf2::doTransform(angular_velocity, transformed_angular_velocity, transform);
+      tf2::doTransform(linear_acceleration, transformed_linear_acceleration, transform);
+
+      preintegration_gyro = Eigen::Vector3d(
+        transformed_angular_velocity.vector.x,
+        transformed_angular_velocity.vector.y,
+        transformed_angular_velocity.vector.z);
+      preintegration_accel = Eigen::Vector3d(
+        transformed_linear_acceleration.vector.x,
+        transformed_linear_acceleration.vector.y,
+        transformed_linear_acceleration.vector.z);
+    } catch (tf2::TransformException & ex) {
+      preintegration_sample_ready = false;
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000,
+        "Failed to transform IMU preintegration sample from %s to %s: %s",
+        msg->header.frame_id.c_str(), base_frame_id_.c_str(), ex.what());
+    }
+  }
+
+  if (
+    use_imu_preintegration_ &&
+    !imu_preintegration_fallback_mode_ &&
+    preintegration_sample_ready) {
     double stamp_sec = stamp_to_sec(msg->header.stamp);
-    const Eigen::Vector3d gyro(
-      msg->angular_velocity.x, msg->angular_velocity.y, msg->angular_velocity.z);
-    const Eigen::Vector3d accel(
-      msg->linear_acceleration.x, msg->linear_acceleration.y, msg->linear_acceleration.z);
 
     // Feed to smoother for dead-reckoning
     if (imu_smoother_.isInitialized() && last_imu_stamp_ > 0.0) {
       double dt = stamp_sec - last_imu_stamp_;
       if (dt > 0.0 && dt < 0.5) {
-        imu_smoother_.integrateImu(gyro, accel, dt);
+        imu_smoother_.integrateImu(preintegration_gyro, preintegration_accel, dt);
       }
     }
     last_imu_stamp_ = stamp_sec;
@@ -1339,78 +1281,152 @@ void PCLLocalization::imuReceived(const sensor_msgs::msg::Imu::ConstSharedPtr ms
 
 void PCLLocalization::cloudReceived(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
-  if (shutting_down_) {return;}
-  if (!msg) {
-    RCLCPP_WARN(get_logger(), "Received null point cloud message");
+  double scan_stamp_sec = 0.0;
+  if (!admitScanMessage(msg, &scan_stamp_sec)) {
+    return;
+  }
+  const PreparedScanCloud prepared_scan = prepareScanForRegistration(msg, scan_stamp_sec);
+  if (!lidar_localization::isPreparedScanReady(prepared_scan.status)) {
+    handleScanPreparationFailure(msg->header.stamp, prepared_scan, scan_stamp_sec);
+    return;
+  }
+  const std::size_t filtered_point_count = prepared_scan.filtered_point_count;
+  const pcl::PointCloud<pcl::PointXYZI>::Ptr tmp_ptr = prepared_scan.cloud;
+  setRegistrationSourceCloud(tmp_ptr);
+
+  const SelectedRegistrationSeed selected_seed = selectRegistrationSeed(scan_stamp_sec);
+  const bool imu_prediction_ready = selected_seed.imu_prediction_ready;
+  Eigen::Matrix4f init_guess =
+    refineSeedWithNdtInitializer(tmp_ptr, selected_seed.init_guess);
+  const auto pipeline_result = runAlignmentPipelineForScan(init_guess, scan_stamp_sec);
+
+  logAlignmentPipelineRecovery(pipeline_result);
+  if (handleTerminalAlignmentPipelineResult(
+      msg->header.stamp,
+      pipeline_result,
+      filtered_point_count,
+      scan_stamp_sec,
+      imu_prediction_ready))
+  {
+    return;
+  }
+  if (!applyAcceptedAlignmentPipelineResult(
+      msg->header.stamp,
+      pipeline_result,
+      filtered_point_count,
+      scan_stamp_sec,
+      imu_prediction_ready))
+  {
     return;
   }
 
-  last_scan_ptr_ = msg;
+  printAlignmentDebugInfo(init_guess, pipeline_result.selected_attempt, filtered_point_count);
+}
 
-  if (!map_recieved_ || !initialpose_recieved_) {return;}
-
-  // Skip scans that arrive too soon after the last processed scan.
-  if (min_scan_interval_sec_ > 0.0 && last_cloud_process_time_.nanoseconds() > 0) {
-    const auto now = this->now();
-    const double dt = (now - last_cloud_process_time_).seconds();
-    if (dt < min_scan_interval_sec_) {
-      return;
+bool PCLLocalization::admitScanMessage(
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg,
+  double * scan_stamp_sec)
+{
+  const bool timing_relevant =
+    !shutting_down_ && static_cast<bool>(msg) && map_recieved_ && initialpose_recieved_;
+  rclcpp::Time now;
+  bool has_last_process_time = false;
+  double elapsed_since_last_process_sec = 0.0;
+  if (timing_relevant) {
+    now = this->now();
+    has_last_process_time = last_cloud_process_time_.nanoseconds() > 0;
+    if (has_last_process_time) {
+      elapsed_since_last_process_sec = (now - last_cloud_process_time_).seconds();
     }
   }
-  last_cloud_process_time_ = this->now();
 
-  RCLCPP_DEBUG(get_logger(), "cloudReceived");
-  const double scan_stamp_sec = stamp_to_sec(msg->header.stamp);
-  if (consecutive_crop_failures_ > 100) {
-    if (!crop_failure_guard_active_) {
+  const auto admission = lidar_localization::decideScanAdmission(
+    lidar_localization::ScanAdmissionInput{
+      shutting_down_,
+      static_cast<bool>(msg),
+      map_recieved_,
+      initialpose_recieved_,
+      min_scan_interval_sec_,
+      has_last_process_time,
+      elapsed_since_last_process_sec,
+      consecutive_crop_failures_,
+      crop_failure_guard_active_,
+      have_last_accepted_pose_});
+
+  if (admission.should_warn_null_scan) {
+    RCLCPP_WARN(get_logger(), "Received null point cloud message");
+  }
+  if (admission.should_store_last_scan) {
+    last_scan_ptr_ = msg;
+  }
+  if (admission.should_update_last_process_time) {
+    last_cloud_process_time_ = now;
+  }
+
+  if (admission.status == lidar_localization::ScanAdmissionStatus::kCropFailureGuard) {
+    const double current_scan_stamp_sec = stamp_to_sec(msg->header.stamp);
+    if (scan_stamp_sec) {
+      *scan_stamp_sec = current_scan_stamp_sec;
+    }
+    if (admission.should_activate_crop_failure_guard) {
       crop_failure_guard_active_ = true;
-      if (have_last_accepted_pose_) {
+      if (admission.should_reset_prediction_to_last_accepted_pose) {
         predicted_pose_matrix_ = last_accepted_pose_matrix_;
-        predicted_pose_time_sec_ = scan_stamp_sec;
+        predicted_pose_time_sec_ = current_scan_stamp_sec;
       }
+    }
+    if (admission.should_log_crop_failure_guard_activation) {
       RCLCPP_ERROR(
         get_logger(),
         "Activating crop failure guard after %d consecutive crop failures; "
         "dropping subsequent scans until a new initial pose arrives.",
         consecutive_crop_failures_);
     }
-    return;
   }
-  const bool cloud_has_intensity = has_field(msg->fields, "intensity");
+
+  if (!admission.accepted) {
+    return false;
+  }
+
+  if (scan_stamp_sec) {
+    *scan_stamp_sec = stamp_to_sec(msg->header.stamp);
+  }
+  RCLCPP_DEBUG(get_logger(), "cloudReceived");
+  return true;
+}
+
+PCLLocalization::PreparedScanCloud PCLLocalization::prepareScanForRegistration(
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg,
+  double scan_stamp_sec)
+{
+  PreparedScanCloud prepared_scan;
+
+  const bool cloud_has_intensity = lidar_localization::hasPointField(msg->fields, "intensity");
   if (!cloud_has_intensity) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 5000,
       "Input cloud does not contain intensity. Falling back to xyz with zero intensity.");
   }
   const bool can_direct_range_filter =
-    !enable_scan_voxel_filter_ &&
-    !use_imu_ &&
-    msg->header.frame_id == base_frame_id_;
-  std::size_t filtered_point_count = 0;
-  pcl::PointCloud<pcl::PointXYZI>::Ptr tmp_ptr;
+    lidar_localization::shouldUseDirectRangeFilter(
+    lidar_localization::ScanPreprocessingPathInput{
+      enable_scan_voxel_filter_,
+      use_imu_,
+      msg->header.frame_id,
+      base_frame_id_});
+
   if (can_direct_range_filter) {
-    const auto * x_field = find_field(msg->fields, "x");
-    const auto * y_field = find_field(msg->fields, "y");
-    const auto * z_field = find_field(msg->fields, "z");
-    const auto * intensity_field = find_field(msg->fields, "intensity");
-    if (!x_field || !y_field || !z_field) {
-      publishAlignmentStatus(
-        msg->header.stamp,
-        diagnostic_msgs::msg::DiagnosticStatus::ERROR,
-        "scan_missing_xyz_field",
-        false,
-        std::numeric_limits<double>::quiet_NaN(),
-        0.0,
-        0,
-        std::numeric_limits<double>::quiet_NaN(),
-        std::numeric_limits<double>::quiet_NaN(),
-        std::numeric_limits<double>::quiet_NaN(),
-        std::numeric_limits<double>::quiet_NaN(),
-        std::numeric_limits<double>::quiet_NaN(),
-        false);
-      RCLCPP_ERROR(get_logger(), "Input scan is missing x/y/z fields.");
-      advancePredictionWithoutMeasurement(stamp_to_sec(msg->header.stamp));
-      return;
+    const auto * x_field = lidar_localization::findPointField(msg->fields, "x");
+    const auto * y_field = lidar_localization::findPointField(msg->fields, "y");
+    const auto * z_field = lidar_localization::findPointField(msg->fields, "z");
+    const auto * intensity_field = lidar_localization::findPointField(msg->fields, "intensity");
+    if (!lidar_localization::hasRequiredXyzFields(
+        lidar_localization::ScanXyzFieldAvailability{
+          x_field != nullptr, y_field != nullptr, z_field != nullptr}))
+    {
+      prepared_scan.status =
+        lidar_localization::classifyPreparedScan(false, true, false);
+      return prepared_scan;
     }
 
     pcl::PointCloud<pcl::PointXYZI> tmp;
@@ -1421,42 +1437,45 @@ void PCLLocalization::cloudReceived(const sensor_msgs::msg::PointCloud2::ConstSh
       const uint8_t * point_data = msg->data.data() + point_idx * msg->point_step;
       pcl::PointXYZI point;
       float intensity = 0.0f;
-      if (!read_field_as_float(point_data, *x_field, &point.x) ||
-        !read_field_as_float(point_data, *y_field, &point.y) ||
-        !read_field_as_float(point_data, *z_field, &point.z))
+      if (!lidar_localization::readPointFieldAsFloat(point_data, *x_field, &point.x) ||
+        !lidar_localization::readPointFieldAsFloat(point_data, *y_field, &point.y) ||
+        !lidar_localization::readPointFieldAsFloat(point_data, *z_field, &point.z))
       {
         continue;
       }
       if (intensity_field) {
-        read_field_as_float(point_data, *intensity_field, &intensity);
+        lidar_localization::readPointFieldAsFloat(point_data, *intensity_field, &intensity);
       }
       point.intensity = intensity;
-      ++filtered_point_count;
-      const double range = std::hypot(point.x, point.y);
-      if (scan_min_range_ < range && range < scan_max_range_) {
+      ++prepared_scan.filtered_point_count;
+      if (lidar_localization::isPointInScanRange(
+          point.x, point.y, point.z, scan_min_range_, scan_max_range_))
+      {
         tmp.push_back(point);
       }
     }
-    tmp_ptr.reset(new pcl::PointCloud<pcl::PointXYZI>(tmp));
+    prepared_scan.cloud.reset(new pcl::PointCloud<pcl::PointXYZI>(tmp));
   } else {
     pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_ptr(new pcl::PointCloud<pcl::PointXYZI>);
-    convert_sensor_cloud_to_xyzi(*msg, *cloud_ptr);
+    lidar_localization::convertSensorCloudToXyzi(*msg, *cloud_ptr);
 
     // If your cloud is not robot-centric, convert to base_frame.
     if (msg->header.frame_id != base_frame_id_) {
       RCLCPP_DEBUG(
-          this->get_logger(), "Transforming point cloud from %s to %s",
-          msg->header.frame_id.c_str(), base_frame_id_.c_str());
+        this->get_logger(), "Transforming point cloud from %s to %s",
+        msg->header.frame_id.c_str(), base_frame_id_.c_str());
       geometry_msgs::msg::TransformStamped base_to_lidar_stamped;
       try {
         base_to_lidar_stamped = tfbuffer_.lookupTransform(
-            base_frame_id_, msg->header.frame_id, msg->header.stamp,
-            rclcpp::Duration::from_seconds(0.1));
+          base_frame_id_, msg->header.frame_id, msg->header.stamp,
+          rclcpp::Duration::from_seconds(0.1));
       } catch (const tf2::TransformException & ex) {
+        prepared_scan.status =
+          lidar_localization::classifyPreparedScan(true, false, false);
         RCLCPP_ERROR(
-            this->get_logger(), "Could not transform %s to %s: %s",
-            msg->header.frame_id.c_str(), base_frame_id_.c_str(), ex.what());
-        return;
+          this->get_logger(), "Could not transform %s to %s: %s",
+          msg->header.frame_id.c_str(), base_frame_id_.c_str(), ex.what());
+        return prepared_scan;
       }
 
       Eigen::Matrix4f initial_transformation =
@@ -1467,741 +1486,502 @@ void PCLLocalization::cloudReceived(const sensor_msgs::msg::PointCloud2::ConstSh
     }
 
     if (use_imu_) {
-      double received_time = msg->header.stamp.sec +
-        msg->header.stamp.nanosec * 1e-9;
-      lidar_undistortion_.adjustDistortion(cloud_ptr, received_time);
+      lidar_undistortion_.adjustDistortion(cloud_ptr, scan_stamp_sec);
     }
 
     pcl::PointCloud<pcl::PointXYZI> tmp;
     tmp.reserve(cloud_ptr->size());
     for (const auto & point : cloud_ptr->points) {
-      if (!std::isfinite(point.x) || !std::isfinite(point.y) || !std::isfinite(point.z)) {
-        continue;
-      }
-      const double range = std::hypot(point.x, point.y);
-      if (scan_min_range_ < range && range < scan_max_range_) {
+      if (lidar_localization::isPointInScanRange(
+          point.x, point.y, point.z, scan_min_range_, scan_max_range_))
+      {
         tmp.push_back(point);
       }
     }
-    filtered_point_count = tmp.size();
-    tmp_ptr.reset(new pcl::PointCloud<pcl::PointXYZI>(tmp));
+    prepared_scan.filtered_point_count = tmp.size();
+    prepared_scan.cloud.reset(new pcl::PointCloud<pcl::PointXYZI>(tmp));
 
-    if (enable_scan_voxel_filter_ && !tmp_ptr->empty()) {
+    if (enable_scan_voxel_filter_ && !prepared_scan.cloud->empty()) {
       pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_cloud_ptr(
         new pcl::PointCloud<pcl::PointXYZI>());
       pcl::VoxelGrid<pcl::PointXYZI> scan_voxel_grid_filter;
       scan_voxel_grid_filter.setLeafSize(voxel_leaf_size_, voxel_leaf_size_, voxel_leaf_size_);
-      scan_voxel_grid_filter.setInputCloud(tmp_ptr);
+      scan_voxel_grid_filter.setInputCloud(prepared_scan.cloud);
       scan_voxel_grid_filter.filter(*filtered_cloud_ptr);
-      filtered_point_count = filtered_cloud_ptr->size();
-      tmp_ptr = filtered_cloud_ptr;
+      prepared_scan.filtered_point_count = filtered_cloud_ptr->size();
+      prepared_scan.cloud = filtered_cloud_ptr;
     }
-    cloud_ptr.reset();
   }
 
-  if (tmp_ptr->empty()) {
-    publishAlignmentStatus(
-      msg->header.stamp,
-      diagnostic_msgs::msg::DiagnosticStatus::ERROR,
-      "filtered_scan_empty",
-      false,
-      std::numeric_limits<double>::quiet_NaN(),
-      0.0,
-      filtered_point_count,
-      std::numeric_limits<double>::quiet_NaN(),
-      std::numeric_limits<double>::quiet_NaN(),
-      std::numeric_limits<double>::quiet_NaN(),
-      std::numeric_limits<double>::quiet_NaN(),
-      std::numeric_limits<double>::quiet_NaN(),
-      false);
+  prepared_scan.status = lidar_localization::classifyPreparedScan(
+    true,
+    true,
+    !prepared_scan.cloud || prepared_scan.cloud->empty());
+  return prepared_scan;
+}
+
+void PCLLocalization::handleScanPreparationFailure(
+  const builtin_interfaces::msg::Time & stamp,
+  const PreparedScanCloud & prepared_scan,
+  double scan_stamp_sec)
+{
+  if (prepared_scan.status == lidar_localization::ScanPreparationStatus::kTransformUnavailable) {
+    return;
+  }
+
+  publishAlignmentStatus(
+    stamp,
+    diagnostic_msgs::msg::DiagnosticStatus::ERROR,
+    lidar_localization::scanPreparationStatusMessage(prepared_scan.status),
+    false,
+    std::numeric_limits<double>::quiet_NaN(),
+    0.0,
+    prepared_scan.filtered_point_count,
+    std::numeric_limits<double>::quiet_NaN(),
+    std::numeric_limits<double>::quiet_NaN(),
+    std::numeric_limits<double>::quiet_NaN(),
+    std::numeric_limits<double>::quiet_NaN(),
+    std::numeric_limits<double>::quiet_NaN(),
+    false);
+
+  if (prepared_scan.status == lidar_localization::ScanPreparationStatus::kMissingXyzField) {
+    RCLCPP_ERROR(get_logger(), "Input scan is missing x/y/z fields.");
+  } else if (prepared_scan.status == lidar_localization::ScanPreparationStatus::kFilteredScanEmpty) {
     RCLCPP_WARN(get_logger(), "Filtered scan is empty after range filtering.");
-	    advancePredictionWithoutMeasurement(stamp_to_sec(msg->header.stamp));
-	    return;
   }
-  registration_->setInputSource(tmp_ptr);
-  keep_cloud_alive(&recent_source_clouds_, tmp_ptr, kRegistrationSourceCloudKeepAliveCount);
 
-  Eigen::Matrix4f init_guess = currentPoseMatrix();
-  bool init_guess_uses_prediction = false;
-  bool imu_prediction_ready =
+  if (lidar_localization::shouldAdvancePredictionAfterScanPreparationFailure(
+      prepared_scan.status))
+  {
+    advancePredictionWithoutMeasurement(scan_stamp_sec);
+  }
+}
+
+PCLLocalization::SelectedRegistrationSeed PCLLocalization::selectRegistrationSeed(
+  double scan_stamp_sec)
+{
+  SelectedRegistrationSeed selected_seed;
+  selected_seed.init_guess = currentPoseMatrix();
+
+  const bool imu_has_new_samples =
+    lidar_localization::hasNewImuSamples(last_imu_stamp_, last_scan_stamp_for_imu_);
+  const bool imu_candidate_ready =
     use_imu_preintegration_ &&
     !imu_preintegration_fallback_mode_ &&
     imu_smoother_.isInitialized() &&
-    last_imu_stamp_ > last_scan_stamp_for_imu_;
-  if (imu_prediction_ready) {
-    const Eigen::Matrix4f imu_init_guess = imu_smoother_.predictedPoseMatrix();
-    if (imu_init_guess.allFinite()) {
-      init_guess = imu_init_guess;
-    } else {
-      imu_prediction_ready = false;
-      RCLCPP_WARN(
-        get_logger(),
-        "Ignoring non-finite IMU predicted pose and falling back to non-IMU seed.");
-    }
-  } else if (use_gtsam_smoother_ && gtsam_smoother_.isInitialized()) {
-    init_guess = gtsam_smoother_.predictedPoseMatrix(last_ndt_roll_, last_ndt_pitch_);
-  } else if (use_twist_ekf_ && twist_ekf_.isInitialized()) {
-    init_guess = twist_ekf_.poseMatrix(last_ndt_roll_, last_ndt_pitch_);
-  } else if (use_twist_prediction_ && have_last_accepted_pose_ && latest_twist_msg_) {
-    const double dt = std::clamp(
-      scan_stamp_sec - predicted_pose_time_sec_, 0.0, max_twist_prediction_dt_);
-    init_guess = applyTwistPrediction(predicted_pose_matrix_, dt);
-    init_guess_uses_prediction = true;
-  } else if (predict_pose_from_previous_delta_ && have_last_accepted_pose_) {
-    init_guess = predicted_pose_matrix_;
-    init_guess_uses_prediction = true;
+    imu_has_new_samples;
+  Eigen::Matrix4f imu_init_guess = Eigen::Matrix4f::Identity();
+  bool imu_prediction_finite = false;
+  if (imu_candidate_ready) {
+    imu_init_guess = imu_smoother_.predictedPoseMatrix();
+    imu_prediction_finite = imu_init_guess.allFinite();
   }
 
-  struct AlignmentAttempt
-  {
-    bool target_ready{false};
-    bool has_converged{false};
-    double alignment_time_sec{0.0};
-    double fitness_score{std::numeric_limits<double>::quiet_NaN()};
-    Eigen::Matrix4f init_guess{Eigen::Matrix4f::Identity()};
-    Eigen::Matrix4f final_transformation{Eigen::Matrix4f::Identity()};
-    double correction_translation_m{std::numeric_limits<double>::quiet_NaN()};
-    double correction_yaw_deg{std::numeric_limits<double>::quiet_NaN()};
-    double seed_translation_since_accept_m{std::numeric_limits<double>::quiet_NaN()};
-    double seed_yaw_since_accept_deg{std::numeric_limits<double>::quiet_NaN()};
-    double accepted_gap_sec{std::numeric_limits<double>::quiet_NaN()};
-  };
+  const lidar_localization::RegistrationSeedPolicyDecision seed_decision =
+    lidar_localization::chooseRegistrationSeed(
+    lidar_localization::RegistrationSeedPolicyInput{
+      use_imu_preintegration_,
+      imu_preintegration_fallback_mode_,
+      imu_smoother_.isInitialized(),
+      imu_has_new_samples,
+      imu_prediction_finite,
+      use_gtsam_smoother_,
+      gtsam_smoother_.isInitialized(),
+      use_twist_ekf_,
+      twist_ekf_.isInitialized(),
+      use_twist_prediction_,
+      have_last_accepted_pose_,
+      static_cast<bool>(latest_twist_msg_),
+      predict_pose_from_previous_delta_});
+  selected_seed.imu_prediction_ready = seed_decision.imu_prediction_ready;
 
-  struct MeasurementGateResult
-  {
-    uint8_t status_level{diagnostic_msgs::msg::DiagnosticStatus::OK};
-    std::string status_message{"ok"};
-    bool reject_measurement{false};
-    bool post_reject_strict_active{false};
-    bool open_loop_strict_active{false};
-    bool borderline_seed_gate_active{false};
-    bool rejected_seed_update_applied{false};
-    double effective_score_threshold{0.0};
-  };
+  switch (seed_decision.source) {
+    case lidar_localization::RegistrationSeedSource::kImuPreintegration:
+      selected_seed.init_guess = imu_init_guess;
+      break;
+    case lidar_localization::RegistrationSeedSource::kGtsamSmoother:
+      selected_seed.init_guess =
+        gtsam_smoother_.predictedPoseMatrix(last_ndt_roll_, last_ndt_pitch_);
+      break;
+    case lidar_localization::RegistrationSeedSource::kTwistEkf:
+      selected_seed.init_guess = twist_ekf_.poseMatrix(last_ndt_roll_, last_ndt_pitch_);
+      break;
+    case lidar_localization::RegistrationSeedSource::kTwistPrediction: {
+      const double dt = lidar_localization::clampPredictionDt(
+        scan_stamp_sec, predicted_pose_time_sec_, max_twist_prediction_dt_);
+      selected_seed.init_guess = applyTwistPrediction(predicted_pose_matrix_, dt);
+      break;
+    }
+    case lidar_localization::RegistrationSeedSource::kPreviousDelta:
+      selected_seed.init_guess = predicted_pose_matrix_;
+      break;
+    case lidar_localization::RegistrationSeedSource::kCurrentPose:
+      break;
+  }
 
-  auto set_input_target_for_pose = [&](const Eigen::Matrix4f & center_pose_matrix) -> bool {
-      if (!use_local_map_crop_ || !full_map_cloud_ptr_) {
-        return true;
-      }
+  if (seed_decision.ignored_non_finite_imu_prediction) {
+    RCLCPP_WARN(
+      get_logger(),
+      "Ignoring non-finite IMU predicted pose and falling back to non-IMU seed.");
+  }
+  return selected_seed;
+}
 
-      const float cx = center_pose_matrix(0, 3);
-      const float cy = center_pose_matrix(1, 3);
-      const float cz = center_pose_matrix(2, 3);
-      const auto steady_now = std::chrono::steady_clock::now();
-      auto maybe_log_crop_failure_streak = [&]() {
-          if (consecutive_crop_failures_ <= 100) {
-            return;
-          }
-          if (
-            last_crop_failure_streak_log_time_ == std::chrono::steady_clock::time_point{} ||
-            steady_now - last_crop_failure_streak_log_time_ >= std::chrono::seconds(5))
-          {
-            last_crop_failure_streak_log_time_ = steady_now;
-            RCLCPP_WARN(
-              get_logger(),
-              "Crop failure streak reached %d while target setup keeps failing.",
-              consecutive_crop_failures_);
-          }
-        };
-      if (
-        map_bounds_valid_ &&
-        (cx < map_min_pt_.x - local_map_radius_ || cx > map_max_pt_.x + local_map_radius_ ||
-        cy < map_min_pt_.y - local_map_radius_ || cy > map_max_pt_.y + local_map_radius_))
-      {
-        ++consecutive_crop_failures_;
-        maybe_log_crop_failure_streak();
-        if (
-          last_crop_out_of_bounds_log_time_ == std::chrono::steady_clock::time_point{} ||
-          steady_now - last_crop_out_of_bounds_log_time_ >= std::chrono::seconds(5))
-        {
-          last_crop_out_of_bounds_log_time_ = steady_now;
-          RCLCPP_WARN(
-            get_logger(),
-            "Crop center (%.1f, %.1f) is outside map bounds + radius, skipping alignment",
-            static_cast<double>(cx), static_cast<double>(cy));
-        }
-        return false;
-      }
-      const float r2 = static_cast<float>(local_map_radius_ * local_map_radius_);
-      pcl::PointCloud<pcl::PointXYZI>::Ptr local_map(new pcl::PointCloud<pcl::PointXYZI>());
-      local_map->reserve(full_map_cloud_ptr_->size() / 10);
-      for (const auto & p : full_map_cloud_ptr_->points) {
-        const float dx = p.x - cx;
-        const float dy = p.y - cy;
-        if (dx * dx + dy * dy <= r2) {
-          local_map->push_back(p);
-        }
-      }
-      if (local_map->size() < local_map_min_points_) {
-        ++consecutive_crop_failures_;
-        maybe_log_crop_failure_streak();
+Eigen::Matrix4f PCLLocalization::refineSeedWithNdtInitializer(
+  const pcl::PointCloud<pcl::PointXYZI>::Ptr & source_cloud,
+  const Eigen::Matrix4f & init_guess)
+{
+  const auto run_input = lidar_localization::NdtInitializerRunInput{
+    use_ndt_initializer_,
+    static_cast<bool>(ndt_initializer_) && static_cast<bool>(source_cloud),
+    ndt_init_scan_count_,
+    ndt_init_scans_required_};
+  if (!lidar_localization::shouldRunNdtInitializer(run_input)) {
+    return init_guess;
+  }
+
+  ndt_initializer_->setInputSource(source_cloud);
+  pcl::PointCloud<pcl::PointXYZI>::Ptr ndt_output(new pcl::PointCloud<pcl::PointXYZI>);
+  ndt_initializer_->align(*ndt_output, init_guess);
+  const auto progress_decision =
+    lidar_localization::updateNdtInitializerProgress(
+    lidar_localization::NdtInitializerProgressInput{
+      run_input,
+      ndt_initializer_->hasConverged()});
+  if (!progress_decision.should_accept_refined_seed) {
+    return init_guess;
+  }
+
+  Eigen::Matrix4f refined_seed = ndt_initializer_->getFinalTransformation();
+  ndt_init_scan_count_ = progress_decision.next_scan_count;
+  RCLCPP_INFO(
+    get_logger(), "NDT init scan %d/%d fitness=%.3f",
+    ndt_init_scan_count_, ndt_init_scans_required_, ndt_initializer_->getFitnessScore());
+  if (progress_decision.should_reset_initializer) {
+    RCLCPP_INFO(get_logger(), "NDT init complete, switching to %s", registration_method_.c_str());
+    ndt_initializer_.reset();
+  }
+  return refined_seed;
+}
+
+bool PCLLocalization::setInputTargetForPose(const Eigen::Matrix4f & center_pose_matrix)
+{
+  if (!use_local_map_crop_ || !full_map_cloud_ptr_) {
+    return true;
+  }
+
+  const float cx = center_pose_matrix(0, 3);
+  const float cy = center_pose_matrix(1, 3);
+  const lidar_localization::LocalMapCropRequest crop_request{
+    cx,
+    cy,
+    local_map_radius_,
+    local_map_min_points_,
+    lidar_localization::LocalMapBounds2d{
+      map_bounds_valid_,
+      map_min_pt_.x,
+      map_max_pt_.x,
+      map_min_pt_.y,
+      map_max_pt_.y}};
+  const auto steady_now = std::chrono::steady_clock::now();
+
+  auto handle_crop_failure = [&](lidar_localization::LocalMapTargetFailure failure) {
+      const bool has_last_streak_log =
+        last_crop_failure_streak_log_time_ != std::chrono::steady_clock::time_point{};
+      const auto elapsed_since_streak_log =
+        has_last_streak_log ?
+        steady_now - last_crop_failure_streak_log_time_ :
+        std::chrono::steady_clock::duration::zero();
+      const bool has_last_bounds_log =
+        last_crop_out_of_bounds_log_time_ != std::chrono::steady_clock::time_point{};
+      const auto elapsed_since_bounds_log =
+        has_last_bounds_log ?
+        steady_now - last_crop_out_of_bounds_log_time_ :
+        std::chrono::steady_clock::duration::zero();
+      const auto decision = lidar_localization::handleLocalMapTargetFailure(
+        lidar_localization::LocalMapTargetFailureHandlingInput{
+          failure,
+          consecutive_crop_failures_,
+          has_last_streak_log,
+          elapsed_since_streak_log,
+          has_last_bounds_log,
+          elapsed_since_bounds_log});
+      consecutive_crop_failures_ = decision.consecutive_crop_failures;
+      if (decision.should_log_failure_streak) {
+        last_crop_failure_streak_log_time_ = steady_now;
         RCLCPP_WARN(
           get_logger(),
-          "Local map crop too small (%zu points, min %zu) around (%.3f, %.3f) with radius %.1fm.",
-          local_map->size(),
-          local_map_min_points_,
-          static_cast<double>(cx),
-          static_cast<double>(cy),
-          local_map_radius_);
-        return false;
+          "Crop failure streak reached %d while target setup keeps failing.",
+          consecutive_crop_failures_);
       }
-
-      pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_local_map(
-        new pcl::PointCloud<pcl::PointXYZI>());
-      voxel_grid_filter_.setInputCloud(local_map);
-      voxel_grid_filter_.filter(*filtered_local_map);
-      if (filtered_local_map->size() >= local_map_min_points_) {
-        registration_->setInputTarget(filtered_local_map);
-        keep_cloud_alive(
-          &recent_target_clouds_, filtered_local_map, kRegistrationTargetCloudKeepAliveCount);
-      } else {
-        registration_->setInputTarget(local_map);
-        keep_cloud_alive(
-          &recent_target_clouds_, local_map, kRegistrationTargetCloudKeepAliveCount);
+      if (decision.should_log_out_of_bounds) {
+        last_crop_out_of_bounds_log_time_ = steady_now;
       }
-      consecutive_crop_failures_ = 0;
-      crop_failure_guard_active_ = false;
-      return true;
+      return decision;
     };
 
-  auto run_alignment_attempt = [&](const Eigen::Matrix4f & attempt_init_guess,
-                                   const Eigen::Matrix4f & crop_center_pose_matrix) {
-      AlignmentAttempt attempt;
-      attempt.init_guess = attempt_init_guess;
-      if (!set_input_target_for_pose(crop_center_pose_matrix)) {
-        return attempt;
-      }
-      attempt.target_ready = true;
-
-      pcl::PointCloud<pcl::PointXYZI> output_cloud;
-      rclcpp::Clock system_clock;
-      const rclcpp::Time time_align_start = system_clock.now();
-      registration_->align(output_cloud, attempt_init_guess);
-      const rclcpp::Time time_align_end = system_clock.now();
-      attempt.alignment_time_sec = time_align_end.seconds() - time_align_start.seconds();
-      attempt.has_converged = registration_->hasConverged();
-      attempt.fitness_score = registration_->getFitnessScore();
-
-      if (have_last_accepted_pose_) {
-        const Eigen::Matrix4f seed_delta_matrix =
-          last_accepted_pose_matrix_.inverse() * attempt_init_guess;
-        attempt.seed_translation_since_accept_m = static_cast<double>(
-          seed_delta_matrix.block<3, 1>(0, 3).norm());
-        attempt.seed_yaw_since_accept_deg = std::abs(std::atan2(
-          static_cast<double>(seed_delta_matrix(1, 0)),
-          static_cast<double>(seed_delta_matrix(0, 0)))) * 180.0 / M_PI;
-        attempt.accepted_gap_sec = std::max(0.0, scan_stamp_sec - last_accepted_pose_time_sec_);
-      }
-
-      if (attempt.has_converged) {
-        attempt.final_transformation = registration_->getFinalTransformation();
-        const Eigen::Matrix4f correction_matrix =
-          attempt_init_guess.inverse() * attempt.final_transformation;
-        attempt.correction_translation_m = static_cast<double>(
-          correction_matrix.block<3, 1>(0, 3).norm());
-        attempt.correction_yaw_deg = std::abs(std::atan2(
-          static_cast<double>(correction_matrix(1, 0)),
-          static_cast<double>(correction_matrix(0, 0)))) * 180.0 / M_PI;
-      }
-
-      return attempt;
-    };
-
-  auto evaluate_measurement_gate = [&](const AlignmentAttempt & attempt) {
-      MeasurementGateResult gate;
-      gate.effective_score_threshold = computeEffectiveScoreThreshold(
-        attempt.accepted_gap_sec,
-        attempt.seed_translation_since_accept_m,
-        &gate.post_reject_strict_active,
-        &gate.open_loop_strict_active);
-      gate.borderline_seed_gate_active = computeBorderlineSeedGateActive(
-        attempt.fitness_score,
-        attempt.seed_translation_since_accept_m,
-        gate.effective_score_threshold);
-
-      if (attempt.fitness_score > gate.effective_score_threshold || gate.borderline_seed_gate_active) {
-        gate.status_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-        if (gate.borderline_seed_gate_active) {
-          gate.status_message = reject_above_score_threshold_ ?
-            "fitness_score_over_borderline_seed_gate_rejected" :
-            "fitness_score_over_borderline_seed_gate";
-        } else if (
-          gate.open_loop_strict_active &&
-          gate.effective_score_threshold == open_loop_strict_score_threshold_)
-        {
-          gate.status_message = reject_above_score_threshold_ ?
-            "fitness_score_over_open_loop_strict_threshold_rejected" :
-            "fitness_score_over_open_loop_strict_threshold";
-        } else if (gate.post_reject_strict_active) {
-          gate.status_message = reject_above_score_threshold_ ?
-            "fitness_score_over_post_reject_strict_threshold_rejected" :
-            "fitness_score_over_post_reject_strict_threshold";
-        } else {
-          gate.status_message = reject_above_score_threshold_ ?
-            "fitness_score_over_threshold_rejected" :
-            "fitness_score_over_threshold";
-        }
-        gate.reject_measurement = reject_above_score_threshold_;
-
-        const bool recovery_candidate =
-          enable_consistency_recovery_gate_ &&
-          gate.reject_measurement &&
-          static_cast<int>(consecutive_rejected_updates_) >= consistency_recovery_min_rejections_ &&
-          attempt.fitness_score <= score_threshold_ + consistency_recovery_score_margin_ &&
-          attempt.correction_translation_m <= consistency_recovery_max_translation_m_ &&
-          attempt.correction_yaw_deg <= consistency_recovery_max_yaw_deg_;
-        if (recovery_candidate) {
-          gate.reject_measurement = false;
-          gate.status_message = "fitness_score_over_threshold_consistency_recovered";
-        }
-
-        const bool rejected_seed_update_candidate =
-          enable_rejected_seed_update_ &&
-          gate.reject_measurement &&
-          static_cast<int>(consecutive_rejected_updates_) >= rejected_seed_update_min_rejections_ &&
-          attempt.fitness_score <= rejected_seed_update_max_fitness_ &&
-          attempt.correction_translation_m <=
-            rejected_seed_update_max_correction_translation_m_ &&
-          attempt.correction_yaw_deg <= rejected_seed_update_max_correction_yaw_deg_;
-        if (rejected_seed_update_candidate) {
-          gate.rejected_seed_update_applied = true;
-          gate.status_message += "_seeded";
-        }
-        RCLCPP_WARN(get_logger(), "The fitness score is over %lf.", gate.effective_score_threshold);
-      }
-
-      return gate;
-    };
-
-  // NDT initializer phase: use NDT for first N scans, then switch to GICP
-  if (use_ndt_initializer_ && ndt_init_scan_count_ < ndt_init_scans_required_) {
-    ndt_initializer_->setInputSource(tmp_ptr);
-    pcl::PointCloud<pcl::PointXYZI>::Ptr ndt_output(new pcl::PointCloud<pcl::PointXYZI>);
-    ndt_initializer_->align(*ndt_output, init_guess);
-    if (ndt_initializer_->hasConverged()) {
-      init_guess = ndt_initializer_->getFinalTransformation();
-      ++ndt_init_scan_count_;
-      RCLCPP_INFO(get_logger(), "NDT init scan %d/%d fitness=%.3f",
-                  ndt_init_scan_count_, ndt_init_scans_required_,
-                  ndt_initializer_->getFitnessScore());
-      if (ndt_init_scan_count_ >= ndt_init_scans_required_) {
-        RCLCPP_INFO(get_logger(), "NDT init complete, switching to %s", registration_method_.c_str());
-        ndt_initializer_.reset();
-      }
-    }
-  }
-
-  AlignmentAttempt selected_attempt = run_alignment_attempt(init_guess, init_guess);
-  MeasurementGateResult gate_result;
-  bool recovered_by_retry_from_last_pose = false;
-  const double recovery_accepted_gap_sec =
-    have_last_accepted_pose_ ? std::max(0.0, scan_stamp_sec - last_accepted_pose_time_sec_) :
-    std::numeric_limits<double>::quiet_NaN();
-  const bool allow_recovery_retry_from_last_pose =
-    enable_recovery_retry_from_last_pose_ &&
-    have_last_accepted_pose_ &&
-    static_cast<int>(consecutive_rejected_updates_) >=
-      recovery_retry_from_last_pose_min_rejections_;
-
-  auto try_recovery_retry_from_last_pose = [&]() -> bool {
-      if (!allow_recovery_retry_from_last_pose) {
-        return false;
-      }
-      const double accepted_gap_sec = std::isfinite(selected_attempt.accepted_gap_sec) ?
-        selected_attempt.accepted_gap_sec : recovery_accepted_gap_sec;
-      if (
-        !std::isfinite(accepted_gap_sec) ||
-        accepted_gap_sec >
-        recovery_retry_from_last_pose_max_accepted_gap_sec_)
-      {
-        return false;
-      }
-      if (
-        std::isfinite(selected_attempt.seed_translation_since_accept_m) &&
-        selected_attempt.seed_translation_since_accept_m >
-        recovery_retry_from_last_pose_max_seed_translation_m_)
-      {
-        return false;
-      }
-
-      const AlignmentAttempt retry_attempt = run_alignment_attempt(
-        last_accepted_pose_matrix_,
-        last_accepted_pose_matrix_);
-      if (!retry_attempt.target_ready || !retry_attempt.has_converged) {
-        return false;
-      }
-
-      const MeasurementGateResult retry_gate = evaluate_measurement_gate(retry_attempt);
-      if (retry_gate.reject_measurement) {
-        return false;
-      }
-
-      selected_attempt = retry_attempt;
-      gate_result = retry_gate;
-      gate_result.status_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-      gate_result.status_message = "recovery_retry_from_last_pose_recovered";
-      gate_result.reject_measurement = false;
-      gate_result.rejected_seed_update_applied = false;
-      recovered_by_retry_from_last_pose = true;
-      RCLCPP_INFO(
+  const auto crop_validation =
+    lidar_localization::validateLocalMapCropRequest(crop_request);
+  if (!crop_validation.can_crop) {
+    const auto failure_decision = handle_crop_failure(crop_validation.failure);
+    if (failure_decision.should_log_out_of_bounds) {
+      RCLCPP_WARN(
         get_logger(),
-        "Recovery retry from last pose succeeded after %zu rejects: fitness=%.6f",
-        consecutive_rejected_updates_,
-        retry_attempt.fitness_score);
-      return true;
-    };
-
-  if (!selected_attempt.target_ready) {
-    if (!try_recovery_retry_from_last_pose()) {
-      publishAlignmentStatus(
-        msg->header.stamp,
-        diagnostic_msgs::msg::DiagnosticStatus::ERROR,
-        "local_map_crop_too_small",
-        false,
-        std::numeric_limits<double>::quiet_NaN(),
-        0.0,
-        filtered_point_count,
-        std::numeric_limits<double>::quiet_NaN(),
-        std::numeric_limits<double>::quiet_NaN(),
-        std::numeric_limits<double>::quiet_NaN(),
-        std::numeric_limits<double>::quiet_NaN(),
-        std::numeric_limits<double>::quiet_NaN(),
-        imu_prediction_ready);
-      advancePredictionWithoutMeasurement(scan_stamp_sec);
-      return;
+        "Crop center (%.1f, %.1f) is outside map bounds + radius, skipping alignment",
+        static_cast<double>(cx), static_cast<double>(cy));
     }
+    return false;
   }
 
-  if (!selected_attempt.has_converged) {
-    if (!try_recovery_retry_from_last_pose()) {
-      publishAlignmentStatus(
-        msg->header.stamp,
-        diagnostic_msgs::msg::DiagnosticStatus::ERROR,
-        "registration_not_converged",
-        selected_attempt.has_converged,
-        selected_attempt.fitness_score,
-        selected_attempt.alignment_time_sec,
-        filtered_point_count,
-        selected_attempt.correction_translation_m,
-        selected_attempt.correction_yaw_deg,
-        selected_attempt.seed_translation_since_accept_m,
-        selected_attempt.seed_yaw_since_accept_deg,
-        selected_attempt.accepted_gap_sec,
-        imu_prediction_ready);
-      RCLCPP_WARN(get_logger(), "The registration didn't converge.");
-      advancePredictionWithoutMeasurement(scan_stamp_sec);
-      return;
-    }
+  pcl::PointCloud<pcl::PointXYZI>::Ptr local_map =
+    lidar_localization::cropLocalMapByRadius(
+      *full_map_cloud_ptr_,
+      crop_request.center_x,
+      crop_request.center_y,
+      crop_request.radius_m);
+  const auto crop_size_validation =
+    lidar_localization::validateLocalMapCropSize(
+      local_map->size(), crop_request.min_points);
+  if (!crop_size_validation.target_ready) {
+    handle_crop_failure(crop_size_validation.failure);
+    RCLCPP_WARN(
+      get_logger(),
+      "Local map crop too small (%zu points, min %zu) around (%.3f, %.3f) with radius %.1fm.",
+      local_map->size(),
+      local_map_min_points_,
+      static_cast<double>(cx),
+      static_cast<double>(cy),
+      local_map_radius_);
+    return false;
+  }
+
+  pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_local_map(
+    new pcl::PointCloud<pcl::PointXYZI>());
+  voxel_grid_filter_.setInputCloud(local_map);
+  voxel_grid_filter_.filter(*filtered_local_map);
+  const auto target_selection = lidar_localization::chooseTargetAfterLocalMapCrop(
+    local_map->size(),
+    filtered_local_map->size(),
+    crop_request.min_points);
+  if (target_selection.target_cloud ==
+    lidar_localization::LocalMapTargetCloud::kFilteredLocalMap)
+  {
+    registration_->setInputTarget(filtered_local_map);
+    keep_cloud_alive(
+      &recent_target_clouds_, filtered_local_map, kRegistrationTargetCloudKeepAliveCount);
   } else {
-    gate_result = evaluate_measurement_gate(selected_attempt);
-    if (gate_result.reject_measurement) {
-      (void)try_recovery_retry_from_last_pose();
-    }
+    registration_->setInputTarget(local_map);
+    keep_cloud_alive(
+      &recent_target_clouds_, local_map, kRegistrationTargetCloudKeepAliveCount);
   }
 
-  bool has_converged = selected_attempt.has_converged;
-  double fitness_score = selected_attempt.fitness_score;
-  double correction_translation_m = selected_attempt.correction_translation_m;
-  double correction_yaw_deg = selected_attempt.correction_yaw_deg;
-  double seed_translation_since_accept_m = selected_attempt.seed_translation_since_accept_m;
-  double seed_yaw_since_accept_deg = selected_attempt.seed_yaw_since_accept_deg;
-  double accepted_gap_sec = selected_attempt.accepted_gap_sec;
-  uint8_t status_level = gate_result.status_level;
-  std::string status_message = gate_result.status_message;
-  bool reject_measurement = gate_result.reject_measurement;
-  bool rejected_seed_update_applied = gate_result.rejected_seed_update_applied;
-  Eigen::Matrix4f final_transformation = selected_attempt.final_transformation;
+  const auto success_decision = lidar_localization::handleLocalMapTargetSuccess();
+  consecutive_crop_failures_ = success_decision.consecutive_crop_failures;
+  crop_failure_guard_active_ = success_decision.crop_failure_guard_active;
+  return true;
+}
 
-  if (!has_converged) {
-    publishAlignmentStatus(
-      msg->header.stamp,
-      diagnostic_msgs::msg::DiagnosticStatus::ERROR,
-      "registration_not_converged",
-      has_converged,
-      fitness_score,
-      selected_attempt.alignment_time_sec,
-      filtered_point_count,
-      correction_translation_m,
-      correction_yaw_deg,
-      seed_translation_since_accept_m,
-      seed_yaw_since_accept_deg,
-      accepted_gap_sec,
-      imu_prediction_ready);
-    RCLCPP_WARN(get_logger(), "The registration didn't converge.");
-    advancePredictionWithoutMeasurement(scan_stamp_sec);
+lidar_localization::AlignmentAttempt PCLLocalization::runAlignmentAttempt(
+  const Eigen::Matrix4f & attempt_init_guess,
+  const Eigen::Matrix4f & crop_center_pose_matrix,
+  double scan_stamp_sec)
+{
+  lidar_localization::AlignmentAttempt attempt;
+  attempt.init_guess = attempt_init_guess;
+  if (!setInputTargetForPose(crop_center_pose_matrix)) {
+    return attempt;
+  }
+  attempt.target_ready = true;
+
+  pcl::PointCloud<pcl::PointXYZI> output_cloud;
+  rclcpp::Clock system_clock;
+  const rclcpp::Time time_align_start = system_clock.now();
+  registration_->align(output_cloud, attempt_init_guess);
+  const rclcpp::Time time_align_end = system_clock.now();
+  attempt.alignment_time_sec = time_align_end.seconds() - time_align_start.seconds();
+  attempt.has_converged = registration_->hasConverged();
+  attempt.fitness_score = registration_->getFitnessScore();
+
+  const auto seed_metrics = lidar_localization::computeAlignmentSeedMetrics(
+    have_last_accepted_pose_,
+    last_accepted_pose_matrix_,
+    attempt_init_guess,
+    scan_stamp_sec,
+    last_accepted_pose_time_sec_);
+  attempt.seed_translation_since_accept_m = seed_metrics.translation_since_accept_m;
+  attempt.seed_yaw_since_accept_deg = seed_metrics.yaw_since_accept_deg;
+  attempt.accepted_gap_sec = seed_metrics.accepted_gap_sec;
+
+  if (attempt.has_converged) {
+    attempt.final_transformation = registration_->getFinalTransformation();
+    const auto correction_metrics =
+      lidar_localization::computeAlignmentCorrectionMetrics(
+      attempt_init_guess,
+      attempt.final_transformation);
+    attempt.correction_translation_m = correction_metrics.translation_m;
+    attempt.correction_yaw_deg = correction_metrics.yaw_deg;
+  }
+
+  return attempt;
+}
+
+lidar_localization::AlignmentPipelineResult PCLLocalization::runAlignmentPipelineForScan(
+  const Eigen::Matrix4f & init_guess,
+  double scan_stamp_sec)
+{
+  const lidar_localization::AlignmentAttempt primary_attempt =
+    runAlignmentAttempt(init_guess, init_guess, scan_stamp_sec);
+  return lidar_localization::runAlignmentPipeline(
+    primary_attempt,
+    lidar_localization::AlignmentPipelineInput{
+      have_last_accepted_pose_,
+      consecutive_rejected_updates_,
+      scan_stamp_sec,
+      last_accepted_pose_time_sec_,
+      recoveryRetryFromLastPoseParams()},
+    [&]() {
+      return runAlignmentAttempt(
+        last_accepted_pose_matrix_, last_accepted_pose_matrix_, scan_stamp_sec);
+    },
+    [this](const lidar_localization::AlignmentAttempt & attempt) {
+      return evaluateMeasurementGateForAttempt(attempt);
+    });
+}
+
+lidar_localization::MeasurementGateDecision PCLLocalization::evaluateMeasurementGateForAttempt(
+  const lidar_localization::AlignmentAttempt & attempt)
+{
+  const auto gate_input = lidar_localization::makeMeasurementGateInput(
+    attempt.fitness_score,
+    attempt.accepted_gap_sec,
+    attempt.seed_translation_since_accept_m,
+    attempt.correction_translation_m,
+    attempt.correction_yaw_deg,
+    consecutive_rejected_updates_);
+  auto gate =
+    lidar_localization::evaluateMeasurementGate(measurementGateParams(), gate_input);
+  if (gate.status_level == lidar_localization::kMeasurementGateWarn) {
+    RCLCPP_WARN(
+      get_logger(), "The fitness score is over %lf.", gate.effective_score_threshold);
+  }
+
+  return gate;
+}
+
+void PCLLocalization::logAlignmentPipelineRecovery(
+  const lidar_localization::AlignmentPipelineResult & pipeline_result)
+{
+  const auto handling = lidar_localization::decideAlignmentPipelineHandling(pipeline_result);
+  if (!handling.log_recovery_retry_success) {
     return;
   }
-  if (recovered_by_retry_from_last_pose && status_level == diagnostic_msgs::msg::DiagnosticStatus::OK) {
-    status_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+
+  RCLCPP_INFO(
+    get_logger(),
+    "Recovery retry from last pose succeeded after %zu rejects: fitness=%.6f",
+    consecutive_rejected_updates_,
+    pipeline_result.selected_attempt.fitness_score);
+}
+
+bool PCLLocalization::handleTerminalAlignmentPipelineResult(
+  const builtin_interfaces::msg::Time & stamp,
+  const lidar_localization::AlignmentPipelineResult & pipeline_result,
+  std::size_t filtered_point_count,
+  double scan_stamp_sec,
+  bool imu_prediction_ready)
+{
+  const auto handling = lidar_localization::decideAlignmentPipelineHandling(pipeline_result);
+  if (!handling.publish_terminal_status) {
+    return false;
   }
 
-  if (use_gtsam_smoother_) {
-    // Extract roll, pitch, yaw from NDT rotation matrix
-    Eigen::Matrix3f ndt_rot = final_transformation.block<3, 3>(0, 0);
-    last_ndt_pitch_ = std::asin(-ndt_rot(2, 0));
-    last_ndt_roll_ = std::atan2(ndt_rot(2, 1), ndt_rot(2, 2));
-    double ndt_yaw = static_cast<double>(std::atan2(ndt_rot(1, 0), ndt_rot(0, 0)));
-    double ndt_px = static_cast<double>(final_transformation(0, 3));
-    double ndt_py = static_cast<double>(final_transformation(1, 3));
-    double ndt_pz = static_cast<double>(final_transformation(2, 3));
-
-    if (!gtsam_smoother_.isInitialized()) {
-      gtsam_smoother_.initialize(ndt_px, ndt_py, ndt_pz, ndt_yaw, scan_stamp_sec);
-    }
-
-    bool gtsam_updated = gtsam_smoother_.update(
-      ndt_px, ndt_py, ndt_pz, ndt_yaw, fitness_score, scan_stamp_sec);
-
-    // Use smoothed state for published pose
-    Eigen::Matrix4f gtsam_pose = gtsam_smoother_.poseMatrix(last_ndt_roll_, last_ndt_pitch_);
-    Eigen::Matrix3d gtsam_rot_mat = gtsam_pose.block<3, 3>(0, 0).cast<double>();
-    Eigen::Quaterniond quat_eig(gtsam_rot_mat);
-    geometry_msgs::msg::Quaternion quat_msg = tf2::toMsg(quat_eig);
-
-    corrent_pose_with_cov_stamped_ptr_->header.stamp = msg->header.stamp;
-    corrent_pose_with_cov_stamped_ptr_->header.frame_id = global_frame_id_;
-    corrent_pose_with_cov_stamped_ptr_->pose.pose.position.x = gtsam_smoother_.px();
-    corrent_pose_with_cov_stamped_ptr_->pose.pose.position.y = gtsam_smoother_.py();
-    corrent_pose_with_cov_stamped_ptr_->pose.pose.position.z = gtsam_smoother_.pz();
-    corrent_pose_with_cov_stamped_ptr_->pose.pose.orientation = quat_msg;
-
-    fillPoseCovariance(fitness_score);
-    updatePredictionState(gtsam_pose, scan_stamp_sec);
-
-    if (!gtsam_updated) {
-      status_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-      status_message = "gtsam_update_rejected";
-    }
-    publishAlignmentStatus(
-      msg->header.stamp, status_level, status_message,
-      has_converged, fitness_score, selected_attempt.alignment_time_sec,
-      filtered_point_count,
-      correction_translation_m,
-      correction_yaw_deg,
-      seed_translation_since_accept_m,
-      seed_yaw_since_accept_deg,
-      accepted_gap_sec,
-      imu_prediction_ready);
-  } else if (use_imu_preintegration_ && last_imu_stamp_ > 0.0) {
-    // Extract full 6DOF from registration result
-    Eigen::Matrix3f ndt_rot = final_transformation.block<3, 3>(0, 0);
-    double ndt_roll = static_cast<double>(std::atan2(ndt_rot(2, 1), ndt_rot(2, 2)));
-    double ndt_pitch = static_cast<double>(std::asin(-std::clamp(ndt_rot(2, 0), -1.0f, 1.0f)));
-    double ndt_yaw = static_cast<double>(std::atan2(ndt_rot(1, 0), ndt_rot(0, 0)));
-    double ndt_px = static_cast<double>(final_transformation(0, 3));
-    double ndt_py = static_cast<double>(final_transformation(1, 3));
-    double ndt_pz = static_cast<double>(final_transformation(2, 3));
-
-    if (!imu_smoother_.isInitialized()) {
-      imu_smoother_.initialize(
-        ndt_px, ndt_py, ndt_pz, ndt_roll, ndt_pitch, ndt_yaw,
-        0.0, 0.0, 0.0, scan_stamp_sec);
-    }
-
-    bool imu_updated = true;
-    bool imu_state_reset = false;
-    bool imu_correction_guard_tripped = false;
-    Eigen::Matrix4f imu_pose = final_transformation;
-    if (
-      !imu_preintegration_fallback_mode_ &&
-      imu_prediction_ready &&
-      (
-        (std::isfinite(correction_translation_m) &&
-        correction_translation_m > imu_prediction_correction_guard_translation_m_) ||
-        (std::isfinite(correction_yaw_deg) &&
-        correction_yaw_deg > imu_prediction_correction_guard_yaw_deg_)))
-    {
-      RCLCPP_WARN(
-        get_logger(),
-        "IMU prediction required a large measurement correction (translation=%.3f m, yaw=%.3f deg). Disabling IMU preintegration for the remainder of this run.",
-        correction_translation_m,
-        correction_yaw_deg);
-      imu_preintegration_fallback_mode_ = true;
-      imu_state_reset = true;
-      imu_correction_guard_tripped = true;
-    }
-
-    if (!imu_preintegration_fallback_mode_) {
-      imu_updated = imu_smoother_.update(
-        ndt_px, ndt_py, ndt_pz, ndt_roll, ndt_pitch, ndt_yaw,
-        fitness_score, scan_stamp_sec);
-
-      imu_pose = imu_smoother_.poseMatrix();
-      double imu_measurement_translation_delta_m = std::numeric_limits<double>::quiet_NaN();
-      double imu_measurement_rotation_delta_deg = std::numeric_limits<double>::quiet_NaN();
-      if (imu_pose.allFinite()) {
-        imu_measurement_translation_delta_m = static_cast<double>(
-          (imu_pose.block<3, 1>(0, 3) - final_transformation.block<3, 1>(0, 3)).norm());
-        imu_measurement_rotation_delta_deg = rotation_delta_deg(
-          final_transformation.block<3, 3>(0, 0),
-          imu_pose.block<3, 3>(0, 0));
-      }
-
-      const bool imu_pose_diverged =
-        !imu_pose.allFinite() ||
-        !std::isfinite(imu_measurement_translation_delta_m) ||
-        !std::isfinite(imu_measurement_rotation_delta_deg) ||
-        imu_measurement_translation_delta_m > kImuSmootherMeasurementTranslationGuardM ||
-        imu_measurement_rotation_delta_deg > kImuSmootherMeasurementRotationGuardDeg;
-      if (imu_pose_diverged) {
-        RCLCPP_WARN(
-          get_logger(),
-          "IMU smoother diverged from measurement (translation=%.3f m, rotation=%.3f deg). Disabling IMU preintegration for the remainder of this run.",
-          imu_measurement_translation_delta_m,
-          imu_measurement_rotation_delta_deg);
-        imu_preintegration_fallback_mode_ = true;
-        imu_state_reset = true;
-      }
-    }
-
-    if (imu_preintegration_fallback_mode_) {
-      imu_pose = final_transformation;
-      imu_updated = true;
-    }
-
-    Eigen::Matrix3d imu_rot_mat = imu_pose.block<3, 3>(0, 0).cast<double>();
-    Eigen::Quaterniond quat_eig(imu_rot_mat);
-    geometry_msgs::msg::Quaternion quat_msg = tf2::toMsg(quat_eig);
-
-    corrent_pose_with_cov_stamped_ptr_->header.stamp = msg->header.stamp;
-    corrent_pose_with_cov_stamped_ptr_->header.frame_id = global_frame_id_;
-    corrent_pose_with_cov_stamped_ptr_->pose.pose.position.x = imu_pose(0, 3);
-    corrent_pose_with_cov_stamped_ptr_->pose.pose.position.y = imu_pose(1, 3);
-    corrent_pose_with_cov_stamped_ptr_->pose.pose.position.z = imu_pose(2, 3);
-    corrent_pose_with_cov_stamped_ptr_->pose.pose.orientation = quat_msg;
-
-    fillPoseCovariance(fitness_score);
-    updatePredictionState(imu_pose, scan_stamp_sec);
-    last_scan_stamp_for_imu_ = scan_stamp_sec;
-
-    if (imu_state_reset) {
-      status_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-      status_message = imu_correction_guard_tripped ?
-        "imu_prediction_correction_guard_imu_disabled" :
-        "imu_smoother_diverged_imu_disabled";
-    } else if (!imu_updated) {
-      status_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-      status_message = "imu_smoother_update_rejected";
-    }
-    publishAlignmentStatus(
-      msg->header.stamp, status_level, status_message,
-      has_converged, fitness_score, selected_attempt.alignment_time_sec,
-      filtered_point_count,
-      correction_translation_m,
-      correction_yaw_deg,
-      seed_translation_since_accept_m,
-      seed_yaw_since_accept_deg,
-      accepted_gap_sec,
-      imu_prediction_ready);
-  } else if (use_twist_ekf_) {
-    // Extract roll, pitch, yaw from NDT rotation matrix using atan2
-    // (eulerAngles() has gimbal-lock ambiguity)
-    Eigen::Matrix3f ndt_rot = final_transformation.block<3, 3>(0, 0);
-    last_ndt_pitch_ = std::asin(-ndt_rot(2, 0));
-    last_ndt_roll_ = std::atan2(ndt_rot(2, 1), ndt_rot(2, 2));
-    double ndt_yaw = static_cast<double>(
-      std::atan2(ndt_rot(1, 0), ndt_rot(0, 0)));
-    double ndt_px = static_cast<double>(final_transformation(0, 3));
-    double ndt_py = static_cast<double>(final_transformation(1, 3));
-    double ndt_pz = static_cast<double>(final_transformation(2, 3));
-
-    if (!twist_ekf_.isInitialized()) {
-      twist_ekf_.initialize(ndt_px, ndt_py, ndt_pz, ndt_yaw, scan_stamp_sec);
-    }
-
-    // EKF update with NDT measurement (not gated by score_threshold)
-    // The EKF adaptively scales measurement noise by fitness
-    bool ekf_updated = twist_ekf_.update(ndt_px, ndt_py, ndt_pz, ndt_yaw, fitness_score);
-
-    // Use EKF state for published pose
-    Eigen::Matrix4f ekf_pose = twist_ekf_.poseMatrix(last_ndt_roll_, last_ndt_pitch_);
-    Eigen::Matrix3d ekf_rot_mat = ekf_pose.block<3, 3>(0, 0).cast<double>();
-    Eigen::Quaterniond quat_eig(ekf_rot_mat);
-    geometry_msgs::msg::Quaternion quat_msg = tf2::toMsg(quat_eig);
-
-    corrent_pose_with_cov_stamped_ptr_->header.stamp = msg->header.stamp;
-    corrent_pose_with_cov_stamped_ptr_->header.frame_id = global_frame_id_;
-    corrent_pose_with_cov_stamped_ptr_->pose.pose.position.x = twist_ekf_.px();
-    corrent_pose_with_cov_stamped_ptr_->pose.pose.position.y = twist_ekf_.py();
-    corrent_pose_with_cov_stamped_ptr_->pose.pose.position.z = twist_ekf_.pz();
-    corrent_pose_with_cov_stamped_ptr_->pose.pose.orientation = quat_msg;
-
-    // Also update prediction state for compatibility
-    fillPoseCovariance(fitness_score);
-    updatePredictionState(ekf_pose, scan_stamp_sec);
-
-    // Publish diagnostics with EKF info
-    if (!ekf_updated) {
-      status_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-      status_message = "ekf_update_rejected";
-    }
-    publishAlignmentStatus(
-      msg->header.stamp, status_level, status_message,
-      has_converged, fitness_score, selected_attempt.alignment_time_sec,
-      filtered_point_count,
-      correction_translation_m,
-      correction_yaw_deg,
-      seed_translation_since_accept_m,
-      seed_yaw_since_accept_deg,
-      accepted_gap_sec,
-      imu_prediction_ready);
-  } else {
-    // Original flow
-    publishAlignmentStatus(
-      msg->header.stamp, status_level, status_message,
-      has_converged, fitness_score, selected_attempt.alignment_time_sec,
-      filtered_point_count,
-      correction_translation_m,
-      correction_yaw_deg,
-      seed_translation_since_accept_m,
-      seed_yaw_since_accept_deg,
-      accepted_gap_sec,
-      imu_prediction_ready);
-
-    if (reject_measurement) {
-      if (rejected_seed_update_applied) {
-        updatePredictionFromRejectedMeasurement(final_transformation, scan_stamp_sec);
-      } else {
-        advancePredictionWithoutMeasurement(scan_stamp_sec);
-      }
-      return;
-    }
-
-    setCurrentPoseFromMatrix(final_transformation, msg->header.stamp);
-    fillPoseCovariance(fitness_score);
-    updatePredictionState(final_transformation, scan_stamp_sec);
+  publishAlignmentStatusForAttempt(
+    stamp,
+    pipeline_result.status_level,
+    pipeline_result.status_message,
+    pipeline_result.selected_attempt,
+    filtered_point_count,
+    imu_prediction_ready);
+  if (handling.warn_registration_not_converged) {
+    RCLCPP_WARN(get_logger(), "The registration didn't converge.");
   }
-    
-  // publish here if timer is not enabled
+  if (handling.advance_prediction_without_measurement) {
+    advancePredictionWithoutMeasurement(scan_stamp_sec);
+  }
+  return true;
+}
 
-  if (!enable_timer_publishing_){
-    publishCurrentPose(msg->header.stamp);
+bool PCLLocalization::applyAcceptedAlignmentPipelineResult(
+  const builtin_interfaces::msg::Time & stamp,
+  const lidar_localization::AlignmentPipelineResult & pipeline_result,
+  std::size_t filtered_point_count,
+  double scan_stamp_sec,
+  bool imu_prediction_ready)
+{
+  const auto handling = lidar_localization::decideAlignmentPipelineHandling(pipeline_result);
+  if (!handling.continue_to_backend) {
+    return false;
   }
 
-  if (enable_debug_) {
-    std::cout << "number of filtered cloud points: " << filtered_point_count << std::endl;
-    std::cout << "align time:" << selected_attempt.alignment_time_sec <<
-      "[sec]" << std::endl;
-    std::cout << "has converged: " << has_converged << std::endl;
-    std::cout << "fitness score: " << fitness_score << std::endl;
-    std::cout << "final transformation:" << std::endl;
-    std::cout << final_transformation << std::endl;
-    /* delta_angle check
-     * trace(RotationMatrix) = 2(cos(theta) + 1)
-     */
-    double init_cos_angle = 0.5 *
-      (init_guess.coeff(0, 0) + init_guess.coeff(1, 1) + init_guess.coeff(2, 2) - 1);
-    double cos_angle = 0.5 *
-      (final_transformation.coeff(0,
-      0) + final_transformation.coeff(1, 1) + final_transformation.coeff(2, 2) - 1);
-    double init_angle = acos(init_cos_angle);
-    double angle = acos(cos_angle);
-    // Ref:https://twitter.com/Atsushi_twi/status/1185868416864808960
-    double delta_angle = abs(atan2(sin(init_angle - angle), cos(init_angle - angle)));
-    std::cout << "delta_angle:" << delta_angle * 180 / M_PI << "[deg]" << std::endl;
-    std::cout << "-----------------------------------------------------" << std::endl;
+  const auto registration_observation =
+    lidar_localization::makeRegistrationObservation(
+    pipeline_result.selected_attempt.final_transformation);
+  if (!applyRegistrationPoseBackend(
+      registration_observation,
+      pipeline_result.selected_attempt,
+      pipeline_result.gate_result,
+      stamp,
+      filtered_point_count,
+      scan_stamp_sec,
+      imu_prediction_ready))
+  {
+    return false;
   }
 
+  if (!enable_timer_publishing_) {
+    publishCurrentPose(stamp);
+  }
+  return true;
+}
+
+void PCLLocalization::setRegistrationSourceCloud(
+  const pcl::PointCloud<pcl::PointXYZI>::Ptr & source_cloud)
+{
+  registration_->setInputSource(source_cloud);
+  keep_cloud_alive(&recent_source_clouds_, source_cloud, kRegistrationSourceCloudKeepAliveCount);
+}
+
+void PCLLocalization::printAlignmentDebugInfo(
+  const Eigen::Matrix4f & init_guess,
+  const lidar_localization::AlignmentAttempt & selected_attempt,
+  std::size_t filtered_point_count) const
+{
+  if (!enable_debug_) {
+    return;
+  }
+
+  std::cout << "number of filtered cloud points: " << filtered_point_count << std::endl;
+  std::cout << "align time:" << selected_attempt.alignment_time_sec <<
+    "[sec]" << std::endl;
+  std::cout << "has converged: " << selected_attempt.has_converged << std::endl;
+  std::cout << "fitness score: " << selected_attempt.fitness_score << std::endl;
+  std::cout << "final transformation:" << std::endl;
+  std::cout << selected_attempt.final_transformation << std::endl;
+  /* delta_angle check
+   * trace(RotationMatrix) = 2(cos(theta) + 1)
+   */
+  double init_cos_angle = 0.5 *
+    (init_guess.coeff(0, 0) + init_guess.coeff(1, 1) + init_guess.coeff(2, 2) - 1);
+  double cos_angle = 0.5 *
+    (selected_attempt.final_transformation.coeff(0,
+    0) + selected_attempt.final_transformation.coeff(1, 1) +
+    selected_attempt.final_transformation.coeff(2, 2) - 1);
+  double init_angle = acos(init_cos_angle);
+  double angle = acos(cos_angle);
+  // Ref:https://twitter.com/Atsushi_twi/status/1185868416864808960
+  double delta_angle = abs(atan2(sin(init_angle - angle), cos(init_angle - angle)));
+  std::cout << "delta_angle:" << delta_angle * 180 / M_PI << "[deg]" << std::endl;
+  std::cout << "-----------------------------------------------------" << std::endl;
 }
 
 Eigen::Matrix4f PCLLocalization::currentPoseMatrix() const
@@ -2253,287 +2033,536 @@ Eigen::Matrix4f PCLLocalization::applyTwistPrediction(
 
 void PCLLocalization::resetPredictionState(const Eigen::Matrix4f & pose_matrix, double stamp_sec)
 {
-  have_last_accepted_pose_ = true;
-  last_accepted_pose_matrix_ = pose_matrix;
-  predicted_pose_matrix_ = pose_matrix;
-  last_relative_motion_matrix_ = Eigen::Matrix4f::Identity();
-  consecutive_rejected_updates_ = 0;
-  last_accepted_pose_time_sec_ = stamp_sec;
-  predicted_pose_time_sec_ = stamp_sec;
+  const auto state = lidar_localization::resetPredictionState(pose_matrix, stamp_sec);
+  have_last_accepted_pose_ = state.have_last_accepted_pose;
+  last_accepted_pose_matrix_ = state.last_accepted_pose_matrix;
+  predicted_pose_matrix_ = state.predicted_pose_matrix;
+  last_relative_motion_matrix_ = state.last_relative_motion_matrix;
+  consecutive_rejected_updates_ = state.consecutive_rejected_updates;
+  last_accepted_pose_time_sec_ = state.last_accepted_pose_time_sec;
+  predicted_pose_time_sec_ = state.predicted_pose_time_sec;
 }
 
 void PCLLocalization::updatePredictionState(
   const Eigen::Matrix4f & accepted_pose_matrix,
   double stamp_sec)
 {
-  if (!have_last_accepted_pose_) {
-    resetPredictionState(accepted_pose_matrix, stamp_sec);
-    return;
-  }
-
-  if (consecutive_rejected_updates_ == 0) {
-    last_relative_motion_matrix_ = last_accepted_pose_matrix_.inverse() * accepted_pose_matrix;
-  }
-
-  last_accepted_pose_matrix_ = accepted_pose_matrix;
-  predicted_pose_matrix_ = accepted_pose_matrix * last_relative_motion_matrix_;
-  have_last_accepted_pose_ = true;
-  consecutive_rejected_updates_ = 0;
-  last_accepted_pose_time_sec_ = stamp_sec;
-  predicted_pose_time_sec_ = stamp_sec;
+  const auto state = lidar_localization::updatePredictionStateFromAcceptedMeasurement(
+    make_prediction_state_snapshot(
+      have_last_accepted_pose_,
+      last_accepted_pose_matrix_,
+      predicted_pose_matrix_,
+      last_relative_motion_matrix_,
+      consecutive_rejected_updates_,
+      last_accepted_pose_time_sec_,
+      predicted_pose_time_sec_),
+    accepted_pose_matrix,
+    stamp_sec);
+  have_last_accepted_pose_ = state.have_last_accepted_pose;
+  last_accepted_pose_matrix_ = state.last_accepted_pose_matrix;
+  predicted_pose_matrix_ = state.predicted_pose_matrix;
+  last_relative_motion_matrix_ = state.last_relative_motion_matrix;
+  consecutive_rejected_updates_ = state.consecutive_rejected_updates;
+  last_accepted_pose_time_sec_ = state.last_accepted_pose_time_sec;
+  predicted_pose_time_sec_ = state.predicted_pose_time_sec;
 }
 
 void PCLLocalization::advancePredictionWithoutMeasurement(double stamp_sec)
 {
-  if (!have_last_accepted_pose_) {
-    return;
-  }
-
-  if (use_twist_prediction_ && latest_twist_msg_) {
+  const auto advance_mode = lidar_localization::choosePredictionAdvanceMode(
+    have_last_accepted_pose_,
+    use_twist_prediction_,
+    static_cast<bool>(latest_twist_msg_),
+    predict_pose_from_previous_delta_);
+  Eigen::Matrix4f twist_predicted_pose_matrix = Eigen::Matrix4f::Identity();
+  if (advance_mode == lidar_localization::PredictionAdvanceMode::kTwistPrediction) {
     const double dt = std::clamp(stamp_sec - predicted_pose_time_sec_, 0.0, max_twist_prediction_dt_);
-    predicted_pose_matrix_ = applyTwistPrediction(predicted_pose_matrix_, dt);
-    predicted_pose_time_sec_ = stamp_sec;
-  } else if (predict_pose_from_previous_delta_) {
-    predicted_pose_matrix_ = predicted_pose_matrix_ * last_relative_motion_matrix_;
-    predicted_pose_time_sec_ = stamp_sec;
-  } else {
-    return;
+    twist_predicted_pose_matrix = applyTwistPrediction(predicted_pose_matrix_, dt);
   }
-  ++consecutive_rejected_updates_;
+  const auto state = lidar_localization::advancePredictionWithoutMeasurement(
+    make_prediction_state_snapshot(
+      have_last_accepted_pose_,
+      last_accepted_pose_matrix_,
+      predicted_pose_matrix_,
+      last_relative_motion_matrix_,
+      consecutive_rejected_updates_,
+      last_accepted_pose_time_sec_,
+      predicted_pose_time_sec_),
+    stamp_sec,
+    advance_mode,
+    twist_predicted_pose_matrix);
+  have_last_accepted_pose_ = state.have_last_accepted_pose;
+  last_accepted_pose_matrix_ = state.last_accepted_pose_matrix;
+  predicted_pose_matrix_ = state.predicted_pose_matrix;
+  last_relative_motion_matrix_ = state.last_relative_motion_matrix;
+  consecutive_rejected_updates_ = state.consecutive_rejected_updates;
+  last_accepted_pose_time_sec_ = state.last_accepted_pose_time_sec;
+  predicted_pose_time_sec_ = state.predicted_pose_time_sec;
 }
 
 void PCLLocalization::updatePredictionFromRejectedMeasurement(
   const Eigen::Matrix4f & rejected_pose_matrix,
   double stamp_sec)
 {
-  if (!have_last_accepted_pose_) {
+  const auto state = lidar_localization::updatePredictionFromRejectedMeasurement(
+    make_prediction_state_snapshot(
+      have_last_accepted_pose_,
+      last_accepted_pose_matrix_,
+      predicted_pose_matrix_,
+      last_relative_motion_matrix_,
+      consecutive_rejected_updates_,
+      last_accepted_pose_time_sec_,
+      predicted_pose_time_sec_),
+    rejected_pose_matrix,
+    stamp_sec);
+  have_last_accepted_pose_ = state.have_last_accepted_pose;
+  last_accepted_pose_matrix_ = state.last_accepted_pose_matrix;
+  predicted_pose_matrix_ = state.predicted_pose_matrix;
+  last_relative_motion_matrix_ = state.last_relative_motion_matrix;
+  consecutive_rejected_updates_ = state.consecutive_rejected_updates;
+  last_accepted_pose_time_sec_ = state.last_accepted_pose_time_sec;
+  predicted_pose_time_sec_ = state.predicted_pose_time_sec;
+}
+
+bool PCLLocalization::applyRegistrationPoseBackend(
+  const lidar_localization::RegistrationObservation & observation,
+  const lidar_localization::AlignmentAttempt & attempt,
+  const lidar_localization::MeasurementGateDecision & gate_result,
+  const builtin_interfaces::msg::Time & stamp,
+  std::size_t filtered_point_count,
+  double stamp_sec,
+  bool imu_prediction_ready)
+{
+  const PoseBackendApplyContext context{
+    observation,
+    attempt,
+    gate_result,
+    stamp,
+    filtered_point_count,
+    stamp_sec,
+    imu_prediction_ready};
+  return dispatchRegistrationPoseBackend(selectRegistrationPoseBackend(), context);
+}
+
+lidar_localization::PoseBackendKind PCLLocalization::selectRegistrationPoseBackend() const
+{
+  return lidar_localization::selectPoseBackend(
+    lidar_localization::PoseBackendSelectionInput{
+      use_gtsam_smoother_,
+      use_imu_preintegration_,
+      last_imu_stamp_ > 0.0,
+      use_twist_ekf_});
+}
+
+bool PCLLocalization::dispatchRegistrationPoseBackend(
+  lidar_localization::PoseBackendKind backend,
+  const PoseBackendApplyContext & context)
+{
+  switch (backend) {
+    case lidar_localization::PoseBackendKind::kGtsamSmoother:
+      return applyGtsamPoseBackend(context);
+
+    case lidar_localization::PoseBackendKind::kImuPreintegration:
+      return applyImuPreintegrationPoseBackend(context);
+
+    case lidar_localization::PoseBackendKind::kTwistEkf:
+      return applyTwistEkfPoseBackend(context);
+
+    case lidar_localization::PoseBackendKind::kRawRegistration:
+      return applyRawRegistrationPoseBackend(context);
+  }
+
+  return applyRawRegistrationPoseBackend(context);
+}
+
+bool PCLLocalization::applyGtsamPoseBackend(const PoseBackendApplyContext & context)
+{
+  updateBackendRollPitch(context.observation);
+  return applyPlanarSmootherPoseBackendUpdate(
+    updateGtsamPoseBackend(context.observation, context.attempt, context.stamp_sec),
+    context);
+}
+
+void PCLLocalization::updateBackendRollPitch(
+  const lidar_localization::RegistrationObservation & observation)
+{
+  last_ndt_roll_ = static_cast<float>(observation.roll);
+  last_ndt_pitch_ = static_cast<float>(observation.pitch);
+}
+
+PCLLocalization::PlanarSmootherBackendUpdate
+PCLLocalization::updateGtsamPoseBackend(
+  const lidar_localization::RegistrationObservation & observation,
+  const lidar_localization::AlignmentAttempt & attempt,
+  double stamp_sec)
+{
+  if (!gtsam_smoother_.isInitialized()) {
+    gtsam_smoother_.initialize(
+      observation.x, observation.y, observation.z, observation.yaw, stamp_sec);
+  }
+
+  PlanarSmootherBackendUpdate update;
+  update.updated = gtsam_smoother_.update(
+    observation.x, observation.y, observation.z, observation.yaw,
+    attempt.fitness_score, stamp_sec);
+  update.pose = gtsam_smoother_.poseMatrix(last_ndt_roll_, last_ndt_pitch_);
+  update.rejected_status_message = "gtsam_update_rejected";
+  return update;
+}
+
+PCLLocalization::PlanarSmootherBackendUpdate
+PCLLocalization::updateTwistEkfPoseBackend(
+  const lidar_localization::RegistrationObservation & observation,
+  const lidar_localization::AlignmentAttempt & attempt,
+  double stamp_sec)
+{
+  if (!twist_ekf_.isInitialized()) {
+    twist_ekf_.initialize(
+      observation.x, observation.y, observation.z, observation.yaw, stamp_sec);
+  }
+
+  PlanarSmootherBackendUpdate update;
+  update.updated = twist_ekf_.update(
+    observation.x, observation.y, observation.z, observation.yaw, attempt.fitness_score);
+  update.pose = twist_ekf_.poseMatrix(last_ndt_roll_, last_ndt_pitch_);
+  update.rejected_status_message = "ekf_update_rejected";
+  return update;
+}
+
+bool PCLLocalization::applyPlanarSmootherPoseBackendUpdate(
+  const PlanarSmootherBackendUpdate & update,
+  const PoseBackendApplyContext & context)
+{
+  const auto backend_result = lidar_localization::applyPoseBackendUpdateStatus(
+    lidar_localization::makePoseBackendResult(
+      update.pose, context.gate_result.status_level, context.gate_result.status_message),
+    update.updated,
+    diagnostic_msgs::msg::DiagnosticStatus::WARN,
+    update.rejected_status_message);
+  applyPoseBackendResult(
+    backend_result, context.stamp, context.stamp_sec, context.attempt.fitness_score);
+  publishAlignmentStatusForAttempt(
+    context.stamp,
+    backend_result.status_level,
+    backend_result.status_message,
+    context.attempt,
+    context.filtered_point_count,
+    context.imu_prediction_ready);
+  return true;
+}
+
+bool PCLLocalization::applyImuPreintegrationPoseBackend(
+  const PoseBackendApplyContext & context)
+{
+  const auto imu_update = updateImuPreintegrationBackend(
+    context.observation, context.attempt, context.stamp_sec, context.imu_prediction_ready);
+  logImuPreintegrationBackendWarnings(imu_update, context.attempt);
+
+  const auto backend_result = makeImuPreintegrationPoseBackendResult(
+    imu_update, context.gate_result.status_level, context.gate_result.status_message);
+  applyPoseBackendResult(
+    backend_result, context.stamp, context.stamp_sec, context.attempt.fitness_score);
+  publishAlignmentStatusForAttempt(
+    context.stamp,
+    backend_result.status_level,
+    backend_result.status_message,
+    context.attempt,
+    context.filtered_point_count,
+    context.imu_prediction_ready);
+  return true;
+}
+
+lidar_localization::ImuPreintegrationGuardParams
+PCLLocalization::imuPreintegrationGuardParams() const
+{
+  return {
+    imu_prediction_correction_guard_translation_m_,
+    imu_prediction_correction_guard_yaw_deg_,
+    lidar_localization::kDefaultImuSmootherMeasurementTranslationGuardM,
+    lidar_localization::kDefaultImuSmootherMeasurementRotationGuardDeg};
+}
+
+void PCLLocalization::initializeImuPreintegrationSmootherIfNeeded(
+  const lidar_localization::RegistrationObservation & observation,
+  double stamp_sec)
+{
+  if (imu_smoother_.isInitialized()) {
     return;
   }
 
-  predicted_pose_matrix_ = rejected_pose_matrix;
-  predicted_pose_time_sec_ = stamp_sec;
-  ++consecutive_rejected_updates_;
+  imu_smoother_.initialize(
+    observation.x, observation.y, observation.z,
+    observation.roll, observation.pitch, observation.yaw,
+    0.0, 0.0, 0.0, stamp_sec);
+}
+
+PCLLocalization::ImuPreintegrationBackendUpdate
+PCLLocalization::updateImuPreintegrationBackend(
+  const lidar_localization::RegistrationObservation & observation,
+  const lidar_localization::AlignmentAttempt & attempt,
+  double stamp_sec,
+  bool imu_prediction_ready)
+{
+  initializeImuPreintegrationSmootherIfNeeded(observation, stamp_sec);
+
+  ImuPreintegrationBackendUpdate update;
+  update.pose = observation.pose_matrix;
+
+  const auto guard_params = imuPreintegrationGuardParams();
+  update.state = lidar_localization::beginImuPreintegrationBackendState(
+    guard_params,
+    lidar_localization::ImuPredictionCorrectionGuardInput{
+      imu_preintegration_fallback_mode_,
+      imu_prediction_ready,
+      attempt.correction_translation_m,
+      attempt.correction_yaw_deg});
+
+  if (update.state.should_update_smoother) {
+    update.updated = imu_smoother_.update(
+      observation.x, observation.y, observation.z,
+      observation.roll, observation.pitch, observation.yaw,
+      attempt.fitness_score, stamp_sec);
+
+    update.pose = imu_smoother_.poseMatrix();
+    if (update.pose.allFinite()) {
+      update.smoother_measurement_translation_delta_m = static_cast<double>(
+        (update.pose.block<3, 1>(0, 3) -
+        observation.pose_matrix.block<3, 1>(0, 3)).norm());
+      update.smoother_measurement_rotation_delta_deg =
+        lidar_localization::rotationDeltaDeg(observation.pose_matrix, update.pose);
+    }
+
+    update.state = lidar_localization::applyImuSmootherDivergenceDecision(
+      update.state,
+      guard_params,
+      lidar_localization::ImuSmootherDivergenceInput{
+        update.pose.allFinite(),
+        update.smoother_measurement_translation_delta_m,
+        update.smoother_measurement_rotation_delta_deg});
+  }
+
+  imu_preintegration_fallback_mode_ = update.state.fallback_mode;
+  if (lidar_localization::shouldUseImuMeasurementPose(update.state)) {
+    update.pose = observation.pose_matrix;
+    update.updated = true;
+  }
+
+  last_scan_stamp_for_imu_ = stamp_sec;
+  return update;
+}
+
+void PCLLocalization::logImuPreintegrationBackendWarnings(
+  const ImuPreintegrationBackendUpdate & update,
+  const lidar_localization::AlignmentAttempt & attempt)
+{
+  if (update.state.correction_guard_tripped) {
+    RCLCPP_WARN(
+      get_logger(),
+      "IMU prediction required a large measurement correction (translation=%.3f m, yaw=%.3f deg). Disabling IMU preintegration for the remainder of this run.",
+      attempt.correction_translation_m,
+      attempt.correction_yaw_deg);
+  }
+
+  if (update.state.smoother_diverged) {
+    RCLCPP_WARN(
+      get_logger(),
+      "IMU smoother diverged from measurement (translation=%.3f m, rotation=%.3f deg). Disabling IMU preintegration for the remainder of this run.",
+      update.smoother_measurement_translation_delta_m,
+      update.smoother_measurement_rotation_delta_deg);
+  }
+}
+
+lidar_localization::PoseBackendResult
+PCLLocalization::makeImuPreintegrationPoseBackendResult(
+  const ImuPreintegrationBackendUpdate & update,
+  uint8_t status_level,
+  const std::string & status_message) const
+{
+  const auto imu_status = lidar_localization::decideImuPreintegrationStatus(
+    update.state, update.updated);
+  return lidar_localization::applyPoseBackendWarningStatus(
+    lidar_localization::makePoseBackendResult(
+      update.pose, status_level, status_message),
+    imu_status.warning,
+    diagnostic_msgs::msg::DiagnosticStatus::WARN,
+    imu_status.status_message);
+}
+
+bool PCLLocalization::applyTwistEkfPoseBackend(
+  const PoseBackendApplyContext & context)
+{
+  updateBackendRollPitch(context.observation);
+  return applyPlanarSmootherPoseBackendUpdate(
+    updateTwistEkfPoseBackend(context.observation, context.attempt, context.stamp_sec),
+    context);
+}
+
+bool PCLLocalization::applyRawRegistrationPoseBackend(
+  const PoseBackendApplyContext & context)
+{
+  const auto localization_update =
+    lidar_localization::decideLocalizationUpdate(context.gate_result);
+  const auto backend_result =
+    lidar_localization::makePoseBackendResultFromLocalizationUpdate(
+      context.attempt.final_transformation,
+      context.gate_result.status_level,
+      context.gate_result.status_message,
+      localization_update);
+  publishAlignmentStatusForAttempt(
+    context.stamp,
+    backend_result.status_level,
+    backend_result.status_message,
+    context.attempt,
+    context.filtered_point_count,
+    context.imu_prediction_ready);
+
+  return applyPoseBackendResult(
+    backend_result, context.stamp, context.stamp_sec, context.attempt.fitness_score);
+}
+
+bool PCLLocalization::applyPoseBackendResult(
+  const lidar_localization::PoseBackendResult & result,
+  const builtin_interfaces::msg::Time & stamp,
+  double stamp_sec,
+  double fitness_score)
+{
+  if (
+    result.advance_prediction_without_measurement ||
+    result.update_prediction_from_rejected_measurement)
+  {
+    return applyPoseBackendPredictionOnlyResult(result, stamp_sec);
+  }
+
+  applyAcceptedPoseBackendResult(result, stamp, stamp_sec, fitness_score);
+  return result.continue_to_pose_publish;
+}
+
+bool PCLLocalization::applyPoseBackendPredictionOnlyResult(
+  const lidar_localization::PoseBackendResult & result,
+  double stamp_sec)
+{
+  if (result.advance_prediction_without_measurement) {
+    advancePredictionWithoutMeasurement(stamp_sec);
+    return result.continue_to_pose_publish;
+  }
+  if (result.update_prediction_from_rejected_measurement) {
+    updatePredictionFromRejectedMeasurement(result.pose_matrix, stamp_sec);
+    return result.continue_to_pose_publish;
+  }
+  return result.continue_to_pose_publish;
+}
+
+void PCLLocalization::applyAcceptedPoseBackendResult(
+  const lidar_localization::PoseBackendResult & result,
+  const builtin_interfaces::msg::Time & stamp,
+  double stamp_sec,
+  double fitness_score)
+{
+  if (result.update_current_pose) {
+    setCurrentPoseFromMatrix(result.pose_matrix, stamp);
+  }
+  if (result.fill_pose_covariance) {
+    fillPoseCovariance(fitness_score);
+  }
+  if (result.update_prediction_state) {
+    updatePredictionState(result.pose_matrix, stamp_sec);
+  }
 }
 
 void PCLLocalization::setCurrentPoseFromMatrix(
   const Eigen::Matrix4f & pose_matrix,
   const builtin_interfaces::msg::Time & stamp)
 {
-  Eigen::Matrix3d rot_mat = pose_matrix.block<3, 3>(0, 0).cast<double>();
-  Eigen::Quaterniond quat_eig(rot_mat);
-  geometry_msgs::msg::Quaternion quat_msg = tf2::toMsg(quat_eig);
-
   corrent_pose_with_cov_stamped_ptr_->header.stamp = stamp;
   corrent_pose_with_cov_stamped_ptr_->header.frame_id = global_frame_id_;
-  corrent_pose_with_cov_stamped_ptr_->pose.pose.position.x = static_cast<double>(pose_matrix(0, 3));
-  corrent_pose_with_cov_stamped_ptr_->pose.pose.position.y = static_cast<double>(pose_matrix(1, 3));
-  corrent_pose_with_cov_stamped_ptr_->pose.pose.position.z = static_cast<double>(pose_matrix(2, 3));
-  corrent_pose_with_cov_stamped_ptr_->pose.pose.orientation = quat_msg;
+  corrent_pose_with_cov_stamped_ptr_->pose.pose =
+    lidar_localization::poseFromMatrix(pose_matrix);
 }
 
 void PCLLocalization::publishCurrentPose(const builtin_interfaces::msg::Time & stamp)
 {
   if (shutting_down_ || !pose_pub_ || !corrent_pose_with_cov_stamped_ptr_) {return;}
-  pose_pub_->publish(*corrent_pose_with_cov_stamped_ptr_);
-
-  geometry_msgs::msg::TransformStamped map_to_base_link_stamped;
-  map_to_base_link_stamped.header.stamp = stamp;
-  map_to_base_link_stamped.header.frame_id = global_frame_id_;
-  map_to_base_link_stamped.child_frame_id = base_frame_id_;
-  map_to_base_link_stamped.transform.translation.x = corrent_pose_with_cov_stamped_ptr_->pose.pose.position.x;
-  map_to_base_link_stamped.transform.translation.y = corrent_pose_with_cov_stamped_ptr_->pose.pose.position.y;
-  map_to_base_link_stamped.transform.translation.z = corrent_pose_with_cov_stamped_ptr_->pose.pose.position.z;
-  map_to_base_link_stamped.transform.rotation = corrent_pose_with_cov_stamped_ptr_->pose.pose.orientation;
-  if (!enable_map_odom_tf_) {
-    broadcaster_.sendTransform(map_to_base_link_stamped);
-  } else {
-    tf2::Transform map_to_base_link_tf;
-    tf2::fromMsg(map_to_base_link_stamped.transform, map_to_base_link_tf);
-
-    geometry_msgs::msg::TransformStamped odom_to_base_link_msg;
-    try {
-      odom_to_base_link_msg = tfbuffer_.lookupTransform(
-        odom_frame_id_, base_frame_id_, stamp, rclcpp::Duration::from_seconds(0.1));
-    } catch (tf2::TransformException & ex) {
-      RCLCPP_WARN(
-        this->get_logger(), "Could not get transform %s to %s: %s",
-        base_frame_id_.c_str(), odom_frame_id_.c_str(), ex.what());
-      return;
-    }
-    tf2::Transform odom_to_base_link_tf;
-    tf2::fromMsg(odom_to_base_link_msg.transform, odom_to_base_link_tf);
-
-    tf2::Transform map_to_odom_tf = map_to_base_link_tf * odom_to_base_link_tf.inverse();
-    geometry_msgs::msg::TransformStamped map_to_odom_stamped;
-    map_to_odom_stamped.header.stamp = stamp;
-    map_to_odom_stamped.header.frame_id = global_frame_id_;
-    map_to_odom_stamped.child_frame_id = odom_frame_id_;
-    map_to_odom_stamped.transform = tf2::toMsg(map_to_odom_tf);
-    broadcaster_.sendTransform(map_to_odom_stamped);
+  publishPoseMessage(*corrent_pose_with_cov_stamped_ptr_);
+  if (!publishPoseTransform(stamp, corrent_pose_with_cov_stamped_ptr_->pose.pose)) {
+    return;
   }
 
-  geometry_msgs::msg::PoseStamped pose_stamped;
-  pose_stamped.header.stamp = stamp;
-  pose_stamped.header.frame_id = global_frame_id_;
-  pose_stamped.pose = corrent_pose_with_cov_stamped_ptr_->pose.pose;
-  path_ptr_->poses.push_back(pose_stamped);
+  appendCurrentPoseToPath(stamp, corrent_pose_with_cov_stamped_ptr_->pose.pose);
+  publishPathMessage();
+}
+
+void PCLLocalization::publishPoseMessage(
+  const geometry_msgs::msg::PoseWithCovarianceStamped & pose)
+{
+  pose_pub_->publish(pose);
+}
+
+void PCLLocalization::appendCurrentPoseToPath(
+  const builtin_interfaces::msg::Time & stamp,
+  const geometry_msgs::msg::Pose & pose)
+{
+  lidar_localization::appendPoseToPath(
+    *path_ptr_,
+    lidar_localization::makePoseStamped(stamp, global_frame_id_, pose));
+}
+
+void PCLLocalization::publishPathMessage()
+{
   path_pub_->publish(*path_ptr_);
+}
+
+bool PCLLocalization::publishPoseTransform(
+  const builtin_interfaces::msg::Time & stamp,
+  const geometry_msgs::msg::Pose & pose)
+{
+  const geometry_msgs::msg::TransformStamped map_to_base_link_stamped =
+    lidar_localization::makeMapToBaseTransform(
+      stamp,
+      global_frame_id_,
+      base_frame_id_,
+      pose);
+  if (!enable_map_odom_tf_) {
+    broadcaster_.sendTransform(map_to_base_link_stamped);
+    return true;
+  }
+
+  return publishMapToOdomTransform(stamp, map_to_base_link_stamped);
+}
+
+bool PCLLocalization::publishMapToOdomTransform(
+  const builtin_interfaces::msg::Time & stamp,
+  const geometry_msgs::msg::TransformStamped & map_to_base_link_stamped)
+{
+  geometry_msgs::msg::TransformStamped odom_to_base_link_msg;
+  try {
+    odom_to_base_link_msg = tfbuffer_.lookupTransform(
+      odom_frame_id_, base_frame_id_, stamp, rclcpp::Duration::from_seconds(0.1));
+  } catch (tf2::TransformException & ex) {
+    RCLCPP_WARN(
+      this->get_logger(), "Could not get transform %s to %s: %s",
+      base_frame_id_.c_str(), odom_frame_id_.c_str(), ex.what());
+    return false;
+  }
+  broadcaster_.sendTransform(
+    lidar_localization::composeMapToOdomTransform(
+      stamp,
+      global_frame_id_,
+      odom_frame_id_,
+      map_to_base_link_stamped,
+      odom_to_base_link_msg));
+  return true;
 }
 
 void PCLLocalization::fillPoseCovariance(double fitness_score)
 {
-  // Nav2 PoseWithCovarianceStamped.pose.covariance: 6x6 row-major [36]
-  // Indices: [0]=xx, [7]=yy, [14]=zz, [21]=roll, [28]=pitch, [35]=yaw
-  auto & cov = corrent_pose_with_cov_stamped_ptr_->pose.covariance;
-  std::fill(cov.begin(), cov.end(), 0.0);
-
-  // Use EKF covariance matrix if available (most accurate)
   if (use_twist_ekf_ && twist_ekf_.isInitialized()) {
-    const auto & P = twist_ekf_.covariance();
-    // EKF state: [px,py,pz,vx,vy,vz,yaw,gyro_bias,speed_bias]
-    cov[0] = P(0, 0);    // xx
-    cov[1] = P(0, 1);    // xy
-    cov[6] = P(1, 0);    // yx
-    cov[7] = P(1, 1);    // yy
-    cov[14] = P(2, 2);   // zz
-    cov[35] = P(6, 6);   // yaw-yaw
-    // roll/pitch not estimated by EKF — use fitness-based estimate
-    double scale = std::max(1.0, fitness_score);
-    cov[21] = 0.001 * scale;
-    cov[28] = 0.001 * scale;
+    corrent_pose_with_cov_stamped_ptr_->pose.covariance =
+      lidar_localization::makeEkfPoseCovariance(twist_ekf_.covariance(), fitness_score);
     return;
   }
 
-  // Fitness-based covariance for smoother / standard paths
-  double scale = std::max(1.0, fitness_score);
-  cov[0] = 0.01 * scale;    // x
-  cov[7] = 0.01 * scale;    // y
-  cov[14] = 0.05 * scale;   // z
-  cov[21] = 0.001 * scale;  // roll
-  cov[28] = 0.001 * scale;  // pitch
-  cov[35] = 0.0005 * scale; // yaw
-}
-
-double PCLLocalization::computeEffectiveScoreThreshold(
-  double accepted_gap_sec,
-  double seed_translation_since_accept_m,
-  bool * post_reject_strict_active,
-  bool * open_loop_strict_active) const
-{
-  const bool post_reject_active =
-    enable_post_reject_strict_score_threshold_ &&
-    static_cast<int>(consecutive_rejected_updates_) >= post_reject_strict_min_rejections_ &&
-    post_reject_strict_score_threshold_ < score_threshold_;
-  const bool open_loop_active =
-    enable_open_loop_strict_score_threshold_ &&
-    accepted_gap_sec >= open_loop_strict_min_accepted_gap_sec_ &&
-    seed_translation_since_accept_m >= open_loop_strict_min_seed_translation_m_ &&
-    open_loop_strict_score_threshold_ < score_threshold_;
-
-  if (post_reject_strict_active != nullptr) {
-    *post_reject_strict_active = post_reject_active;
-  }
-  if (open_loop_strict_active != nullptr) {
-    *open_loop_strict_active = open_loop_active;
-  }
-
-  double effective_score_threshold = score_threshold_;
-  if (post_reject_active && post_reject_strict_score_threshold_ < effective_score_threshold) {
-    effective_score_threshold = post_reject_strict_score_threshold_;
-  }
-  if (open_loop_active && open_loop_strict_score_threshold_ < effective_score_threshold) {
-    effective_score_threshold = open_loop_strict_score_threshold_;
-  }
-  return effective_score_threshold;
-}
-
-bool PCLLocalization::computeBorderlineSeedGateActive(
-  double fitness_score,
-  double seed_translation_since_accept_m,
-  double effective_score_threshold) const
-{
-  return enable_borderline_seed_rejection_gate_ &&
-         borderline_seed_gate_score_threshold_ < effective_score_threshold &&
-         fitness_score > borderline_seed_gate_score_threshold_ &&
-         fitness_score <= effective_score_threshold &&
-         seed_translation_since_accept_m >= borderline_seed_gate_min_seed_translation_m_;
-}
-
-PCLLocalization::ReinitializationRequestDecision
-PCLLocalization::computeReinitializationRequest(
-  const builtin_interfaces::msg::Time & stamp,
-  const std::string & status_message,
-  double fitness_score,
-  double seed_translation_since_accept_m,
-  double accepted_gap_sec) const
-{
-  ReinitializationRequestDecision decision;
-
-  double effective_gap_sec = accepted_gap_sec;
-  if (!std::isfinite(effective_gap_sec) && have_last_accepted_pose_) {
-    effective_gap_sec = std::max(0.0, stamp_to_sec(stamp) - last_accepted_pose_time_sec_);
-  }
-
-  double effective_seed_translation_m = seed_translation_since_accept_m;
-  if (!std::isfinite(effective_seed_translation_m) && have_last_accepted_pose_) {
-    const Eigen::Matrix4f seed_delta_matrix =
-      last_accepted_pose_matrix_.inverse() * predicted_pose_matrix_;
-    effective_seed_translation_m = static_cast<double>(
-      seed_delta_matrix.block<3, 1>(0, 3).norm());
-  }
-
-  const bool target_unavailable = status_message == "local_map_crop_too_small";
-  const bool not_converged = status_message == "registration_not_converged";
-  const bool rejected_measurement = status_message.rfind("fitness_score_over_", 0) == 0;
-  const bool failure = target_unavailable || not_converged || rejected_measurement;
-
-  if (!failure) {
-    decision.reason = "not_failure";
-    return decision;
-  }
-
-  const double gap_component =
-    std::isfinite(effective_gap_sec) && reinitialization_trigger_gap_scale_sec_ > 0.0 ?
-    std::min(1.0, effective_gap_sec / reinitialization_trigger_gap_scale_sec_) : 0.0;
-  const double seed_component =
-    std::isfinite(effective_seed_translation_m) &&
-    reinitialization_trigger_seed_translation_scale_m_ > 0.0 ?
-    std::min(1.0, effective_seed_translation_m / reinitialization_trigger_seed_translation_scale_m_) : 0.0;
-  const double streak_component =
-    reinitialization_trigger_reject_streak_scale_ > 0.0 ?
-    std::min(
-      1.0,
-      static_cast<double>(consecutive_rejected_updates_) /
-      reinitialization_trigger_reject_streak_scale_) : 0.0;
-  const bool fitness_exploded =
-    std::isfinite(fitness_score) &&
-    fitness_score >= reinitialization_trigger_fitness_explosion_threshold_;
-
-  decision.score =
-    0.45 * gap_component +
-    0.30 * seed_component +
-    0.20 * streak_component +
-    (target_unavailable ? 0.15 : 0.0) +
-    (fitness_exploded ? 0.15 : 0.0);
-
-  if (decision.score < reinitialization_trigger_threshold_) {
-    decision.reason = "reinit_not_requested";
-    return decision;
-  }
-
-  decision.requested = true;
-  if (target_unavailable) {
-    decision.reason = "target_unavailable_reinit_requested";
-  } else if (fitness_exploded) {
-    decision.reason = "fitness_exploded_reinit_requested";
-  } else if (gap_component >= 1.0) {
-    decision.reason = "accepted_gap_reinit_requested";
-  } else if (streak_component >= 1.0) {
-    decision.reason = "reject_streak_reinit_requested";
-  } else {
-    decision.reason = "reinit_score_exceeded";
-  }
-  return decision;
+  corrent_pose_with_cov_stamped_ptr_->pose.covariance =
+    lidar_localization::makeFitnessPoseCovariance(fitness_score);
 }
 
 PCLLocalization::ReinitializationRequestDecision
@@ -2541,113 +2570,22 @@ PCLLocalization::applyReinitializationRequestLatch(
   const builtin_interfaces::msg::Time & stamp,
   const ReinitializationRequestDecision & decision)
 {
-  if (!enable_reinitialization_request_latch_) {
-    return decision;
-  }
+  const auto latch_result = lidar_localization::applyReinitializationRequestLatch(
+    lidar_localization::ReinitializationRequestLatchInput{
+      enable_reinitialization_request_latch_,
+      lidar_localization::ReinitializationRequestLatchState{
+        reinitialization_request_latched_,
+        reinitialization_request_latch_reason_,
+        reinitialization_request_latch_score_,
+        reinitialization_request_latch_stamp_sec_},
+      decision,
+      stamp_to_sec(stamp)});
 
-  if (decision.requested) {
-    if (!reinitialization_request_latched_) {
-      reinitialization_request_latch_stamp_sec_ = stamp_to_sec(stamp);
-      reinitialization_request_latch_reason_ = decision.reason;
-    }
-    reinitialization_request_latched_ = true;
-    reinitialization_request_latch_score_ =
-      std::max(reinitialization_request_latch_score_, decision.score);
-  }
-
-  if (!reinitialization_request_latched_) {
-    return decision;
-  }
-
-  ReinitializationRequestDecision latched_decision = decision;
-  latched_decision.requested = true;
-  latched_decision.reason = reinitialization_request_latch_reason_;
-  latched_decision.score = std::max(reinitialization_request_latch_score_, decision.score);
-  return latched_decision;
-}
-
-const char * PCLLocalization::recoverySupervisorStateName(
-  RecoverySupervisorState state) const
-{
-  switch (state) {
-    case RecoverySupervisorState::kTracking:
-      return "tracking";
-    case RecoverySupervisorState::kDegraded:
-      return "degraded";
-    case RecoverySupervisorState::kRecovering:
-      return "recovering";
-    case RecoverySupervisorState::kReinitializationRequested:
-      return "reinitialization_requested";
-  }
-  return "unknown";
-}
-
-bool PCLLocalization::isRecoveryFailureStatus(const std::string & status_message) const
-{
-  return status_message == "local_map_crop_too_small" ||
-         status_message == "registration_not_converged" ||
-         status_message == "filtered_scan_empty" ||
-         status_message == "scan_missing_xyz_field" ||
-         status_message.rfind("fitness_score_over_", 0) == 0;
-}
-
-PCLLocalization::RecoverySupervisorState
-PCLLocalization::classifyRecoverySupervisorState(
-  uint8_t level,
-  const std::string & status_message,
-  const ReinitializationRequestDecision & reinitialization_request) const
-{
-  if (reinitialization_request.requested) {
-    return RecoverySupervisorState::kReinitializationRequested;
-  }
-  if (
-    status_message == "recovery_retry_from_last_pose_recovered" ||
-    isRecoveryFailureStatus(status_message) ||
-    consecutive_rejected_updates_ > 0)
-  {
-    return RecoverySupervisorState::kRecovering;
-  }
-  if (level != diagnostic_msgs::msg::DiagnosticStatus::OK) {
-    return RecoverySupervisorState::kDegraded;
-  }
-  return RecoverySupervisorState::kTracking;
-}
-
-std::string PCLLocalization::classifyRecoverySupervisorAction(
-  uint8_t level,
-  const std::string & status_message,
-  const ReinitializationRequestDecision & reinitialization_request) const
-{
-  if (reinitialization_request.requested) {
-    return "request_reinitialization";
-  }
-  if (status_message == "recovery_retry_from_last_pose_recovered") {
-    return "retry_from_last_pose";
-  }
-  if (status_message.find("_seeded") != std::string::npos) {
-    return "reuse_rejected_seed_for_prediction";
-  }
-  if (
-    status_message == "local_map_crop_too_small" ||
-    status_message == "registration_not_converged" ||
-    status_message == "filtered_scan_empty" ||
-    status_message == "scan_missing_xyz_field")
-  {
-    return "advance_prediction_without_measurement";
-  }
-  if (
-    status_message.rfind("fitness_score_over_", 0) == 0 &&
-    status_message.find("_rejected") != std::string::npos)
-  {
-    return "reject_measurement";
-  }
-  if (consecutive_rejected_updates_ > 0) {
-    return "accept_measurement_after_recovery";
-  }
-  if (level != diagnostic_msgs::msg::DiagnosticStatus::OK) {
-    return "accept_measurement_with_warning";
-  }
-  return "accept_measurement";
+  reinitialization_request_latched_ = latch_result.state.latched;
+  reinitialization_request_latch_reason_ = latch_result.state.reason;
+  reinitialization_request_latch_score_ = latch_result.state.score;
+  reinitialization_request_latch_stamp_sec_ = latch_result.state.stamp_sec;
+  return latch_result.decision;
 }
 
 void PCLLocalization::updateRecoverySupervisorState(
@@ -2656,42 +2594,97 @@ void PCLLocalization::updateRecoverySupervisorState(
   const std::string & action)
 {
   const double stamp_sec = stamp_to_sec(stamp);
-  if (recovery_supervisor_state_entered_stamp_sec_ <= 0.0) {
-    recovery_supervisor_state_entered_stamp_sec_ = stamp_sec;
-  }
-  if (next_state != recovery_supervisor_state_) {
+  const auto update = lidar_localization::updateRecoverySupervisorRuntimeState(
+    lidar_localization::RecoverySupervisorStateUpdateInput{
+      lidar_localization::RecoverySupervisorRuntimeState{
+        recovery_supervisor_state_,
+        recovery_supervisor_action_,
+        recovery_supervisor_state_entered_stamp_sec_,
+        recovery_supervisor_transition_count_},
+      next_state,
+      action,
+      stamp_sec});
+
+  if (update.transitioned) {
     RCLCPP_INFO(
       get_logger(),
       "Recovery supervisor state transition: %s -> %s (%s)",
-      recoverySupervisorStateName(recovery_supervisor_state_),
-      recoverySupervisorStateName(next_state),
+      lidar_localization::recoverySupervisorStateName(update.previous_state),
+      lidar_localization::recoverySupervisorStateName(update.state.state),
       action.c_str());
-    recovery_supervisor_state_ = next_state;
-    recovery_supervisor_state_entered_stamp_sec_ = stamp_sec;
-    ++recovery_supervisor_transition_count_;
   }
-  recovery_supervisor_action_ = action;
+
+  recovery_supervisor_state_ = update.state.state;
+  recovery_supervisor_action_ = update.state.action;
+  recovery_supervisor_state_entered_stamp_sec_ = update.state.entered_stamp_sec;
+  recovery_supervisor_transition_count_ = update.state.transition_count;
 }
 
 void PCLLocalization::publishReinitializationRequest(
   const builtin_interfaces::msg::Time & stamp,
   const ReinitializationRequestDecision & decision)
 {
-  reinitialization_requested_ = decision.requested;
-  reinitialization_request_reason_ = decision.reason;
-  reinitialization_request_score_ = decision.score;
+  (void)stamp;
+  const bool publisher_ready =
+    reinitialization_request_pub_ && reinitialization_request_pub_->is_activated();
+  const auto output = lidar_localization::prepareReinitializationRequestOutput(
+    lidar_localization::ReinitializationRequestOutputInput{
+      enable_reinitialization_request_output_,
+      publisher_ready,
+      decision});
 
-  if (
-    !enable_reinitialization_request_output_ ||
-    !reinitialization_request_pub_ ||
-    !reinitialization_request_pub_->is_activated())
-  {
+  reinitialization_requested_ = output.state.requested;
+  reinitialization_request_reason_ = output.state.reason;
+  reinitialization_request_score_ = output.state.score;
+
+  if (!output.should_publish) {
     return;
   }
 
   std_msgs::msg::Bool msg;
-  msg.data = decision.requested;
+  msg.data = output.message_value;
   reinitialization_request_pub_->publish(msg);
+}
+
+lidar_localization::MeasurementGateParams PCLLocalization::measurementGateParams() const
+{
+  return lidar_localization::makeMeasurementGateParams(measurement_gate_config_);
+}
+
+lidar_localization::ReinitializationTriggerParams
+PCLLocalization::reinitializationTriggerParams() const
+{
+  return reinitialization_trigger_config_;
+}
+
+lidar_localization::RecoveryRetryFromLastPoseParams
+PCLLocalization::recoveryRetryFromLastPoseParams() const
+{
+  return recovery_retry_from_last_pose_config_;
+}
+
+void PCLLocalization::publishAlignmentStatusForAttempt(
+  const builtin_interfaces::msg::Time & stamp,
+  uint8_t level,
+  const std::string & message,
+  const lidar_localization::AlignmentAttempt & attempt,
+  std::size_t filtered_point_count,
+  bool imu_prediction_active)
+{
+  publishAlignmentStatus(
+    stamp,
+    level,
+    message,
+    attempt.has_converged,
+    attempt.fitness_score,
+    attempt.alignment_time_sec,
+    filtered_point_count,
+    attempt.correction_translation_m,
+    attempt.correction_yaw_deg,
+    attempt.seed_translation_since_accept_m,
+    attempt.seed_yaw_since_accept_deg,
+    attempt.accepted_gap_sec,
+    imu_prediction_active);
 }
 
 void PCLLocalization::publishAlignmentStatus(
@@ -2711,169 +2704,175 @@ void PCLLocalization::publishAlignmentStatus(
 {
   if (!status_pub_) {return;}
 
-  diagnostic_msgs::msg::DiagnosticStatus status;
-  status.level = level;
-  status.name = "lidar_localization_ros2/alignment";
-  status.message = message;
-  status.hardware_id = registration_method_;
-
-  auto append_value =
-    [&status](const std::string & key, const std::string & value)
-    {
-      diagnostic_msgs::msg::KeyValue kv;
-      kv.key = key;
-      kv.value = value;
-      status.values.push_back(kv);
-    };
-
-  append_value("registration_method", registration_method_);
-  append_value("has_converged", has_converged ? "true" : "false");
-  append_value("fitness_score", std::to_string(fitness_score));
-  append_value("score_threshold", std::to_string(score_threshold_));
-  bool post_reject_strict_active = false;
-  bool open_loop_strict_active = false;
-  const double effective_score_threshold = computeEffectiveScoreThreshold(
-    accepted_gap_sec,
-    seed_translation_since_accept_m,
-    &post_reject_strict_active,
-    &open_loop_strict_active);
-  const bool borderline_seed_gate_active = computeBorderlineSeedGateActive(
+  const AlignmentStatusPublishInput publish_input{
+    stamp,
+    level,
+    message,
+    has_converged,
     fitness_score,
+    alignment_time_sec,
+    filtered_point_count,
+    correction_translation_m,
+    correction_yaw_deg,
     seed_translation_since_accept_m,
-    effective_score_threshold);
-  ReinitializationRequestDecision reinitialization_request =
-    computeReinitializationRequest(
-      stamp,
-      message,
-      fitness_score,
-      seed_translation_since_accept_m,
-      accepted_gap_sec);
-  reinitialization_request =
-    applyReinitializationRequestLatch(stamp, reinitialization_request);
-  const RecoverySupervisorState recovery_state =
-    classifyRecoverySupervisorState(level, message, reinitialization_request);
-  const std::string recovery_action =
-    classifyRecoverySupervisorAction(level, message, reinitialization_request);
-  updateRecoverySupervisorState(stamp, recovery_state, recovery_action);
-  const double stamp_sec = stamp_to_sec(stamp);
-  const double recovery_state_age_sec =
-    recovery_supervisor_state_entered_stamp_sec_ > 0.0 ?
-    std::max(0.0, stamp_sec - recovery_supervisor_state_entered_stamp_sec_) : 0.0;
-  const double reinitialization_request_latch_age_sec =
-    reinitialization_request_latched_ && reinitialization_request_latch_stamp_sec_ > 0.0 ?
-    std::max(0.0, stamp_sec - reinitialization_request_latch_stamp_sec_) : 0.0;
-  append_value("effective_score_threshold", std::to_string(effective_score_threshold));
-  append_value(
-    "post_reject_strict_score_threshold_active",
-    post_reject_strict_active ? "true" : "false");
-  append_value(
-    "open_loop_strict_score_threshold_active",
-    open_loop_strict_active ? "true" : "false");
-  append_value(
-    "borderline_seed_rejection_gate_active",
-    borderline_seed_gate_active ? "true" : "false");
-  append_value("alignment_time_sec", std::to_string(alignment_time_sec));
-  append_value("filtered_point_count", std::to_string(filtered_point_count));
-  append_value("correction_translation_m", std::to_string(correction_translation_m));
-  append_value("correction_yaw_deg", std::to_string(correction_yaw_deg));
-  append_value(
-    "seed_translation_since_accept_m",
-    std::to_string(seed_translation_since_accept_m));
-  append_value(
-    "seed_yaw_since_accept_deg",
-    std::to_string(seed_yaw_since_accept_deg));
-  append_value("accepted_gap_sec", std::to_string(accepted_gap_sec));
-  append_value(
-    "consecutive_rejected_updates",
-    std::to_string(consecutive_rejected_updates_));
-  append_value("recovery_state", recoverySupervisorStateName(recovery_supervisor_state_));
-  append_value("recovery_action", recovery_supervisor_action_);
-  append_value("recovery_state_age_sec", std::to_string(recovery_state_age_sec));
-  append_value(
-    "recovery_state_transition_count",
-    std::to_string(recovery_supervisor_transition_count_));
-  append_value(
-    "imu_prediction_active",
-    imu_prediction_active ? "true" : "false");
-  append_value(
-    "reinitialization_requested",
-    reinitialization_request.requested ? "true" : "false");
-  append_value(
-    "reinitialization_request_reason",
-    reinitialization_request.reason);
-  append_value(
-    "reinitialization_request_score",
-    std::to_string(reinitialization_request.score));
-  append_value(
-    "reinitialization_request_latched",
-    reinitialization_request_latched_ ? "true" : "false");
-  append_value(
-    "reinitialization_request_latch_age_sec",
-    std::to_string(reinitialization_request_latch_age_sec));
-  append_value("map_received", map_recieved_ ? "true" : "false");
-  append_value("initialpose_received", initialpose_recieved_ ? "true" : "false");
+    seed_yaw_since_accept_deg,
+    accepted_gap_sec,
+    imu_prediction_active};
 
+  const auto evaluation = evaluateAlignmentStatus(stamp, publish_input);
+  auto status = makeAlignmentDiagnosticStatus(evaluation.status_input);
+
+  appendAlignmentDiagnosticValues(
+    status,
+    prepareAlignmentDiagnosticValuesInput(
+      evaluation.status_input,
+      evaluation.status_preparation,
+      evaluation.reinitialization_request));
+  publishAlignmentDiagnosticStatus(stamp, status);
+  publishReinitializationRequest(stamp, evaluation.reinitialization_request);
+}
+
+lidar_localization::AlignmentStatusInput PCLLocalization::makeAlignmentStatusInput(
+  const AlignmentStatusPublishInput & input) const
+{
+  const double stamp_sec = stamp_to_sec(input.stamp);
+  return lidar_localization::makeAlignmentStatusInput(
+    lidar_localization::AlignmentStatusObservation{
+      input.level,
+      input.message,
+      input.has_converged,
+      input.fitness_score,
+      input.alignment_time_sec,
+      input.filtered_point_count,
+      input.correction_translation_m,
+      input.correction_yaw_deg,
+      input.seed_translation_since_accept_m,
+      input.seed_yaw_since_accept_deg,
+      input.accepted_gap_sec,
+      input.imu_prediction_active},
+    makeAlignmentStatusRuntimeContext(stamp_sec));
+}
+
+lidar_localization::AlignmentStatusRuntimeContext
+PCLLocalization::makeAlignmentStatusRuntimeContext(double stamp_sec) const
+{
+  const auto fallback_seed_metrics = lidar_localization::computeAlignmentSeedMetrics(
+    have_last_accepted_pose_,
+    last_accepted_pose_matrix_,
+    predicted_pose_matrix_,
+    stamp_sec,
+    last_accepted_pose_time_sec_);
+
+  return lidar_localization::AlignmentStatusRuntimeContext{
+    registration_method_,
+    consecutive_rejected_updates_,
+    have_last_accepted_pose_,
+    stamp_sec,
+    last_accepted_pose_time_sec_,
+    fallback_seed_metrics.translation_since_accept_m,
+    map_recieved_,
+    initialpose_recieved_,
+    measurementGateParams(),
+    reinitializationTriggerParams()};
+}
+
+diagnostic_msgs::msg::DiagnosticStatus PCLLocalization::makeAlignmentDiagnosticStatus(
+  const lidar_localization::AlignmentStatusInput & status_input) const
+{
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  status.level = status_input.level;
+  status.name = "lidar_localization_ros2/alignment";
+  status.message = status_input.message;
+  status.hardware_id = status_input.registration_method;
+  return status;
+}
+
+PCLLocalization::AlignmentStatusEvaluation PCLLocalization::evaluateAlignmentStatus(
+  const builtin_interfaces::msg::Time & stamp,
+  const AlignmentStatusPublishInput & publish_input)
+{
+  AlignmentStatusEvaluation evaluation;
+  evaluation.status_input = makeAlignmentStatusInput(publish_input);
+  evaluation.status_preparation =
+    lidar_localization::prepareAlignmentStatus(evaluation.status_input);
+  evaluation.reinitialization_request =
+    applyReinitializationRequestLatch(
+      stamp,
+      evaluation.status_preparation.reinitialization_request);
+
+  const auto recovery_evaluation =
+    lidar_localization::evaluateAlignmentStatusRecovery(
+      evaluation.status_input,
+      evaluation.reinitialization_request);
+  updateRecoverySupervisorState(
+    stamp,
+    recovery_evaluation.state,
+    recovery_evaluation.action);
+  return evaluation;
+}
+
+lidar_localization::AlignmentDiagnosticValuesInput
+PCLLocalization::prepareAlignmentDiagnosticValuesInput(
+  const lidar_localization::AlignmentStatusInput & status_input,
+  const lidar_localization::AlignmentStatusPreparation & status_preparation,
+  const ReinitializationRequestDecision & reinitialization_request) const
+{
+  return lidar_localization::makeAlignmentStatusDiagnosticValuesInput(
+    lidar_localization::makeAlignmentStatusDiagnosticInput(
+      status_input,
+      status_preparation,
+      reinitialization_request,
+      lidar_localization::AlignmentStatusDiagnosticRuntimeContext{
+        lidar_localization::recoverySupervisorStateName(recovery_supervisor_state_),
+        recovery_supervisor_action_,
+        recovery_supervisor_state_entered_stamp_sec_,
+        recovery_supervisor_transition_count_,
+        reinitialization_request_latched_,
+        reinitialization_request_latch_stamp_sec_}));
+}
+
+void PCLLocalization::appendAlignmentDiagnosticValues(
+  diagnostic_msgs::msg::DiagnosticStatus & status,
+  const lidar_localization::AlignmentDiagnosticValuesInput & diagnostic_values_input) const
+{
+  for (const auto & value :
+    lidar_localization::makeRosAlignmentDiagnosticKeyValues(diagnostic_values_input))
+  {
+    status.values.push_back(value);
+  }
+}
+
+diagnostic_msgs::msg::DiagnosticArray PCLLocalization::makeAlignmentDiagnosticArray(
+  const builtin_interfaces::msg::Time & stamp,
+  const diagnostic_msgs::msg::DiagnosticStatus & status) const
+{
   diagnostic_msgs::msg::DiagnosticArray status_array;
   status_array.header.stamp = stamp;
   status_array.header.frame_id = base_frame_id_;
   status_array.status.push_back(status);
-  status_pub_->publish(status_array);
-  publishReinitializationRequest(stamp, reinitialization_request);
+  return status_array;
+}
+
+void PCLLocalization::publishAlignmentDiagnosticStatus(
+  const builtin_interfaces::msg::Time & stamp,
+  const diagnostic_msgs::msg::DiagnosticStatus & status)
+{
+  status_pub_->publish(makeAlignmentDiagnosticArray(stamp, status));
 }
 
 void PCLLocalization::timerPublishPose()
 {
   if (shutting_down_ || !pose_pub_ || !path_pub_ || !path_ptr_) {return;}
   if (!corrent_pose_with_cov_stamped_ptr_) {return;}
-  geometry_msgs::msg::PoseWithCovarianceStamped pose_copy = *corrent_pose_with_cov_stamped_ptr_;
-  pose_copy.header.stamp = now();
+  geometry_msgs::msg::PoseWithCovarianceStamped pose_copy =
+    lidar_localization::stampPoseWithCovariance(*corrent_pose_with_cov_stamped_ptr_, now());
 
-  geometry_msgs::msg::PoseStamped stamped;
-  stamped.header = pose_copy.header;
-  stamped.header.frame_id = global_frame_id_;
-  stamped.pose = pose_copy.pose.pose;
-  path_ptr_->poses.push_back(stamped);
+  appendCurrentPoseToPath(pose_copy.header.stamp, pose_copy.pose.pose);
 
   nav_msgs::msg::Path path_copy = *path_ptr_;
 
-  pose_pub_->publish(pose_copy);
+  publishPoseMessage(pose_copy);
   path_pub_->publish(path_copy);
 
-  geometry_msgs::msg::TransformStamped map_to_base_link_stamped;
-  map_to_base_link_stamped.header.stamp = pose_copy.header.stamp;
-  map_to_base_link_stamped.header.frame_id = global_frame_id_;
-  map_to_base_link_stamped.child_frame_id = base_frame_id_;
-  map_to_base_link_stamped.transform.translation.x = pose_copy.pose.pose.position.x;
-  map_to_base_link_stamped.transform.translation.y = pose_copy.pose.pose.position.y;
-  map_to_base_link_stamped.transform.translation.z = pose_copy.pose.pose.position.z;
-  map_to_base_link_stamped.transform.rotation = pose_copy.pose.pose.orientation;
-
-  if (!enable_map_odom_tf_) {
-    broadcaster_.sendTransform(map_to_base_link_stamped);
-  } else {
-    tf2::Transform map_to_base_link_tf;
-    tf2::fromMsg(map_to_base_link_stamped.transform, map_to_base_link_tf);
-
-    geometry_msgs::msg::TransformStamped odom_to_base_link_msg;
-    try {
-      odom_to_base_link_msg = tfbuffer_.lookupTransform(
-        odom_frame_id_, base_frame_id_, pose_copy.header.stamp, rclcpp::Duration::from_seconds(0.1));
-    } catch (tf2::TransformException & ex) {
-      RCLCPP_WARN(
-        this->get_logger(), "Could not get transform %s to %s: %s",
-        base_frame_id_.c_str(), odom_frame_id_.c_str(), ex.what());
-      return;
-    }
-    tf2::Transform odom_to_base_link_tf;
-    tf2::fromMsg(odom_to_base_link_msg.transform, odom_to_base_link_tf);
-
-    tf2::Transform map_to_odom_tf = map_to_base_link_tf * odom_to_base_link_tf.inverse();
-    geometry_msgs::msg::TransformStamped map_to_odom_stamped;
-    map_to_odom_stamped.header.stamp = pose_copy.header.stamp;
-    map_to_odom_stamped.header.frame_id = global_frame_id_;
-    map_to_odom_stamped.child_frame_id = odom_frame_id_;
-    map_to_odom_stamped.transform = tf2::toMsg(map_to_odom_tf);
-    
-    broadcaster_.sendTransform(map_to_odom_stamped);
-  }
+  publishPoseTransform(pose_copy.header.stamp, pose_copy.pose.pose);
 }

--- a/test/test_alignment_attempt_policy.cpp
+++ b/test/test_alignment_attempt_policy.cpp
@@ -1,0 +1,81 @@
+#include "lidar_localization/alignment_attempt_policy.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <limits>
+
+#include <Eigen/Geometry>
+
+namespace ll = lidar_localization;
+
+constexpr double kPi = 3.14159265358979323846;
+
+Eigen::Matrix4f make_pose(float x, float y, float yaw_rad)
+{
+  Eigen::Matrix4f pose = Eigen::Matrix4f::Identity();
+  pose.block<3, 3>(0, 0) =
+    Eigen::AngleAxisf(yaw_rad, Eigen::Vector3f::UnitZ()).toRotationMatrix();
+  pose(0, 3) = x;
+  pose(1, 3) = y;
+  return pose;
+}
+
+void test_pose_delta_helpers()
+{
+  const Eigen::Matrix4f delta = make_pose(3.0f, 4.0f, static_cast<float>(kPi / 2.0));
+  assert(std::abs(ll::poseDeltaTranslationNormM(delta) - 5.0) < 1.0e-6);
+  assert(std::abs(ll::poseDeltaYawAbsDeg(delta) - 90.0) < 1.0e-4);
+
+  const Eigen::Matrix4f negative_yaw =
+    make_pose(0.0f, 0.0f, static_cast<float>(-kPi / 4.0));
+  assert(std::abs(ll::poseDeltaYawAbsDeg(negative_yaw) - 45.0) < 1.0e-4);
+}
+
+void test_seed_metrics_are_nan_without_last_accepted_pose()
+{
+  const auto metrics = ll::computeAlignmentSeedMetrics(
+    false,
+    Eigen::Matrix4f::Identity(),
+    make_pose(1.0f, 2.0f, 0.1f),
+    10.0,
+    5.0);
+
+  assert(std::isnan(metrics.translation_since_accept_m));
+  assert(std::isnan(metrics.yaw_since_accept_deg));
+  assert(std::isnan(metrics.accepted_gap_sec));
+}
+
+void test_seed_metrics_use_relative_pose_and_nonnegative_gap()
+{
+  const Eigen::Matrix4f last_pose = make_pose(10.0f, 20.0f, static_cast<float>(kPi / 2.0));
+  const Eigen::Matrix4f init_guess =
+    last_pose * make_pose(3.0f, 4.0f, static_cast<float>(kPi / 6.0));
+
+  auto metrics = ll::computeAlignmentSeedMetrics(true, last_pose, init_guess, 12.0, 10.5);
+  assert(std::abs(metrics.translation_since_accept_m - 5.0) < 1.0e-5);
+  assert(std::abs(metrics.yaw_since_accept_deg - 30.0) < 1.0e-4);
+  assert(std::abs(metrics.accepted_gap_sec - 1.5) < 1.0e-9);
+
+  metrics = ll::computeAlignmentSeedMetrics(true, last_pose, init_guess, 9.0, 10.5);
+  assert(metrics.accepted_gap_sec == 0.0);
+}
+
+void test_correction_metrics_use_init_to_final_delta()
+{
+  const Eigen::Matrix4f init_guess = make_pose(-2.0f, 5.0f, static_cast<float>(kPi / 3.0));
+  const Eigen::Matrix4f final_pose =
+    init_guess * make_pose(0.3f, 0.4f, static_cast<float>(-kPi / 9.0));
+
+  const auto metrics = ll::computeAlignmentCorrectionMetrics(init_guess, final_pose);
+  assert(std::abs(metrics.translation_m - 0.5) < 1.0e-5);
+  assert(std::abs(metrics.yaw_deg - 20.0) < 1.0e-4);
+}
+
+int main()
+{
+  test_pose_delta_helpers();
+  test_seed_metrics_are_nan_without_last_accepted_pose();
+  test_seed_metrics_use_relative_pose_and_nonnegative_gap();
+  test_correction_metrics_use_init_to_final_delta();
+  return 0;
+}

--- a/test/test_alignment_diagnostic_ros_adapter.cpp
+++ b/test/test_alignment_diagnostic_ros_adapter.cpp
@@ -1,0 +1,53 @@
+#include "lidar_localization/alignment_diagnostic_ros_adapter.hpp"
+
+#include <cassert>
+#include <vector>
+
+namespace ll = lidar_localization;
+
+void test_make_ros_diagnostic_key_value_preserves_pair()
+{
+  const auto key_value = ll::makeRosDiagnosticKeyValue({"recovery_state", "tracking"});
+
+  assert(key_value.key == "recovery_state");
+  assert(key_value.value == "tracking");
+}
+
+void test_make_ros_diagnostic_key_values_preserves_order()
+{
+  const std::vector<ll::DiagnosticKeyValue> values{
+    {"first", "1"},
+    {"second", "2"}};
+
+  const auto key_values = ll::makeRosDiagnosticKeyValues(values);
+
+  assert(key_values.size() == 2);
+  assert(key_values[0].key == "first");
+  assert(key_values[0].value == "1");
+  assert(key_values[1].key == "second");
+  assert(key_values[1].value == "2");
+}
+
+void test_make_ros_alignment_diagnostic_key_values_uses_policy_values()
+{
+  ll::AlignmentDiagnosticValuesInput input;
+  input.registration_method = "NDT";
+  input.has_converged = true;
+  input.recovery_state = "tracking";
+  input.recovery_action = "accept_measurement";
+  input.reinitialization_request_reason = "not_requested";
+
+  const auto key_values = ll::makeRosAlignmentDiagnosticKeyValues(input);
+
+  assert(!key_values.empty());
+  assert(key_values.front().key == "registration_method");
+  assert(key_values.front().value == "NDT");
+}
+
+int main()
+{
+  test_make_ros_diagnostic_key_value_preserves_pair();
+  test_make_ros_diagnostic_key_values_preserves_order();
+  test_make_ros_alignment_diagnostic_key_values_uses_policy_values();
+  return 0;
+}

--- a/test/test_alignment_diagnostics_policy.cpp
+++ b/test/test_alignment_diagnostics_policy.cpp
@@ -1,0 +1,121 @@
+#include "lidar_localization/alignment_diagnostics_policy.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <string>
+
+namespace ll = lidar_localization;
+
+void test_bool_and_elapsed_helpers()
+{
+  assert(std::string(ll::boolString(true)) == "true");
+  assert(std::string(ll::boolString(false)) == "false");
+  assert(ll::nonnegativeElapsedOrZero(10.0, 7.0) == 3.0);
+  assert(ll::nonnegativeElapsedOrZero(7.0, 10.0) == 0.0);
+  assert(ll::nonnegativeElapsedOrZero(10.0, 0.0) == 0.0);
+}
+
+void test_effective_reinitialization_metrics_use_direct_values_when_finite()
+{
+  const auto metrics = ll::resolveEffectiveReinitializationMetrics(
+    ll::EffectiveReinitializationMetricsInput{
+      2.0,
+      3.0,
+      true,
+      10.0,
+      1.0,
+      99.0});
+
+  assert(metrics.accepted_gap_sec == 2.0);
+  assert(metrics.seed_translation_since_accept_m == 3.0);
+}
+
+void test_effective_reinitialization_metrics_fallbacks()
+{
+  const auto metrics = ll::resolveEffectiveReinitializationMetrics(
+    ll::EffectiveReinitializationMetricsInput{
+      std::numeric_limits<double>::quiet_NaN(),
+      std::numeric_limits<double>::quiet_NaN(),
+      true,
+      10.0,
+      7.0,
+      4.0});
+
+  assert(metrics.accepted_gap_sec == 3.0);
+  assert(metrics.seed_translation_since_accept_m == 4.0);
+
+  const auto no_pose = ll::resolveEffectiveReinitializationMetrics(
+    ll::EffectiveReinitializationMetricsInput{
+      std::numeric_limits<double>::quiet_NaN(),
+      std::numeric_limits<double>::quiet_NaN(),
+      false,
+      10.0,
+      7.0,
+      4.0});
+  assert(std::isnan(no_pose.accepted_gap_sec));
+  assert(std::isnan(no_pose.seed_translation_since_accept_m));
+}
+
+void test_build_alignment_diagnostic_values_order_and_strings()
+{
+  ll::AlignmentDiagnosticValuesInput input;
+  input.registration_method = "NDT";
+  input.has_converged = true;
+  input.fitness_score = 1.25;
+  input.score_threshold = 2.0;
+  input.effective_score_threshold = 1.5;
+  input.post_reject_strict_active = true;
+  input.open_loop_strict_active = false;
+  input.borderline_seed_gate_active = true;
+  input.alignment_time_sec = 0.01;
+  input.filtered_point_count = 123;
+  input.correction_translation_m = 0.2;
+  input.correction_yaw_deg = 0.3;
+  input.seed_translation_since_accept_m = 4.0;
+  input.seed_yaw_since_accept_deg = 5.0;
+  input.accepted_gap_sec = 6.0;
+  input.consecutive_rejected_updates = 7;
+  input.recovery_state = "recovering";
+  input.recovery_action = "reject_measurement";
+  input.recovery_state_age_sec = 8.0;
+  input.recovery_state_transition_count = 9;
+  input.imu_prediction_active = true;
+  input.reinitialization_requested = false;
+  input.reinitialization_request_reason = "not_requested";
+  input.reinitialization_request_score = 0.4;
+  input.reinitialization_request_latched = true;
+  input.reinitialization_request_latch_age_sec = 10.0;
+  input.map_received = true;
+  input.initialpose_received = false;
+
+  const auto values = ll::buildAlignmentDiagnosticValues(input);
+  assert(values.size() == 28);
+  assert(values[0].first == "registration_method");
+  assert(values[0].second == "NDT");
+  assert(values[1].first == "has_converged");
+  assert(values[1].second == "true");
+  assert(values[5].first == "post_reject_strict_score_threshold_active");
+  assert(values[5].second == "true");
+  assert(values[7].first == "borderline_seed_rejection_gate_active");
+  assert(values[7].second == "true");
+  assert(values[9].first == "filtered_point_count");
+  assert(values[9].second == "123");
+  assert(values[16].first == "recovery_state");
+  assert(values[16].second == "recovering");
+  assert(values[20].first == "imu_prediction_active");
+  assert(values[20].second == "true");
+  assert(values[26].first == "map_received");
+  assert(values[26].second == "true");
+  assert(values[27].first == "initialpose_received");
+  assert(values[27].second == "false");
+}
+
+int main()
+{
+  test_bool_and_elapsed_helpers();
+  test_effective_reinitialization_metrics_use_direct_values_when_finite();
+  test_effective_reinitialization_metrics_fallbacks();
+  test_build_alignment_diagnostic_values_order_and_strings();
+  return 0;
+}

--- a/test/test_alignment_pipeline_policy.cpp
+++ b/test/test_alignment_pipeline_policy.cpp
@@ -1,0 +1,230 @@
+#include "lidar_localization/alignment_pipeline_policy.hpp"
+
+#include <cassert>
+#include <limits>
+#include <string>
+
+namespace ll = lidar_localization;
+
+ll::AlignmentAttempt make_attempt(
+  bool target_ready,
+  bool has_converged,
+  double fitness_score = 1.0)
+{
+  ll::AlignmentAttempt attempt;
+  attempt.target_ready = target_ready;
+  attempt.has_converged = has_converged;
+  attempt.alignment_time_sec = 0.25;
+  attempt.fitness_score = fitness_score;
+  attempt.seed_translation_since_accept_m = 0.5;
+  attempt.seed_yaw_since_accept_deg = 1.0;
+  attempt.accepted_gap_sec = 0.4;
+  if (has_converged) {
+    attempt.final_transformation(0, 3) = static_cast<float>(fitness_score);
+    attempt.correction_translation_m = 0.1;
+    attempt.correction_yaw_deg = 0.2;
+  }
+  return attempt;
+}
+
+ll::AlignmentPipelineInput default_input()
+{
+  return {
+    true,
+    2,
+    12.0,
+    10.0,
+    ll::makeRecoveryRetryFromLastPoseParams(true, 2, 5.0, 10.0)};
+}
+
+ll::MeasurementGateDecision accepted_gate()
+{
+  ll::MeasurementGateDecision gate;
+  gate.status_level = ll::kMeasurementGateOk;
+  gate.status_message = "ok";
+  gate.reject_measurement = false;
+  return gate;
+}
+
+ll::MeasurementGateDecision rejected_gate()
+{
+  ll::MeasurementGateDecision gate;
+  gate.status_level = ll::kMeasurementGateWarn;
+  gate.status_message = "fitness_score_over_threshold_rejected";
+  gate.reject_measurement = true;
+  return gate;
+}
+
+void test_target_missing_terminal_failure_when_retry_unavailable()
+{
+  auto input = default_input();
+  input.have_last_accepted_pose = false;
+  int retry_calls = 0;
+  int gate_calls = 0;
+
+  const auto result = ll::runAlignmentPipeline(
+    make_attempt(false, false, std::numeric_limits<double>::quiet_NaN()),
+    input,
+    [&]() {
+      ++retry_calls;
+      return make_attempt(true, true);
+    },
+    [&](const ll::AlignmentAttempt &) {
+      ++gate_calls;
+      return accepted_gate();
+    });
+
+  assert(!result.should_continue);
+  assert(result.should_advance_prediction_without_measurement);
+  assert(result.status_level == ll::kAlignmentPipelineError);
+  assert(result.status_message == "local_map_crop_too_small");
+  assert(retry_calls == 0);
+  assert(gate_calls == 0);
+}
+
+void test_not_converged_terminal_failure_when_retry_disabled()
+{
+  auto input = default_input();
+  input.recovery_retry_params.enable = false;
+  int retry_calls = 0;
+
+  const auto result = ll::runAlignmentPipeline(
+    make_attempt(true, false, 3.0),
+    input,
+    [&]() {
+      ++retry_calls;
+      return make_attempt(true, true);
+    },
+    [](const ll::AlignmentAttempt &) {
+      return accepted_gate();
+    });
+
+  assert(!result.should_continue);
+  assert(result.status_message == "registration_not_converged");
+  assert(result.selected_attempt.target_ready);
+  assert(!result.selected_attempt.has_converged);
+  assert(retry_calls == 0);
+}
+
+void test_fitness_reject_remains_rejected_when_retry_denied()
+{
+  auto input = default_input();
+  input.recovery_retry_params.min_rejections = 3;
+  int retry_calls = 0;
+  int gate_calls = 0;
+
+  const auto result = ll::runAlignmentPipeline(
+    make_attempt(true, true, 9.0),
+    input,
+    [&]() {
+      ++retry_calls;
+      return make_attempt(true, true, 1.0);
+    },
+    [&](const ll::AlignmentAttempt &) {
+      ++gate_calls;
+      return rejected_gate();
+    });
+
+  assert(result.should_continue);
+  assert(!result.recovered_by_retry_from_last_pose);
+  assert(result.gate_result.reject_measurement);
+  assert(result.status_message == "fitness_score_over_threshold_rejected");
+  assert(retry_calls == 0);
+  assert(gate_calls == 1);
+}
+
+void test_retry_success_replaces_rejected_primary_attempt()
+{
+  int retry_calls = 0;
+  int gate_calls = 0;
+
+  const auto result = ll::runAlignmentPipeline(
+    make_attempt(true, true, 9.0),
+    default_input(),
+    [&]() {
+      ++retry_calls;
+      return make_attempt(true, true, 1.0);
+    },
+    [&](const ll::AlignmentAttempt & attempt) {
+      ++gate_calls;
+      return attempt.fitness_score > 5.0 ? rejected_gate() : accepted_gate();
+    });
+
+  assert(result.should_continue);
+  assert(result.recovered_by_retry_from_last_pose);
+  assert(result.selected_attempt.fitness_score == 1.0);
+  assert(!result.gate_result.reject_measurement);
+  assert(result.gate_result.status_level == ll::kMeasurementGateWarn);
+  assert(result.gate_result.status_message == "recovery_retry_from_last_pose_recovered");
+  assert(retry_calls == 1);
+  assert(gate_calls == 2);
+}
+
+void test_target_missing_can_recover_by_retry()
+{
+  int retry_calls = 0;
+  int gate_calls = 0;
+
+  const auto result = ll::runAlignmentPipeline(
+    make_attempt(false, false, std::numeric_limits<double>::quiet_NaN()),
+    default_input(),
+    [&]() {
+      ++retry_calls;
+      return make_attempt(true, true, 1.5);
+    },
+    [&](const ll::AlignmentAttempt &) {
+      ++gate_calls;
+      return accepted_gate();
+    });
+
+  assert(result.should_continue);
+  assert(result.recovered_by_retry_from_last_pose);
+  assert(result.selected_attempt.target_ready);
+  assert(result.selected_attempt.has_converged);
+  assert(result.status_message == "recovery_retry_from_last_pose_recovered");
+  assert(retry_calls == 1);
+  assert(gate_calls == 1);
+}
+
+void test_terminal_handling_publishes_and_advances()
+{
+  ll::AlignmentPipelineResult result =
+    ll::makeTerminalAlignmentPipelineResult(
+    make_attempt(true, false, 3.0), "registration_not_converged");
+
+  const auto handling = ll::decideAlignmentPipelineHandling(result);
+
+  assert(!handling.log_recovery_retry_success);
+  assert(handling.publish_terminal_status);
+  assert(handling.warn_registration_not_converged);
+  assert(handling.advance_prediction_without_measurement);
+  assert(!handling.continue_to_backend);
+}
+
+void test_continuing_recovery_handling_logs_and_uses_backend()
+{
+  ll::AlignmentPipelineResult result;
+  result.should_continue = true;
+  result.recovered_by_retry_from_last_pose = true;
+  result.status_message = "recovery_retry_from_last_pose_recovered";
+
+  const auto handling = ll::decideAlignmentPipelineHandling(result);
+
+  assert(handling.log_recovery_retry_success);
+  assert(!handling.publish_terminal_status);
+  assert(!handling.warn_registration_not_converged);
+  assert(!handling.advance_prediction_without_measurement);
+  assert(handling.continue_to_backend);
+}
+
+int main()
+{
+  test_target_missing_terminal_failure_when_retry_unavailable();
+  test_not_converged_terminal_failure_when_retry_disabled();
+  test_fitness_reject_remains_rejected_when_retry_denied();
+  test_retry_success_replaces_rejected_primary_attempt();
+  test_target_missing_can_recover_by_retry();
+  test_terminal_handling_publishes_and_advances();
+  test_continuing_recovery_handling_logs_and_uses_backend();
+  return 0;
+}

--- a/test/test_alignment_retry_policy.cpp
+++ b/test/test_alignment_retry_policy.cpp
@@ -1,0 +1,141 @@
+#include "lidar_localization/alignment_retry_policy.hpp"
+
+#include <cassert>
+#include <limits>
+
+namespace ll = lidar_localization;
+
+ll::RecoveryRetryFromLastPoseParams default_params()
+{
+  return ll::makeRecoveryRetryFromLastPoseParams(true, 2, 1.0, 5.0);
+}
+
+ll::RecoveryRetryFromLastPoseInput default_input()
+{
+  return ll::makeRecoveryRetryFromLastPoseInput(true, 2, 0.5, 0.7, 4.0);
+}
+
+void test_retry_builders_and_fallback_gap()
+{
+  const auto params = ll::makeRecoveryRetryFromLastPoseParams(true, 3, 2.5, 6.0);
+  assert(params.enable);
+  assert(params.min_rejections == 3);
+  assert(params.max_accepted_gap_sec == 2.5);
+  assert(params.max_seed_translation_m == 6.0);
+
+  const auto input = ll::makeRecoveryRetryFromLastPoseInput(true, 4, 1.0, 1.5, 2.0);
+  assert(input.have_last_accepted_pose);
+  assert(input.consecutive_rejected_updates == 4);
+  assert(input.selected_accepted_gap_sec == 1.0);
+  assert(input.fallback_accepted_gap_sec == 1.5);
+  assert(input.selected_seed_translation_since_accept_m == 2.0);
+
+  assert(ll::computeRecoveryRetryFallbackAcceptedGapSec(true, 12.0, 10.5) == 1.5);
+  assert(ll::computeRecoveryRetryFallbackAcceptedGapSec(true, 9.0, 10.5) == 0.0);
+  assert(!std::isfinite(ll::computeRecoveryRetryFallbackAcceptedGapSec(false, 12.0, 10.5)));
+}
+
+void test_disabled_and_missing_state_block_retry()
+{
+  auto params = default_params();
+  auto input = default_input();
+
+  params.enable = false;
+  auto decision = ll::decideRecoveryRetryFromLastPose(params, input);
+  assert(!decision.should_retry);
+  assert(decision.reason == "disabled");
+
+  params.enable = true;
+  input.have_last_accepted_pose = false;
+  decision = ll::decideRecoveryRetryFromLastPose(params, input);
+  assert(!decision.should_retry);
+  assert(decision.reason == "no_last_accepted_pose");
+}
+
+void test_min_rejections_and_gap_gate()
+{
+  auto params = default_params();
+  auto input = default_input();
+
+  input.consecutive_rejected_updates = 1;
+  auto decision = ll::decideRecoveryRetryFromLastPose(params, input);
+  assert(!decision.should_retry);
+  assert(decision.reason == "not_enough_rejections");
+
+  input = default_input();
+  input.selected_accepted_gap_sec = 1.1;
+  decision = ll::decideRecoveryRetryFromLastPose(params, input);
+  assert(!decision.should_retry);
+  assert(decision.reason == "accepted_gap_too_large");
+}
+
+void test_fallback_gap_and_unavailable_gap()
+{
+  auto params = default_params();
+  auto input = default_input();
+  input.selected_accepted_gap_sec = std::numeric_limits<double>::quiet_NaN();
+
+  auto decision = ll::decideRecoveryRetryFromLastPose(params, input);
+  assert(decision.should_retry);
+  assert(decision.accepted_gap_sec == input.fallback_accepted_gap_sec);
+
+  input.fallback_accepted_gap_sec = std::numeric_limits<double>::quiet_NaN();
+  decision = ll::decideRecoveryRetryFromLastPose(params, input);
+  assert(!decision.should_retry);
+  assert(decision.reason == "accepted_gap_unavailable");
+}
+
+void test_seed_translation_gate_ignores_nan()
+{
+  auto params = default_params();
+  auto input = default_input();
+
+  input.selected_seed_translation_since_accept_m = 5.1;
+  auto decision = ll::decideRecoveryRetryFromLastPose(params, input);
+  assert(!decision.should_retry);
+  assert(decision.reason == "seed_translation_too_large");
+
+  input.selected_seed_translation_since_accept_m =
+    std::numeric_limits<double>::quiet_NaN();
+  decision = ll::decideRecoveryRetryFromLastPose(params, input);
+  assert(decision.should_retry);
+}
+
+void test_retry_result_requires_target_convergence_and_gate_acceptance()
+{
+  assert(ll::isRecoveryRetryAlignmentUsable(true, true));
+  assert(!ll::isRecoveryRetryAlignmentUsable(false, true));
+  assert(!ll::isRecoveryRetryAlignmentUsable(true, false));
+
+  assert(ll::shouldUseRecoveryRetryResult(true, true, false));
+  assert(!ll::shouldUseRecoveryRetryResult(true, true, true));
+  assert(!ll::shouldUseRecoveryRetryResult(false, true, false));
+  assert(!ll::shouldUseRecoveryRetryResult(true, false, false));
+}
+
+void test_recovered_gate_decision_clears_rejection_state()
+{
+  ll::MeasurementGateDecision gate;
+  gate.status_level = ll::kMeasurementGateOk;
+  gate.status_message = "fitness_score_over_threshold_rejected_seeded";
+  gate.reject_measurement = true;
+  gate.rejected_seed_update_applied = true;
+
+  const auto recovered_gate = ll::makeRecoveryRetryRecoveredGateDecision(gate);
+  assert(recovered_gate.status_level == ll::kMeasurementGateWarn);
+  assert(recovered_gate.status_message == "recovery_retry_from_last_pose_recovered");
+  assert(!recovered_gate.reject_measurement);
+  assert(!recovered_gate.rejected_seed_update_applied);
+}
+
+int main()
+{
+  test_retry_builders_and_fallback_gap();
+  test_disabled_and_missing_state_block_retry();
+  test_min_rejections_and_gap_gate();
+  test_fallback_gap_and_unavailable_gap();
+  test_seed_translation_gate_ignores_nan();
+  test_retry_result_requires_target_convergence_and_gate_acceptance();
+  test_recovered_gate_decision_clears_rejection_state();
+  return 0;
+}

--- a/test/test_alignment_status_policy.cpp
+++ b/test/test_alignment_status_policy.cpp
@@ -1,0 +1,230 @@
+#include "lidar_localization/alignment_status_policy.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <string>
+
+namespace ll = lidar_localization;
+
+ll::AlignmentStatusInput default_status_input()
+{
+  ll::AlignmentStatusInput input;
+  input.registration_method = "NDT";
+  input.level = ll::kMeasurementGateWarn;
+  input.message = "fitness_score_over_threshold_rejected";
+  input.has_converged = true;
+  input.fitness_score = 6.0;
+  input.alignment_time_sec = 0.05;
+  input.filtered_point_count = 1200;
+  input.correction_translation_m = 0.2;
+  input.correction_yaw_deg = 0.3;
+  input.seed_translation_since_accept_m = 4.0;
+  input.seed_yaw_since_accept_deg = 2.0;
+  input.accepted_gap_sec = 8.0;
+  input.consecutive_rejected_updates = 5;
+  input.have_last_accepted_pose = true;
+  input.stamp_sec = 20.0;
+  input.last_accepted_pose_time_sec = 12.0;
+  input.fallback_seed_translation_since_accept_m = 9.0;
+  input.imu_prediction_active = true;
+  input.map_received = true;
+  input.initialpose_received = true;
+  input.gate_params.score_threshold = 7.0;
+  input.gate_params.enable_post_reject_strict_score_threshold = true;
+  input.gate_params.post_reject_strict_min_rejections = 5;
+  input.gate_params.post_reject_strict_score_threshold = 5.0;
+  input.gate_params.enable_borderline_seed_rejection_gate = true;
+  input.gate_params.borderline_seed_gate_score_threshold = 4.5;
+  input.gate_params.borderline_seed_gate_min_seed_translation_m = 1.0;
+  input.reinitialization_params = ll::makeReinitializationTriggerParams(
+    0.5, 8.0, 4.0, 5.0, 1000.0);
+  return input;
+}
+
+void test_prepare_alignment_status_computes_gate_and_reinit()
+{
+  const auto input = default_status_input();
+  const auto preparation = ll::prepareAlignmentStatus(input);
+
+  assert(preparation.threshold_decision.post_reject_strict_active);
+  assert(preparation.threshold_decision.effective_score_threshold == 5.0);
+  assert(!preparation.borderline_seed_gate_active);
+  assert(preparation.effective_reinitialization_metrics.accepted_gap_sec == 8.0);
+  assert(preparation.effective_reinitialization_metrics.seed_translation_since_accept_m == 4.0);
+  assert(preparation.reinitialization_request.requested);
+  assert(preparation.reinitialization_request.reason == "accepted_gap_reinit_requested");
+}
+
+void test_make_alignment_status_input_combines_observation_and_context()
+{
+  ll::AlignmentStatusObservation observation;
+  observation.level = ll::kMeasurementGateWarn;
+  observation.message = "registration_not_converged";
+  observation.has_converged = false;
+  observation.fitness_score = 9.0;
+  observation.alignment_time_sec = 0.2;
+  observation.filtered_point_count = 345;
+  observation.correction_translation_m = 1.2;
+  observation.correction_yaw_deg = 3.4;
+  observation.seed_translation_since_accept_m = 5.6;
+  observation.seed_yaw_since_accept_deg = 7.8;
+  observation.accepted_gap_sec = 9.1;
+  observation.imu_prediction_active = true;
+
+  ll::AlignmentStatusRuntimeContext context;
+  context.registration_method = "GICP";
+  context.consecutive_rejected_updates = 12;
+  context.have_last_accepted_pose = true;
+  context.stamp_sec = 44.0;
+  context.last_accepted_pose_time_sec = 40.0;
+  context.fallback_seed_translation_since_accept_m = 2.5;
+  context.map_received = true;
+  context.initialpose_received = false;
+  context.gate_params.score_threshold = 4.0;
+  context.reinitialization_params.threshold = 0.8;
+
+  const auto input = ll::makeAlignmentStatusInput(observation, context);
+
+  assert(input.registration_method == "GICP");
+  assert(input.level == ll::kMeasurementGateWarn);
+  assert(input.message == "registration_not_converged");
+  assert(!input.has_converged);
+  assert(input.fitness_score == 9.0);
+  assert(input.alignment_time_sec == 0.2);
+  assert(input.filtered_point_count == 345);
+  assert(input.correction_translation_m == 1.2);
+  assert(input.correction_yaw_deg == 3.4);
+  assert(input.seed_translation_since_accept_m == 5.6);
+  assert(input.seed_yaw_since_accept_deg == 7.8);
+  assert(input.accepted_gap_sec == 9.1);
+  assert(input.consecutive_rejected_updates == 12);
+  assert(input.have_last_accepted_pose);
+  assert(input.stamp_sec == 44.0);
+  assert(input.last_accepted_pose_time_sec == 40.0);
+  assert(input.fallback_seed_translation_since_accept_m == 2.5);
+  assert(input.imu_prediction_active);
+  assert(input.map_received);
+  assert(!input.initialpose_received);
+  assert(input.gate_params.score_threshold == 4.0);
+  assert(input.reinitialization_params.threshold == 0.8);
+}
+
+void test_prepare_alignment_status_uses_fallback_reinit_metrics()
+{
+  auto input = default_status_input();
+  input.accepted_gap_sec = NAN;
+  input.seed_translation_since_accept_m = NAN;
+  input.message = "registration_not_converged";
+
+  const auto preparation = ll::prepareAlignmentStatus(input);
+
+  assert(preparation.effective_reinitialization_metrics.accepted_gap_sec == 8.0);
+  assert(preparation.effective_reinitialization_metrics.seed_translation_since_accept_m == 9.0);
+  assert(preparation.reinitialization_request.requested);
+}
+
+void test_recovery_evaluation_uses_latched_reinit_request()
+{
+  const auto input = default_status_input();
+  const ll::ReinitializationRequestDecision latched_request{
+    true, "latched_request", 1.0};
+
+  const auto recovery = ll::evaluateAlignmentStatusRecovery(input, latched_request);
+
+  assert(recovery.state == ll::RecoverySupervisorState::kReinitializationRequested);
+  assert(recovery.action == "request_reinitialization");
+}
+
+void test_make_diagnostic_input_preserves_status_context()
+{
+  const auto input = default_status_input();
+  const auto preparation = ll::prepareAlignmentStatus(input);
+  const ll::ReinitializationRequestDecision reinit_request{
+    true, "latched_request", 0.75};
+  const auto diagnostic_input = ll::makeAlignmentStatusDiagnosticValuesInput(
+    ll::AlignmentStatusDiagnosticInput{
+      input,
+      preparation,
+      reinit_request,
+      "reinitialization_requested",
+      "request_reinitialization",
+      3.0,
+      2,
+      true,
+      4.0});
+
+  assert(diagnostic_input.registration_method == "NDT");
+  assert(diagnostic_input.has_converged);
+  assert(diagnostic_input.effective_score_threshold == 5.0);
+  assert(diagnostic_input.recovery_state == "reinitialization_requested");
+  assert(diagnostic_input.recovery_action == "request_reinitialization");
+  assert(diagnostic_input.reinitialization_requested);
+  assert(diagnostic_input.reinitialization_request_reason == "latched_request");
+  assert(diagnostic_input.reinitialization_request_score == 0.75);
+  assert(diagnostic_input.reinitialization_request_latched);
+  assert(diagnostic_input.map_received);
+  assert(diagnostic_input.initialpose_received);
+}
+
+void test_make_diagnostic_input_computes_runtime_ages()
+{
+  auto input = default_status_input();
+  input.stamp_sec = 25.0;
+  const auto preparation = ll::prepareAlignmentStatus(input);
+  const ll::ReinitializationRequestDecision reinit_request{
+    true, "latched_request", 0.75};
+
+  const auto diagnostic_input = ll::makeAlignmentStatusDiagnosticInput(
+    input,
+    preparation,
+    reinit_request,
+    ll::AlignmentStatusDiagnosticRuntimeContext{
+      "recovering",
+      "reject_measurement",
+      20.0,
+      6,
+      true,
+      21.5});
+
+  assert(diagnostic_input.recovery_state == "recovering");
+  assert(diagnostic_input.recovery_action == "reject_measurement");
+  assert(diagnostic_input.recovery_state_age_sec == 5.0);
+  assert(diagnostic_input.recovery_state_transition_count == 6);
+  assert(diagnostic_input.reinitialization_request_latched);
+  assert(diagnostic_input.reinitialization_request_latch_age_sec == 3.5);
+}
+
+void test_make_diagnostic_input_zeros_unlatched_request_age()
+{
+  auto input = default_status_input();
+  input.stamp_sec = 25.0;
+  const auto preparation = ll::prepareAlignmentStatus(input);
+
+  const auto diagnostic_input = ll::makeAlignmentStatusDiagnosticInput(
+    input,
+    preparation,
+    ll::ReinitializationRequestDecision{},
+    ll::AlignmentStatusDiagnosticRuntimeContext{
+      "tracking",
+      "accept_measurement",
+      30.0,
+      1,
+      false,
+      21.5});
+
+  assert(diagnostic_input.recovery_state_age_sec == 0.0);
+  assert(!diagnostic_input.reinitialization_request_latched);
+  assert(diagnostic_input.reinitialization_request_latch_age_sec == 0.0);
+}
+
+int main()
+{
+  test_make_alignment_status_input_combines_observation_and_context();
+  test_prepare_alignment_status_computes_gate_and_reinit();
+  test_prepare_alignment_status_uses_fallback_reinit_metrics();
+  test_recovery_evaluation_uses_latched_reinit_request();
+  test_make_diagnostic_input_preserves_status_context();
+  test_make_diagnostic_input_computes_runtime_ages();
+  test_make_diagnostic_input_zeros_unlatched_request_age();
+  return 0;
+}

--- a/test/test_imu_preintegration_guard_policy.cpp
+++ b/test/test_imu_preintegration_guard_policy.cpp
@@ -1,0 +1,188 @@
+#include "lidar_localization/imu_preintegration_guard_policy.hpp"
+
+#include <cassert>
+#include <limits>
+#include <string>
+
+namespace ll = lidar_localization;
+
+ll::ImuPreintegrationGuardParams default_params()
+{
+  ll::ImuPreintegrationGuardParams params;
+  params.prediction_correction_guard_translation_m = 2.0;
+  params.prediction_correction_guard_yaw_deg = 4.0;
+  params.smoother_measurement_translation_guard_m = 2.0;
+  params.smoother_measurement_rotation_guard_deg = 10.0;
+  return params;
+}
+
+void test_prediction_correction_guard_requires_active_prediction()
+{
+  const auto params = default_params();
+  ll::ImuPredictionCorrectionGuardInput input;
+  input.fallback_mode = false;
+  input.imu_prediction_ready = true;
+  input.correction_translation_m = 2.1;
+  input.correction_yaw_deg = 0.0;
+  assert(ll::isImuPredictionCorrectionGuardTripped(params, input));
+
+  input.fallback_mode = true;
+  assert(!ll::isImuPredictionCorrectionGuardTripped(params, input));
+
+  input.fallback_mode = false;
+  input.imu_prediction_ready = false;
+  assert(!ll::isImuPredictionCorrectionGuardTripped(params, input));
+}
+
+void test_prediction_correction_guard_checks_translation_or_yaw()
+{
+  const auto params = default_params();
+  ll::ImuPredictionCorrectionGuardInput input;
+  input.imu_prediction_ready = true;
+  input.correction_translation_m = 2.0;
+  input.correction_yaw_deg = 4.0;
+  assert(!ll::isImuPredictionCorrectionGuardTripped(params, input));
+
+  input.correction_translation_m = 2.1;
+  assert(ll::isImuPredictionCorrectionGuardTripped(params, input));
+
+  input.correction_translation_m = std::numeric_limits<double>::quiet_NaN();
+  input.correction_yaw_deg = 4.1;
+  assert(ll::isImuPredictionCorrectionGuardTripped(params, input));
+
+  input.correction_yaw_deg = std::numeric_limits<double>::quiet_NaN();
+  assert(!ll::isImuPredictionCorrectionGuardTripped(params, input));
+}
+
+void test_smoother_divergence_rejects_non_finite_or_large_delta()
+{
+  const auto params = default_params();
+  ll::ImuSmootherDivergenceInput input;
+  input.pose_all_finite = true;
+  input.measurement_translation_delta_m = 2.0;
+  input.measurement_rotation_delta_deg = 10.0;
+  assert(!ll::isImuSmootherDiverged(params, input));
+
+  input.measurement_translation_delta_m = 2.1;
+  assert(ll::isImuSmootherDiverged(params, input));
+
+  input.measurement_translation_delta_m = 0.0;
+  input.measurement_rotation_delta_deg = 10.1;
+  assert(ll::isImuSmootherDiverged(params, input));
+
+  input.measurement_rotation_delta_deg = 0.0;
+  input.pose_all_finite = false;
+  assert(ll::isImuSmootherDiverged(params, input));
+
+  input.pose_all_finite = true;
+  input.measurement_translation_delta_m = std::numeric_limits<double>::quiet_NaN();
+  assert(ll::isImuSmootherDiverged(params, input));
+}
+
+void test_backend_state_skips_smoother_when_already_in_fallback()
+{
+  const auto params = default_params();
+  ll::ImuPredictionCorrectionGuardInput input;
+  input.fallback_mode = true;
+  input.imu_prediction_ready = true;
+  input.correction_translation_m = 10.0;
+  input.correction_yaw_deg = 10.0;
+
+  const auto state = ll::beginImuPreintegrationBackendState(params, input);
+
+  assert(state.fallback_mode);
+  assert(!state.state_reset);
+  assert(!state.correction_guard_tripped);
+  assert(!state.should_update_smoother);
+  assert(ll::shouldUseImuMeasurementPose(state));
+}
+
+void test_backend_state_enters_fallback_on_prediction_guard()
+{
+  const auto params = default_params();
+  ll::ImuPredictionCorrectionGuardInput input;
+  input.imu_prediction_ready = true;
+  input.correction_translation_m = 2.1;
+
+  const auto state = ll::beginImuPreintegrationBackendState(params, input);
+
+  assert(state.fallback_mode);
+  assert(state.state_reset);
+  assert(state.correction_guard_tripped);
+  assert(!state.smoother_diverged);
+  assert(!state.should_update_smoother);
+}
+
+void test_backend_state_enters_fallback_on_smoother_divergence()
+{
+  const auto params = default_params();
+  ll::ImuPredictionCorrectionGuardInput correction_input;
+  correction_input.imu_prediction_ready = true;
+
+  auto state = ll::beginImuPreintegrationBackendState(params, correction_input);
+  assert(!state.fallback_mode);
+  assert(state.should_update_smoother);
+
+  ll::ImuSmootherDivergenceInput divergence_input;
+  divergence_input.pose_all_finite = true;
+  divergence_input.measurement_translation_delta_m = 2.1;
+  divergence_input.measurement_rotation_delta_deg = 0.0;
+  state = ll::applyImuSmootherDivergenceDecision(state, params, divergence_input);
+
+  assert(state.fallback_mode);
+  assert(state.state_reset);
+  assert(!state.correction_guard_tripped);
+  assert(state.smoother_diverged);
+  assert(!state.should_update_smoother);
+}
+
+void test_backend_status_overload_uses_backend_state()
+{
+  ll::ImuPreintegrationBackendState state;
+  state.state_reset = true;
+  state.correction_guard_tripped = true;
+
+  auto status = ll::decideImuPreintegrationStatus(state, true);
+  assert(status.warning);
+  assert(std::string(status.status_message) ==
+         "imu_prediction_correction_guard_imu_disabled");
+
+  state.correction_guard_tripped = false;
+  state.smoother_diverged = true;
+  status = ll::decideImuPreintegrationStatus(state, true);
+  assert(status.warning);
+  assert(std::string(status.status_message) == "imu_smoother_diverged_imu_disabled");
+}
+
+void test_status_decision_prioritizes_reset_reasons()
+{
+  auto status = ll::decideImuPreintegrationStatus(true, true, true);
+  assert(status.warning);
+  assert(std::string(status.status_message) ==
+         "imu_prediction_correction_guard_imu_disabled");
+
+  status = ll::decideImuPreintegrationStatus(true, false, true);
+  assert(status.warning);
+  assert(std::string(status.status_message) == "imu_smoother_diverged_imu_disabled");
+
+  status = ll::decideImuPreintegrationStatus(false, false, false);
+  assert(status.warning);
+  assert(std::string(status.status_message) == "imu_smoother_update_rejected");
+
+  status = ll::decideImuPreintegrationStatus(false, false, true);
+  assert(!status.warning);
+  assert(std::string(status.status_message) == "ok");
+}
+
+int main()
+{
+  test_prediction_correction_guard_requires_active_prediction();
+  test_prediction_correction_guard_checks_translation_or_yaw();
+  test_smoother_divergence_rejects_non_finite_or_large_delta();
+  test_backend_state_skips_smoother_when_already_in_fallback();
+  test_backend_state_enters_fallback_on_prediction_guard();
+  test_backend_state_enters_fallback_on_smoother_divergence();
+  test_backend_status_overload_uses_backend_state();
+  test_status_decision_prioritizes_reset_reasons();
+  return 0;
+}

--- a/test/test_local_map_target_policy.cpp
+++ b/test/test_local_map_target_policy.cpp
@@ -1,0 +1,172 @@
+#include "lidar_localization/local_map_target_policy.hpp"
+
+#include <cassert>
+#include <chrono>
+#include <limits>
+
+namespace ll = lidar_localization;
+
+pcl::PointXYZI make_point(float x, float y, float z = 0.0f)
+{
+  pcl::PointXYZI point;
+  point.x = x;
+  point.y = y;
+  point.z = z;
+  point.intensity = 1.0f;
+  return point;
+}
+
+void test_crop_bounds_are_optional_and_radius_expanded()
+{
+  ll::LocalMapCropRequest request;
+  request.center_x = 1000.0f;
+  request.center_y = 0.0f;
+  request.radius_m = 10.0;
+  request.bounds.valid = false;
+  assert(!ll::isCropCenterOutsideLocalMapBounds(request));
+
+  request.bounds = {true, 0.0f, 100.0f, -50.0f, 50.0f};
+  request.center_x = 110.0f;
+  assert(!ll::isCropCenterOutsideLocalMapBounds(request));
+  request.center_x = 110.1f;
+  assert(ll::isCropCenterOutsideLocalMapBounds(request));
+  request.center_x = -10.0f;
+  assert(!ll::isCropCenterOutsideLocalMapBounds(request));
+  request.center_x = -10.1f;
+  assert(ll::isCropCenterOutsideLocalMapBounds(request));
+
+  request.center_x = 50.0f;
+  request.center_y = 60.1f;
+  assert(ll::isCropCenterOutsideLocalMapBounds(request));
+}
+
+void test_crop_local_map_by_horizontal_radius()
+{
+  pcl::PointCloud<pcl::PointXYZI> full_map;
+  full_map.push_back(make_point(0.0f, 0.0f));
+  full_map.push_back(make_point(3.0f, 4.0f, 100.0f));
+  full_map.push_back(make_point(5.1f, 0.0f));
+  full_map.push_back(make_point(-3.0f, -4.0f));
+
+  const auto local_map = ll::cropLocalMapByRadius(full_map, 0.0f, 0.0f, 5.0);
+  assert(local_map->size() == 3);
+  assert(local_map->points[1].z == 100.0f);
+}
+
+void test_min_points_and_target_choice()
+{
+  assert(ll::isLocalMapCropTooSmall(9, 10));
+  assert(!ll::isLocalMapCropTooSmall(10, 10));
+
+  assert(ll::chooseLocalMapTargetCloud(10, 10) == ll::LocalMapTargetCloud::kFilteredLocalMap);
+  assert(ll::chooseLocalMapTargetCloud(9, 10) == ll::LocalMapTargetCloud::kRawLocalMap);
+
+  const auto too_small = ll::chooseTargetAfterLocalMapCrop(9, 9, 10);
+  assert(!too_small.target_ready);
+  assert(too_small.failure == ll::LocalMapTargetFailure::kCropTooSmall);
+  assert(!ll::validateLocalMapCropSize(9, 10).target_ready);
+  assert(ll::validateLocalMapCropSize(10, 10).target_ready);
+
+  const auto filtered_ready = ll::chooseTargetAfterLocalMapCrop(20, 10, 10);
+  assert(filtered_ready.target_ready);
+  assert(filtered_ready.target_cloud == ll::LocalMapTargetCloud::kFilteredLocalMap);
+
+  const auto raw_fallback = ll::chooseTargetAfterLocalMapCrop(20, 9, 10);
+  assert(raw_fallback.target_ready);
+  assert(raw_fallback.target_cloud == ll::LocalMapTargetCloud::kRawLocalMap);
+}
+
+void test_crop_request_validation()
+{
+  ll::LocalMapCropRequest request;
+  request.center_x = 100.0f;
+  request.center_y = 0.0f;
+  request.radius_m = 10.0;
+  request.bounds = {true, 0.0f, 50.0f, -10.0f, 10.0f};
+
+  const auto invalid = ll::validateLocalMapCropRequest(request);
+  assert(!invalid.can_crop);
+  assert(invalid.failure == ll::LocalMapTargetFailure::kCropCenterOutsideBounds);
+
+  request.center_x = 60.0f;
+  const auto valid = ll::validateLocalMapCropRequest(request);
+  assert(valid.can_crop);
+  assert(valid.failure == ll::LocalMapTargetFailure::kNone);
+}
+
+void test_map_subscription_target_choice()
+{
+  assert(
+    ll::chooseMapSubscriptionTargetCloud(true) == ll::LocalMapTargetCloud::kFilteredLocalMap);
+  assert(ll::chooseMapSubscriptionTargetCloud(false) == ll::LocalMapTargetCloud::kRawLocalMap);
+}
+
+void test_crop_failure_count_and_log_throttles()
+{
+  assert(ll::incrementCropFailureCount(0) == 1);
+  assert(
+    ll::incrementCropFailureCount(std::numeric_limits<int>::max()) ==
+    std::numeric_limits<int>::max());
+
+  assert(!ll::shouldLogCropFailureStreak(100, false, std::chrono::seconds(0)));
+  assert(ll::shouldLogCropFailureStreak(101, false, std::chrono::seconds(0)));
+  assert(!ll::shouldLogCropFailureStreak(101, true, std::chrono::seconds(4)));
+  assert(ll::shouldLogCropFailureStreak(101, true, std::chrono::seconds(5)));
+
+  assert(ll::shouldLogCropOutOfBounds(false, std::chrono::seconds(0)));
+  assert(!ll::shouldLogCropOutOfBounds(true, std::chrono::seconds(4)));
+  assert(ll::shouldLogCropOutOfBounds(true, std::chrono::seconds(5)));
+}
+
+void test_target_failure_handling_decision()
+{
+  ll::LocalMapTargetFailureHandlingInput input;
+  input.failure = ll::LocalMapTargetFailure::kCropTooSmall;
+  input.consecutive_crop_failures = 100;
+  input.has_last_failure_streak_log = false;
+  input.has_last_out_of_bounds_log = false;
+
+  const auto too_small = ll::handleLocalMapTargetFailure(input);
+  assert(too_small.consecutive_crop_failures == 101);
+  assert(too_small.should_log_failure_streak);
+  assert(!too_small.should_log_out_of_bounds);
+
+  input.failure = ll::LocalMapTargetFailure::kCropCenterOutsideBounds;
+  input.consecutive_crop_failures = 1;
+  input.has_last_failure_streak_log = true;
+  input.elapsed_since_failure_streak_log = std::chrono::seconds(1);
+  input.has_last_out_of_bounds_log = true;
+  input.elapsed_since_out_of_bounds_log = std::chrono::seconds(5);
+
+  const auto out_of_bounds = ll::handleLocalMapTargetFailure(input);
+  assert(out_of_bounds.consecutive_crop_failures == 2);
+  assert(!out_of_bounds.should_log_failure_streak);
+  assert(out_of_bounds.should_log_out_of_bounds);
+
+  input.failure = ll::LocalMapTargetFailure::kNone;
+  input.consecutive_crop_failures = 7;
+  const auto no_failure = ll::handleLocalMapTargetFailure(input);
+  assert(no_failure.consecutive_crop_failures == 7);
+  assert(!no_failure.should_log_failure_streak);
+  assert(!no_failure.should_log_out_of_bounds);
+}
+
+void test_target_success_resets_runtime_guard_state()
+{
+  const auto success = ll::handleLocalMapTargetSuccess();
+  assert(success.consecutive_crop_failures == 0);
+  assert(!success.crop_failure_guard_active);
+}
+
+int main()
+{
+  test_crop_bounds_are_optional_and_radius_expanded();
+  test_crop_local_map_by_horizontal_radius();
+  test_min_points_and_target_choice();
+  test_crop_request_validation();
+  test_map_subscription_target_choice();
+  test_crop_failure_count_and_log_throttles();
+  test_target_failure_handling_decision();
+  test_target_success_resets_runtime_guard_state();
+  return 0;
+}

--- a/test/test_localization_update_policy.cpp
+++ b/test/test_localization_update_policy.cpp
@@ -1,0 +1,57 @@
+#include "lidar_localization/localization_update_policy.hpp"
+
+#include <cassert>
+
+namespace ll = lidar_localization;
+
+ll::MeasurementGateDecision make_gate(bool reject_measurement, bool rejected_seed_update_applied)
+{
+  ll::MeasurementGateDecision gate;
+  gate.reject_measurement = reject_measurement;
+  gate.rejected_seed_update_applied = rejected_seed_update_applied;
+  return gate;
+}
+
+void test_accept_measurement_updates_pose_and_prediction()
+{
+  const auto decision = ll::decideLocalizationUpdate(make_gate(false, false));
+
+  assert(decision.action == ll::LocalizationUpdateAction::kAcceptMeasurement);
+  assert(decision.update_current_pose);
+  assert(decision.update_prediction_from_accepted_measurement);
+  assert(!decision.advance_prediction_without_measurement);
+  assert(!decision.update_prediction_from_rejected_measurement);
+  assert(decision.continue_to_pose_publish);
+}
+
+void test_rejected_measurement_advances_prediction_without_pose_publish()
+{
+  const auto decision = ll::decideLocalizationUpdate(make_gate(true, false));
+
+  assert(decision.action == ll::LocalizationUpdateAction::kAdvancePredictionWithoutMeasurement);
+  assert(!decision.update_current_pose);
+  assert(!decision.update_prediction_from_accepted_measurement);
+  assert(decision.advance_prediction_without_measurement);
+  assert(!decision.update_prediction_from_rejected_measurement);
+  assert(!decision.continue_to_pose_publish);
+}
+
+void test_rejected_seed_update_keeps_pose_publish_closed()
+{
+  const auto decision = ll::decideLocalizationUpdate(make_gate(true, true));
+
+  assert(decision.action == ll::LocalizationUpdateAction::kUpdatePredictionFromRejectedMeasurement);
+  assert(!decision.update_current_pose);
+  assert(!decision.update_prediction_from_accepted_measurement);
+  assert(!decision.advance_prediction_without_measurement);
+  assert(decision.update_prediction_from_rejected_measurement);
+  assert(!decision.continue_to_pose_publish);
+}
+
+int main()
+{
+  test_accept_measurement_updates_pose_and_prediction();
+  test_rejected_measurement_advances_prediction_without_pose_publish();
+  test_rejected_seed_update_keeps_pose_publish_closed();
+  return 0;
+}

--- a/test/test_map_initialization_policy.cpp
+++ b/test/test_map_initialization_policy.cpp
@@ -1,0 +1,101 @@
+#include "lidar_localization/map_initialization_policy.hpp"
+
+#include <cassert>
+#include <cstddef>
+
+#include <pcl/conversions.h>
+
+namespace ll = lidar_localization;
+
+pcl::PointXYZI make_point(float x, float y, float z = 0.0f)
+{
+  pcl::PointXYZI point;
+  point.x = x;
+  point.y = y;
+  point.z = z;
+  point.intensity = 1.0f;
+  return point;
+}
+
+void test_map_file_format_detection_matches_existing_path_matching()
+{
+  assert(ll::detectMapFileFormat("/maps/site.pcd") == ll::MapFileFormat::kPcd);
+  assert(ll::detectMapFileFormat("/maps/site.ply") == ll::MapFileFormat::kPly);
+  assert(ll::detectMapFileFormat("/maps/site.pcd.backup") == ll::MapFileFormat::kPcd);
+  assert(ll::detectMapFileFormat("/maps/site.bin") == ll::MapFileFormat::kUnsupported);
+}
+
+void test_compute_map_bounds()
+{
+  pcl::PointCloud<pcl::PointXYZI> empty_cloud;
+  assert(!ll::computeMapBounds(empty_cloud).valid);
+
+  pcl::PointCloud<pcl::PointXYZI> cloud;
+  cloud.push_back(make_point(2.0f, -1.0f, 3.0f));
+  cloud.push_back(make_point(-4.0f, 5.0f, -2.0f));
+
+  const auto bounds = ll::computeMapBounds(cloud);
+  assert(bounds.valid);
+  assert(bounds.min_point.x == -4.0f);
+  assert(bounds.max_point.y == 5.0f);
+  assert(bounds.min_point.z == -2.0f);
+  assert(bounds.max_point.z == 3.0f);
+}
+
+void test_make_initial_map_message_sets_frame_and_preserves_points_without_downsample()
+{
+  pcl::PointCloud<pcl::PointXYZI> cloud;
+  cloud.push_back(make_point(0.0f, 0.0f));
+  cloud.push_back(make_point(1.0f, 0.0f));
+
+  pcl::PCLPointCloud2 raw_cloud;
+  pcl::toPCLPointCloud2(cloud, raw_cloud);
+
+  const auto msg = ll::makeInitialMapMessage(raw_cloud, "map", false, 0.5);
+  assert(msg.header.frame_id == "map");
+  assert(static_cast<std::size_t>(msg.width) * static_cast<std::size_t>(msg.height) == 2);
+}
+
+void test_make_initial_map_message_can_downsample()
+{
+  pcl::PointCloud<pcl::PointXYZI> cloud;
+  cloud.push_back(make_point(0.0f, 0.0f));
+  cloud.push_back(make_point(0.1f, 0.1f));
+  cloud.push_back(make_point(2.0f, 0.0f));
+
+  pcl::PCLPointCloud2 raw_cloud;
+  pcl::toPCLPointCloud2(cloud, raw_cloud);
+
+  const auto msg = ll::makeInitialMapMessage(raw_cloud, "map", true, 1.0);
+  assert(msg.header.frame_id == "map");
+  assert(static_cast<std::size_t>(msg.width) * static_cast<std::size_t>(msg.height) > 0);
+  assert(static_cast<std::size_t>(msg.width) * static_cast<std::size_t>(msg.height) <= 3);
+}
+
+void test_initial_map_target_setup_plan()
+{
+  auto plan = ll::planInitialMapTargetSetup(false, "NDT");
+  assert(!plan.use_local_map_crop);
+  assert(!plan.create_ndt_initializer);
+  assert(plan.set_full_map_as_registration_target);
+
+  plan = ll::planInitialMapTargetSetup(false, "GICP");
+  assert(plan.use_local_map_crop);
+  assert(plan.create_ndt_initializer);
+  assert(!plan.set_full_map_as_registration_target);
+
+  plan = ll::planInitialMapTargetSetup(true, "NDT");
+  assert(plan.use_local_map_crop);
+  assert(!plan.create_ndt_initializer);
+  assert(!plan.set_full_map_as_registration_target);
+}
+
+int main()
+{
+  test_map_file_format_detection_matches_existing_path_matching();
+  test_compute_map_bounds();
+  test_make_initial_map_message_sets_frame_and_preserves_points_without_downsample();
+  test_make_initial_map_message_can_downsample();
+  test_initial_map_target_setup_plan();
+  return 0;
+}

--- a/test/test_measurement_gate_policy.cpp
+++ b/test/test_measurement_gate_policy.cpp
@@ -1,0 +1,231 @@
+#include "lidar_localization/measurement_gate_policy.hpp"
+
+#include <cassert>
+#include <limits>
+#include <string>
+
+namespace ll = lidar_localization;
+
+ll::MeasurementGateParams default_params()
+{
+  ll::MeasurementGateParams params;
+  params.score_threshold = 10.0;
+  params.reject_above_score_threshold = true;
+  return params;
+}
+
+ll::MeasurementGateInput default_input()
+{
+  return ll::makeMeasurementGateInput(1.0, 0.0, 0.0, 0.0, 0.0, 0);
+}
+
+void test_param_and_input_builders_map_fields()
+{
+  ll::MeasurementGateParamConfig config;
+  config.score_threshold = 9.0;
+  config.reject_above_score_threshold = false;
+  config.enable_consistency_recovery_gate = true;
+  config.consistency_recovery_min_rejections = 4;
+  config.consistency_recovery_score_margin = 1.5;
+  config.consistency_recovery_max_translation_m = 0.2;
+  config.consistency_recovery_max_yaw_deg = 3.0;
+  config.enable_post_reject_strict_score_threshold = true;
+  config.post_reject_strict_min_rejections = 5;
+  config.post_reject_strict_score_threshold = 7.0;
+  config.enable_open_loop_strict_score_threshold = true;
+  config.open_loop_strict_min_accepted_gap_sec = 6.0;
+  config.open_loop_strict_min_seed_translation_m = 2.5;
+  config.open_loop_strict_score_threshold = 6.5;
+  config.enable_borderline_seed_rejection_gate = true;
+  config.borderline_seed_gate_score_threshold = 6.25;
+  config.borderline_seed_gate_min_seed_translation_m = 1.25;
+  config.enable_rejected_seed_update = true;
+  config.rejected_seed_update_min_rejections = 8;
+  config.rejected_seed_update_max_fitness = 10.5;
+  config.rejected_seed_update_max_correction_translation_m = 1.75;
+  config.rejected_seed_update_max_correction_yaw_deg = 2.25;
+
+  const auto params = ll::makeMeasurementGateParams(config);
+  assert(params.score_threshold == 9.0);
+  assert(!params.reject_above_score_threshold);
+  assert(params.enable_consistency_recovery_gate);
+  assert(params.consistency_recovery_min_rejections == 4);
+  assert(params.consistency_recovery_score_margin == 1.5);
+  assert(params.consistency_recovery_max_translation_m == 0.2);
+  assert(params.consistency_recovery_max_yaw_deg == 3.0);
+  assert(params.enable_post_reject_strict_score_threshold);
+  assert(params.post_reject_strict_min_rejections == 5);
+  assert(params.post_reject_strict_score_threshold == 7.0);
+  assert(params.enable_open_loop_strict_score_threshold);
+  assert(params.open_loop_strict_min_accepted_gap_sec == 6.0);
+  assert(params.open_loop_strict_min_seed_translation_m == 2.5);
+  assert(params.open_loop_strict_score_threshold == 6.5);
+  assert(params.enable_borderline_seed_rejection_gate);
+  assert(params.borderline_seed_gate_score_threshold == 6.25);
+  assert(params.borderline_seed_gate_min_seed_translation_m == 1.25);
+  assert(params.enable_rejected_seed_update);
+  assert(params.rejected_seed_update_min_rejections == 8);
+  assert(params.rejected_seed_update_max_fitness == 10.5);
+  assert(params.rejected_seed_update_max_correction_translation_m == 1.75);
+  assert(params.rejected_seed_update_max_correction_yaw_deg == 2.25);
+
+  const auto input = ll::makeMeasurementGateInput(1.0, 2.0, 3.0, 4.0, 5.0, 6);
+  assert(input.fitness_score == 1.0);
+  assert(input.accepted_gap_sec == 2.0);
+  assert(input.seed_translation_since_accept_m == 3.0);
+  assert(input.correction_translation_m == 4.0);
+  assert(input.correction_yaw_deg == 5.0);
+  assert(input.consecutive_rejected_updates == 6);
+}
+
+void test_default_ok_gate()
+{
+  const auto gate = ll::evaluateMeasurementGate(default_params(), default_input());
+  assert(gate.status_level == ll::kMeasurementGateOk);
+  assert(gate.status_message == "ok");
+  assert(!gate.reject_measurement);
+  assert(gate.effective_score_threshold == 10.0);
+
+  auto nan_input = default_input();
+  nan_input.fitness_score = std::numeric_limits<double>::quiet_NaN();
+  const auto nan_gate = ll::evaluateMeasurementGate(default_params(), nan_input);
+  assert(nan_gate.status_level == ll::kMeasurementGateOk);
+}
+
+void test_effective_threshold_uses_lowest_active_strict_threshold()
+{
+  auto params = default_params();
+  params.enable_post_reject_strict_score_threshold = true;
+  params.post_reject_strict_min_rejections = 3;
+  params.post_reject_strict_score_threshold = 8.0;
+  params.enable_open_loop_strict_score_threshold = true;
+  params.open_loop_strict_min_accepted_gap_sec = 5.0;
+  params.open_loop_strict_min_seed_translation_m = 2.0;
+  params.open_loop_strict_score_threshold = 6.0;
+
+  auto input = default_input();
+  input.consecutive_rejected_updates = 3;
+  input.accepted_gap_sec = 5.0;
+  input.seed_translation_since_accept_m = 2.0;
+
+  const auto threshold = ll::computeEffectiveScoreThreshold(params, input);
+  assert(threshold.post_reject_strict_active);
+  assert(threshold.open_loop_strict_active);
+  assert(threshold.effective_score_threshold == 6.0);
+}
+
+void test_threshold_rejection_messages()
+{
+  auto params = default_params();
+  auto input = default_input();
+  input.fitness_score = 11.0;
+
+  auto gate = ll::evaluateMeasurementGate(params, input);
+  assert(gate.status_level == ll::kMeasurementGateWarn);
+  assert(gate.reject_measurement);
+  assert(gate.status_message == "fitness_score_over_threshold_rejected");
+
+  params.reject_above_score_threshold = false;
+  gate = ll::evaluateMeasurementGate(params, input);
+  assert(gate.status_level == ll::kMeasurementGateWarn);
+  assert(!gate.reject_measurement);
+  assert(gate.status_message == "fitness_score_over_threshold");
+}
+
+void test_open_loop_and_post_reject_messages()
+{
+  auto params = default_params();
+  params.enable_open_loop_strict_score_threshold = true;
+  params.open_loop_strict_min_accepted_gap_sec = 5.0;
+  params.open_loop_strict_min_seed_translation_m = 2.0;
+  params.open_loop_strict_score_threshold = 6.0;
+
+  auto input = default_input();
+  input.accepted_gap_sec = 5.0;
+  input.seed_translation_since_accept_m = 2.0;
+  input.fitness_score = 7.0;
+
+  auto gate = ll::evaluateMeasurementGate(params, input);
+  assert(gate.open_loop_strict_active);
+  assert(gate.status_message == "fitness_score_over_open_loop_strict_threshold_rejected");
+
+  params.enable_post_reject_strict_score_threshold = true;
+  params.post_reject_strict_min_rejections = 2;
+  params.post_reject_strict_score_threshold = 5.0;
+  input.consecutive_rejected_updates = 2;
+  gate = ll::evaluateMeasurementGate(params, input);
+  assert(gate.post_reject_strict_active);
+  assert(gate.status_message == "fitness_score_over_post_reject_strict_threshold_rejected");
+}
+
+void test_borderline_seed_gate()
+{
+  auto params = default_params();
+  params.enable_borderline_seed_rejection_gate = true;
+  params.borderline_seed_gate_score_threshold = 8.0;
+  params.borderline_seed_gate_min_seed_translation_m = 1.0;
+
+  auto input = default_input();
+  input.fitness_score = 9.0;
+  input.seed_translation_since_accept_m = 1.0;
+
+  const auto gate = ll::evaluateMeasurementGate(params, input);
+  assert(gate.borderline_seed_gate_active);
+  assert(gate.reject_measurement);
+  assert(gate.status_message == "fitness_score_over_borderline_seed_gate_rejected");
+}
+
+void test_consistency_recovery_clears_rejection()
+{
+  auto params = default_params();
+  params.enable_consistency_recovery_gate = true;
+  params.consistency_recovery_min_rejections = 3;
+  params.consistency_recovery_score_margin = 2.0;
+  params.consistency_recovery_max_translation_m = 0.1;
+  params.consistency_recovery_max_yaw_deg = 1.0;
+
+  auto input = default_input();
+  input.fitness_score = 11.0;
+  input.consecutive_rejected_updates = 3;
+  input.correction_translation_m = 0.05;
+  input.correction_yaw_deg = 0.5;
+
+  const auto gate = ll::evaluateMeasurementGate(params, input);
+  assert(gate.status_level == ll::kMeasurementGateWarn);
+  assert(!gate.reject_measurement);
+  assert(gate.status_message == "fitness_score_over_threshold_consistency_recovered");
+}
+
+void test_rejected_seed_update_marks_rejection_for_prediction_update()
+{
+  auto params = default_params();
+  params.enable_rejected_seed_update = true;
+  params.rejected_seed_update_min_rejections = 2;
+  params.rejected_seed_update_max_fitness = 12.0;
+  params.rejected_seed_update_max_correction_translation_m = 1.0;
+  params.rejected_seed_update_max_correction_yaw_deg = 2.0;
+
+  auto input = default_input();
+  input.fitness_score = 11.0;
+  input.consecutive_rejected_updates = 2;
+  input.correction_translation_m = 0.5;
+  input.correction_yaw_deg = 1.0;
+
+  const auto gate = ll::evaluateMeasurementGate(params, input);
+  assert(gate.reject_measurement);
+  assert(gate.rejected_seed_update_applied);
+  assert(gate.status_message == "fitness_score_over_threshold_rejected_seeded");
+}
+
+int main()
+{
+  test_param_and_input_builders_map_fields();
+  test_default_ok_gate();
+  test_effective_threshold_uses_lowest_active_strict_threshold();
+  test_threshold_rejection_messages();
+  test_open_loop_and_post_reject_messages();
+  test_borderline_seed_gate();
+  test_consistency_recovery_clears_rejection();
+  test_rejected_seed_update_marks_rejection_for_prediction_update();
+  return 0;
+}

--- a/test/test_mid360_bringup_model.py
+++ b/test/test_mid360_bringup_model.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from lidar_localization_mid360.bringup_model import BringupCheckConfig
+from lidar_localization_mid360.bringup_model import BringupSnapshot
+from lidar_localization_mid360.bringup_model import FAIL
+from lidar_localization_mid360.bringup_model import OK
+from lidar_localization_mid360.bringup_model import WARN
+from lidar_localization_mid360.bringup_model import TopicStats
+from lidar_localization_mid360.bringup_model import build_tf_checks
+from lidar_localization_mid360.bringup_model import evaluate_snapshot
+from lidar_localization_mid360.bringup_model import exit_code
+from lidar_localization_mid360.bringup_model import topic_summary
+
+
+def marked_topic(frame_id="base_link", count=1):
+    topic = TopicStats()
+    for index in range(count):
+        topic.mark(frame_id, float(index), float(index))
+    return topic
+
+
+def snapshot(config, cloud, imu=None, pose=None, status=None, tf_available=None):
+    return BringupSnapshot(
+        cloud=cloud,
+        imu=imu if imu is not None else TopicStats(),
+        pose=pose if pose is not None else TopicStats(),
+        status=status if status is not None else TopicStats(),
+        tf_checks=build_tf_checks(config, tf_available or {}),
+    )
+
+
+class TestMid360BringupModel(unittest.TestCase):
+    def test_missing_cloud_is_hard_failure(self):
+        config = BringupCheckConfig()
+        results = evaluate_snapshot(config, snapshot(config, TopicStats()))
+
+        self.assertEqual(results[0].level, FAIL)
+        self.assertIn("/livox/points", results[0].message)
+        self.assertEqual(exit_code(results), 1)
+
+    def test_imu_is_optional_by_default(self):
+        config = BringupCheckConfig()
+        cloud = marked_topic("livox_frame")
+        cloud.has_xyz_fields = True
+        results = evaluate_snapshot(config, snapshot(config, cloud))
+
+        self.assertEqual(results[0].level, OK)
+        self.assertEqual(results[1].level, WARN)
+
+    def test_imu_can_be_required_for_strict_runs(self):
+        config = BringupCheckConfig(require_imu=True)
+        cloud = marked_topic("livox_frame")
+        cloud.has_xyz_fields = True
+        results = evaluate_snapshot(config, snapshot(config, cloud))
+
+        self.assertEqual(results[1].level, FAIL)
+
+    def test_map_to_odom_tf_can_be_warning_or_failure(self):
+        cloud = marked_topic("livox_frame")
+        cloud.has_xyz_fields = True
+        availability = {
+            "base_link <- livox_frame": True,
+            "odom <- base_link": True,
+            "map <- odom": False,
+        }
+
+        loose_config = BringupCheckConfig()
+        loose_results = evaluate_snapshot(
+            loose_config,
+            snapshot(loose_config, cloud, tf_available=availability),
+        )
+        self.assertIn(WARN, [result.level for result in loose_results])
+
+        strict_config = BringupCheckConfig(require_map_odom_tf=True)
+        strict_results = evaluate_snapshot(
+            strict_config,
+            snapshot(strict_config, cloud, tf_available=availability),
+        )
+        self.assertIn(FAIL, [result.level for result in strict_results])
+
+    def test_alignment_status_error_is_failure(self):
+        config = BringupCheckConfig()
+        cloud = marked_topic("livox_frame")
+        cloud.has_xyz_fields = True
+        status = marked_topic("base_link")
+        status.last_status_level = 2
+        status.last_status_message = "registration_not_converged"
+
+        results = evaluate_snapshot(config, snapshot(config, cloud, status=status))
+
+        self.assertIn(
+            "registration_not_converged",
+            [result.message for result in results if result.level == FAIL][-1],
+        )
+
+    def test_topic_rate_is_deterministic(self):
+        stats = marked_topic("livox_frame", count=3)
+
+        self.assertAlmostEqual(stats.hz(), 1.0)
+        self.assertIn("1.0 Hz", topic_summary("/livox/points", stats))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_ndt_initializer_policy.cpp
+++ b/test/test_ndt_initializer_policy.cpp
@@ -1,0 +1,65 @@
+#include "lidar_localization/ndt_initializer_policy.hpp"
+
+#include <cassert>
+
+namespace ll = lidar_localization;
+
+void test_initializer_runs_only_while_enabled_available_and_incomplete()
+{
+  assert(ll::shouldRunNdtInitializer({true, true, 0, 5}));
+  assert(!ll::shouldRunNdtInitializer({false, true, 0, 5}));
+  assert(!ll::shouldRunNdtInitializer({true, false, 0, 5}));
+  assert(!ll::shouldRunNdtInitializer({true, true, 5, 5}));
+  assert(!ll::shouldRunNdtInitializer({true, true, 0, 0}));
+}
+
+void test_non_converged_run_keeps_count_and_seed()
+{
+  const auto decision = ll::updateNdtInitializerProgress(
+    ll::NdtInitializerProgressInput{
+      ll::NdtInitializerRunInput{true, true, 2, 5},
+      false});
+
+  assert(decision.should_run);
+  assert(!decision.should_accept_refined_seed);
+  assert(decision.next_scan_count == 2);
+  assert(!decision.completed);
+  assert(!decision.should_reset_initializer);
+}
+
+void test_converged_run_accepts_seed_and_advances_count()
+{
+  const auto decision = ll::updateNdtInitializerProgress(
+    ll::NdtInitializerProgressInput{
+      ll::NdtInitializerRunInput{true, true, 2, 5},
+      true});
+
+  assert(decision.should_run);
+  assert(decision.should_accept_refined_seed);
+  assert(decision.next_scan_count == 3);
+  assert(!decision.completed);
+  assert(!decision.should_reset_initializer);
+}
+
+void test_last_required_scan_completes_initializer()
+{
+  const auto decision = ll::updateNdtInitializerProgress(
+    ll::NdtInitializerProgressInput{
+      ll::NdtInitializerRunInput{true, true, 4, 5},
+      true});
+
+  assert(decision.should_run);
+  assert(decision.should_accept_refined_seed);
+  assert(decision.next_scan_count == 5);
+  assert(decision.completed);
+  assert(decision.should_reset_initializer);
+}
+
+int main()
+{
+  test_initializer_runs_only_while_enabled_available_and_incomplete();
+  test_non_converged_run_keeps_count_and_seed();
+  test_converged_run_accepts_seed_and_advances_count();
+  test_last_required_scan_completes_initializer();
+  return 0;
+}

--- a/test/test_parameter_validation_policy.cpp
+++ b/test/test_parameter_validation_policy.cpp
@@ -1,0 +1,76 @@
+#include "lidar_localization/parameter_validation_policy.hpp"
+
+#include <cassert>
+#include <chrono>
+#include <limits>
+
+namespace ll = lidar_localization;
+
+void test_positive_int_parameter_keeps_valid_values()
+{
+  const auto value = ll::normalizePositiveIntParameter(3);
+  assert(value.value == 3);
+  assert(!value.was_adjusted);
+}
+
+void test_positive_int_parameter_uses_valid_fallback()
+{
+  const auto zero = ll::normalizePositiveIntParameter(0, 4);
+  assert(zero.value == 4);
+  assert(zero.was_adjusted);
+
+  const auto negative_fallback = ll::normalizePositiveIntParameter(-2, -10);
+  assert(negative_fallback.value == ll::kMinimumPositiveIntParameter);
+  assert(negative_fallback.was_adjusted);
+}
+
+void test_local_map_min_points_clamps_to_one()
+{
+  const auto valid = ll::normalizeLocalMapMinPoints(100);
+  assert(valid.value == 100);
+  assert(!valid.was_adjusted);
+
+  const auto invalid = ll::normalizeLocalMapMinPoints(0);
+  assert(invalid.value == 1);
+  assert(invalid.was_adjusted);
+}
+
+void test_positive_finite_double_parameter_rejects_invalid_values()
+{
+  const auto valid = ll::normalizePositiveFiniteDoubleParameter(20.0, 10.0);
+  assert(valid.value == 20.0);
+  assert(!valid.was_adjusted);
+
+  const auto zero = ll::normalizePositiveFiniteDoubleParameter(0.0, 5.0);
+  assert(zero.value == 5.0);
+  assert(zero.was_adjusted);
+
+  const auto nan = ll::normalizePositiveFiniteDoubleParameter(
+    std::numeric_limits<double>::quiet_NaN(), 5.0);
+  assert(nan.value == 5.0);
+  assert(nan.was_adjusted);
+
+  const auto invalid_fallback = ll::normalizePositiveFiniteDoubleParameter(
+    -1.0, std::numeric_limits<double>::infinity());
+  assert(invalid_fallback.value == ll::kDefaultPosePublishFrequencyHz);
+  assert(invalid_fallback.was_adjusted);
+}
+
+void test_pose_publish_period_uses_safe_frequency()
+{
+  const auto period_20hz = ll::posePublishPeriodFromFrequencyHz(20.0);
+  assert(period_20hz == std::chrono::nanoseconds(50000000));
+
+  const auto fallback_period = ll::posePublishPeriodFromFrequencyHz(0.0);
+  assert(fallback_period == std::chrono::nanoseconds(100000000));
+}
+
+int main()
+{
+  test_positive_int_parameter_keeps_valid_values();
+  test_positive_int_parameter_uses_valid_fallback();
+  test_local_map_min_points_clamps_to_one();
+  test_positive_finite_double_parameter_rejects_invalid_values();
+  test_pose_publish_period_uses_safe_frequency();
+  return 0;
+}

--- a/test/test_point_cloud_conversion.cpp
+++ b/test/test_point_cloud_conversion.cpp
@@ -1,0 +1,160 @@
+#include "lidar_localization/point_cloud_conversion.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace ll = lidar_localization;
+
+sensor_msgs::msg::PointField make_field(
+  const std::string & name,
+  uint32_t offset,
+  uint8_t datatype)
+{
+  sensor_msgs::msg::PointField field;
+  field.name = name;
+  field.offset = offset;
+  field.datatype = datatype;
+  field.count = 1;
+  return field;
+}
+
+template<typename T>
+void write_value(std::vector<uint8_t> & data, std::size_t offset, const T & value)
+{
+  std::memcpy(data.data() + offset, &value, sizeof(value));
+}
+
+sensor_msgs::msg::PointCloud2 make_sensor_cloud()
+{
+  sensor_msgs::msg::PointCloud2 cloud;
+  cloud.header.frame_id = "livox_frame";
+  cloud.height = 1;
+  cloud.width = 2;
+  cloud.is_dense = false;
+  cloud.point_step = 16;
+  cloud.row_step = cloud.point_step * cloud.width;
+  cloud.fields = {
+    make_field("x", 0, sensor_msgs::msg::PointField::FLOAT32),
+    make_field("y", 4, sensor_msgs::msg::PointField::FLOAT32),
+    make_field("z", 8, sensor_msgs::msg::PointField::FLOAT32),
+    make_field("intensity", 12, sensor_msgs::msg::PointField::UINT16)};
+  cloud.data.resize(cloud.row_step);
+
+  write_value<float>(cloud.data, 0, 1.0f);
+  write_value<float>(cloud.data, 4, 2.0f);
+  write_value<float>(cloud.data, 8, 3.0f);
+  write_value<uint16_t>(cloud.data, 12, 42);
+
+  write_value<float>(cloud.data, 16, -1.0f);
+  write_value<float>(cloud.data, 20, -2.0f);
+  write_value<float>(cloud.data, 24, 0.5f);
+  write_value<uint16_t>(cloud.data, 28, 7);
+  return cloud;
+}
+
+void test_field_lookup_and_numeric_conversion()
+{
+  const auto cloud = make_sensor_cloud();
+  assert(ll::hasPointField(cloud.fields, "intensity"));
+  assert(!ll::hasPointField(cloud.fields, "ring"));
+  assert(ll::findPointField(cloud.fields, "x") != nullptr);
+  assert(ll::findPointField(cloud.fields, "ring") == nullptr);
+
+  float value = 0.0f;
+  assert(ll::readPointFieldAsFloat(cloud.data.data(), *ll::findPointField(cloud.fields, "x"), &value));
+  assert(std::abs(value - 1.0f) < 1.0e-6f);
+  assert(ll::readPointFieldAsFloat(
+    cloud.data.data(), *ll::findPointField(cloud.fields, "intensity"), &value));
+  assert(std::abs(value - 42.0f) < 1.0e-6f);
+
+  auto unsupported = make_field("unsupported", 0, 255);
+  assert(!ll::readPointFieldAsFloat(cloud.data.data(), unsupported, &value));
+}
+
+void test_sensor_cloud_to_xyzi_uses_intensity_when_available()
+{
+  const auto cloud = make_sensor_cloud();
+  pcl::PointCloud<pcl::PointXYZI> output;
+  ll::convertSensorCloudToXyzi(cloud, output);
+
+  assert(output.size() == 2);
+  assert(std::abs(output[0].x - 1.0f) < 1.0e-6f);
+  assert(std::abs(output[0].intensity - 42.0f) < 1.0e-6f);
+  assert(std::abs(output[1].y + 2.0f) < 1.0e-6f);
+  assert(std::abs(output[1].intensity - 7.0f) < 1.0e-6f);
+  assert(output.is_dense == cloud.is_dense);
+}
+
+void test_sensor_cloud_to_xyzi_falls_back_to_zero_intensity()
+{
+  auto cloud = make_sensor_cloud();
+  cloud.fields.pop_back();
+
+  pcl::PointCloud<pcl::PointXYZI> output;
+  ll::convertSensorCloudToXyzi(cloud, output);
+
+  assert(output.size() == 2);
+  assert(output[0].intensity == 0.0f);
+  assert(output[1].intensity == 0.0f);
+}
+
+void test_sensor_cloud_to_xyzi_clears_output_when_xyz_missing()
+{
+  auto cloud = make_sensor_cloud();
+  cloud.fields.erase(cloud.fields.begin() + 2);
+
+  pcl::PointCloud<pcl::PointXYZI> output;
+  output.push_back(pcl::PointXYZI{});
+  ll::convertSensorCloudToXyzi(cloud, output);
+
+  assert(output.empty());
+  assert(output.width == 0);
+  assert(output.height == 1);
+  assert(!output.is_dense);
+}
+
+void test_pcl_cloud_to_xyzi_detects_or_synthesizes_intensity()
+{
+  pcl::PointCloud<pcl::PointXYZI> xyzi_cloud;
+  xyzi_cloud.width = 1;
+  xyzi_cloud.height = 1;
+  xyzi_cloud.points.resize(1);
+  xyzi_cloud[0].x = 1.0f;
+  xyzi_cloud[0].intensity = 9.0f;
+  pcl::PCLPointCloud2 xyzi_raw;
+  pcl::toPCLPointCloud2(xyzi_cloud, xyzi_raw);
+
+  pcl::PointCloud<pcl::PointXYZI> converted_xyzi;
+  assert(ll::convertPclCloudToXyzi(xyzi_raw, converted_xyzi));
+  assert(converted_xyzi.size() == 1);
+  assert(std::abs(converted_xyzi[0].intensity - 9.0f) < 1.0e-6f);
+
+  pcl::PointCloud<pcl::PointXYZ> xyz_cloud;
+  xyz_cloud.width = 1;
+  xyz_cloud.height = 1;
+  xyz_cloud.points.resize(1);
+  xyz_cloud[0].x = 2.0f;
+  xyz_cloud[0].y = 3.0f;
+  xyz_cloud[0].z = 4.0f;
+  pcl::PCLPointCloud2 xyz_raw;
+  pcl::toPCLPointCloud2(xyz_cloud, xyz_raw);
+
+  pcl::PointCloud<pcl::PointXYZI> converted_xyz;
+  assert(!ll::convertPclCloudToXyzi(xyz_raw, converted_xyz));
+  assert(converted_xyz.size() == 1);
+  assert(std::abs(converted_xyz[0].x - 2.0f) < 1.0e-6f);
+  assert(converted_xyz[0].intensity == 0.0f);
+}
+
+int main()
+{
+  test_field_lookup_and_numeric_conversion();
+  test_sensor_cloud_to_xyzi_uses_intensity_when_available();
+  test_sensor_cloud_to_xyzi_falls_back_to_zero_intensity();
+  test_sensor_cloud_to_xyzi_clears_output_when_xyz_missing();
+  test_pcl_cloud_to_xyzi_detects_or_synthesizes_intensity();
+  return 0;
+}

--- a/test/test_pose_backend_result_policy.cpp
+++ b/test/test_pose_backend_result_policy.cpp
@@ -1,0 +1,131 @@
+#include "lidar_localization/pose_backend_result_policy.hpp"
+
+#include <cassert>
+
+namespace ll = lidar_localization;
+
+Eigen::Matrix4f pose_x(float x)
+{
+  Eigen::Matrix4f pose = Eigen::Matrix4f::Identity();
+  pose(0, 3) = x;
+  return pose;
+}
+
+void test_pose_backend_result_carries_pose_and_status()
+{
+  const auto result = ll::makePoseBackendResult(pose_x(3.0f), 0, "ok");
+
+  assert(result.pose_matrix(0, 3) == 3.0f);
+  assert(result.status_level == 0);
+  assert(result.status_message == "ok");
+  assert(result.update_current_pose);
+  assert(result.update_prediction_state);
+  assert(!result.advance_prediction_without_measurement);
+  assert(!result.update_prediction_from_rejected_measurement);
+  assert(result.fill_pose_covariance);
+  assert(result.continue_to_pose_publish);
+}
+
+void test_backend_update_failure_overrides_status_only()
+{
+  const auto result = ll::applyPoseBackendUpdateStatus(
+    ll::makePoseBackendResult(pose_x(5.0f), 0, "ok"),
+    false,
+    1,
+    "backend_update_rejected");
+
+  assert(result.pose_matrix(0, 3) == 5.0f);
+  assert(result.status_level == 1);
+  assert(result.status_message == "backend_update_rejected");
+  assert(result.update_current_pose);
+  assert(result.update_prediction_state);
+}
+
+void test_backend_update_success_preserves_existing_status()
+{
+  const auto result = ll::applyPoseBackendUpdateStatus(
+    ll::makePoseBackendResult(pose_x(7.0f), 2, "upstream_warning"),
+    true,
+    1,
+    "backend_update_rejected");
+
+  assert(result.pose_matrix(0, 3) == 7.0f);
+  assert(result.status_level == 2);
+  assert(result.status_message == "upstream_warning");
+}
+
+void test_warning_status_applies_only_when_requested()
+{
+  auto result = ll::applyPoseBackendWarningStatus(
+    ll::makePoseBackendResult(pose_x(1.0f), 0, "ok"),
+    false,
+    1,
+    "warning");
+  assert(result.status_level == 0);
+  assert(result.status_message == "ok");
+
+  result = ll::applyPoseBackendWarningStatus(result, true, 1, "warning");
+  assert(result.status_level == 1);
+  assert(result.status_message == "warning");
+}
+
+void test_localization_accept_maps_to_pose_backend_result()
+{
+  const auto result = ll::makePoseBackendResultFromLocalizationUpdate(
+    pose_x(2.0f),
+    0,
+    "ok",
+    ll::makeAcceptedLocalizationUpdateDecision());
+
+  assert(result.pose_matrix(0, 3) == 2.0f);
+  assert(result.update_current_pose);
+  assert(result.update_prediction_state);
+  assert(!result.advance_prediction_without_measurement);
+  assert(!result.update_prediction_from_rejected_measurement);
+  assert(result.fill_pose_covariance);
+  assert(result.continue_to_pose_publish);
+}
+
+void test_localization_reject_maps_to_prediction_advance_result()
+{
+  const auto result = ll::makePoseBackendResultFromLocalizationUpdate(
+    pose_x(4.0f),
+    1,
+    "fitness_score_over_threshold_rejected",
+    ll::makePredictionAdvanceLocalizationUpdateDecision());
+
+  assert(!result.update_current_pose);
+  assert(!result.update_prediction_state);
+  assert(result.advance_prediction_without_measurement);
+  assert(!result.update_prediction_from_rejected_measurement);
+  assert(!result.fill_pose_covariance);
+  assert(!result.continue_to_pose_publish);
+}
+
+void test_localization_rejected_seed_maps_to_prediction_update_result()
+{
+  const auto result = ll::makePoseBackendResultFromLocalizationUpdate(
+    pose_x(6.0f),
+    1,
+    "fitness_score_over_threshold_rejected",
+    ll::makeRejectedSeedLocalizationUpdateDecision());
+
+  assert(!result.update_current_pose);
+  assert(!result.update_prediction_state);
+  assert(!result.advance_prediction_without_measurement);
+  assert(result.update_prediction_from_rejected_measurement);
+  assert(!result.fill_pose_covariance);
+  assert(!result.continue_to_pose_publish);
+}
+
+int main()
+{
+  test_pose_backend_result_carries_pose_and_status();
+  test_backend_update_failure_overrides_status_only();
+  test_backend_update_success_preserves_existing_status();
+  test_warning_status_applies_only_when_requested();
+  test_localization_accept_maps_to_pose_backend_result();
+  test_localization_reject_maps_to_prediction_advance_result();
+  test_localization_rejected_seed_maps_to_prediction_update_result();
+  return 0;
+}

--- a/test/test_pose_backend_selection_policy.cpp
+++ b/test/test_pose_backend_selection_policy.cpp
@@ -1,0 +1,57 @@
+#include "lidar_localization/pose_backend_selection_policy.hpp"
+
+#include <cassert>
+
+namespace ll = lidar_localization;
+
+void test_raw_registration_is_default_backend()
+{
+  const auto selected = ll::selectPoseBackend({});
+
+  assert(selected == ll::PoseBackendKind::kRawRegistration);
+}
+
+void test_twist_ekf_selected_when_only_twist_enabled()
+{
+  ll::PoseBackendSelectionInput input;
+  input.use_twist_ekf = true;
+
+  const auto selected = ll::selectPoseBackend(input);
+
+  assert(selected == ll::PoseBackendKind::kTwistEkf);
+}
+
+void test_imu_requires_stamp_before_it_can_win()
+{
+  ll::PoseBackendSelectionInput input;
+  input.use_imu_preintegration = true;
+  input.use_twist_ekf = true;
+  input.has_imu_stamp = false;
+
+  assert(ll::selectPoseBackend(input) == ll::PoseBackendKind::kTwistEkf);
+
+  input.has_imu_stamp = true;
+  assert(ll::selectPoseBackend(input) == ll::PoseBackendKind::kImuPreintegration);
+}
+
+void test_gtsam_has_highest_priority()
+{
+  ll::PoseBackendSelectionInput input;
+  input.use_gtsam_smoother = true;
+  input.use_imu_preintegration = true;
+  input.has_imu_stamp = true;
+  input.use_twist_ekf = true;
+
+  const auto selected = ll::selectPoseBackend(input);
+
+  assert(selected == ll::PoseBackendKind::kGtsamSmoother);
+}
+
+int main()
+{
+  test_raw_registration_is_default_backend();
+  test_twist_ekf_selected_when_only_twist_enabled();
+  test_imu_requires_stamp_before_it_can_win();
+  test_gtsam_has_highest_priority();
+  return 0;
+}

--- a/test/test_pose_covariance_policy.cpp
+++ b/test/test_pose_covariance_policy.cpp
@@ -1,0 +1,76 @@
+#include "lidar_localization/pose_covariance_policy.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <limits>
+
+namespace ll = lidar_localization;
+
+bool near(double lhs, double rhs)
+{
+  return std::abs(lhs - rhs) < 1.0e-12;
+}
+
+void test_fitness_covariance_uses_fitness_floor()
+{
+  const auto covariance = ll::makeFitnessPoseCovariance(0.2);
+
+  assert(near(covariance[0], 0.01));
+  assert(near(covariance[7], 0.01));
+  assert(near(covariance[14], 0.05));
+  assert(near(covariance[21], 0.001));
+  assert(near(covariance[28], 0.001));
+  assert(near(covariance[35], 0.0005));
+}
+
+void test_fitness_covariance_scales_pose_axes()
+{
+  const auto covariance = ll::makeFitnessPoseCovariance(3.0);
+
+  assert(near(covariance[0], 0.03));
+  assert(near(covariance[7], 0.03));
+  assert(near(covariance[14], 0.15));
+  assert(near(covariance[21], 0.003));
+  assert(near(covariance[28], 0.003));
+  assert(near(covariance[35], 0.0015));
+}
+
+void test_ekf_covariance_maps_estimated_terms()
+{
+  ll::EkfStateCovariance ekf_covariance = ll::EkfStateCovariance::Zero();
+  ekf_covariance(0, 0) = 1.0;
+  ekf_covariance(0, 1) = 0.2;
+  ekf_covariance(1, 0) = 0.3;
+  ekf_covariance(1, 1) = 2.0;
+  ekf_covariance(2, 2) = 3.0;
+  ekf_covariance(6, 6) = 4.0;
+
+  const auto covariance = ll::makeEkfPoseCovariance(ekf_covariance, 5.0);
+
+  assert(near(covariance[0], 1.0));
+  assert(near(covariance[1], 0.2));
+  assert(near(covariance[6], 0.3));
+  assert(near(covariance[7], 2.0));
+  assert(near(covariance[14], 3.0));
+  assert(near(covariance[35], 4.0));
+  assert(near(covariance[21], 0.005));
+  assert(near(covariance[28], 0.005));
+}
+
+void test_nan_fitness_uses_floor_like_previous_std_max_behavior()
+{
+  const auto covariance =
+    ll::makeFitnessPoseCovariance(std::numeric_limits<double>::quiet_NaN());
+
+  assert(near(covariance[0], 0.01));
+  assert(near(covariance[35], 0.0005));
+}
+
+int main()
+{
+  test_fitness_covariance_uses_fitness_floor();
+  test_fitness_covariance_scales_pose_axes();
+  test_ekf_covariance_maps_estimated_terms();
+  test_nan_fitness_uses_floor_like_previous_std_max_behavior();
+  return 0;
+}

--- a/test/test_pose_publish_policy.cpp
+++ b/test/test_pose_publish_policy.cpp
@@ -1,0 +1,111 @@
+#include "lidar_localization/pose_publish_policy.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <string>
+
+namespace ll = lidar_localization;
+
+builtin_interfaces::msg::Time stamp(int32_t sec, uint32_t nanosec = 0)
+{
+  builtin_interfaces::msg::Time time;
+  time.sec = sec;
+  time.nanosec = nanosec;
+  return time;
+}
+
+geometry_msgs::msg::Pose pose_xyz(double x, double y, double z)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = x;
+  pose.position.y = y;
+  pose.position.z = z;
+  pose.orientation.w = 1.0;
+  return pose;
+}
+
+bool near(double lhs, double rhs)
+{
+  return std::abs(lhs - rhs) < 1.0e-9;
+}
+
+void test_pose_from_matrix()
+{
+  Eigen::Matrix4f matrix = Eigen::Matrix4f::Identity();
+  matrix(0, 3) = 1.0f;
+  matrix(1, 3) = 2.0f;
+  matrix(2, 3) = 3.0f;
+
+  const auto pose = ll::poseFromMatrix(matrix);
+  assert(near(pose.position.x, 1.0));
+  assert(near(pose.position.y, 2.0));
+  assert(near(pose.position.z, 3.0));
+  assert(near(pose.orientation.w, 1.0));
+}
+
+void test_pose_stamped_and_path_append()
+{
+  nav_msgs::msg::Path path;
+  path.header.frame_id = "map";
+  const auto pose = pose_xyz(1.0, 2.0, 3.0);
+  const auto pose_stamped = ll::makePoseStamped(stamp(10, 20), "map", pose);
+
+  assert(pose_stamped.header.stamp.sec == 10);
+  assert(pose_stamped.header.stamp.nanosec == 20);
+  assert(pose_stamped.header.frame_id == "map");
+  assert(near(pose_stamped.pose.position.y, 2.0));
+
+  ll::appendPoseToPath(path, pose_stamped);
+  assert(path.poses.size() == 1);
+  assert(path.poses[0].header.stamp.sec == 10);
+}
+
+void test_stamp_pose_with_covariance()
+{
+  geometry_msgs::msg::PoseWithCovarianceStamped pose;
+  pose.header.frame_id = "map";
+  pose.header.stamp.sec = 1;
+  pose.pose.pose = pose_xyz(1.0, 2.0, 3.0);
+
+  const auto stamped = ll::stampPoseWithCovariance(pose, stamp(5));
+  assert(stamped.header.frame_id == "map");
+  assert(stamped.header.stamp.sec == 5);
+  assert(near(stamped.pose.pose.position.x, 1.0));
+}
+
+void test_map_to_base_transform()
+{
+  const auto transform = ll::makeMapToBaseTransform(
+    stamp(2), "map", "base_link", pose_xyz(4.0, 5.0, 6.0));
+
+  assert(transform.header.stamp.sec == 2);
+  assert(transform.header.frame_id == "map");
+  assert(transform.child_frame_id == "base_link");
+  assert(near(transform.transform.translation.x, 4.0));
+  assert(near(transform.transform.rotation.w, 1.0));
+}
+
+void test_compose_map_to_odom_transform()
+{
+  const auto map_to_base = ll::makeMapToBaseTransform(
+    stamp(3), "map", "base_link", pose_xyz(10.0, 0.0, 0.0));
+  const auto odom_to_base = ll::makeMapToBaseTransform(
+    stamp(3), "odom", "base_link", pose_xyz(4.0, 0.0, 0.0));
+
+  const auto map_to_odom = ll::composeMapToOdomTransform(
+    stamp(3), "map", "odom", map_to_base, odom_to_base);
+  assert(map_to_odom.header.frame_id == "map");
+  assert(map_to_odom.child_frame_id == "odom");
+  assert(near(map_to_odom.transform.translation.x, 6.0));
+  assert(near(map_to_odom.transform.rotation.w, 1.0));
+}
+
+int main()
+{
+  test_pose_from_matrix();
+  test_pose_stamped_and_path_append();
+  test_stamp_pose_with_covariance();
+  test_map_to_base_transform();
+  test_compose_map_to_odom_transform();
+  return 0;
+}

--- a/test/test_prediction_state_policy.cpp
+++ b/test/test_prediction_state_policy.cpp
@@ -1,0 +1,139 @@
+#include "lidar_localization/prediction_state_policy.hpp"
+
+#include <cassert>
+#include <cmath>
+
+namespace ll = lidar_localization;
+
+Eigen::Matrix4f pose_x(float x)
+{
+  Eigen::Matrix4f pose = Eigen::Matrix4f::Identity();
+  pose(0, 3) = x;
+  return pose;
+}
+
+bool near(float lhs, float rhs)
+{
+  return std::abs(lhs - rhs) < 1.0e-5f;
+}
+
+void test_reset_prediction_state()
+{
+  const auto pose = pose_x(3.0f);
+  const auto state = ll::resetPredictionState(pose, 10.0);
+
+  assert(state.have_last_accepted_pose);
+  assert(near(state.last_accepted_pose_matrix(0, 3), 3.0f));
+  assert(near(state.predicted_pose_matrix(0, 3), 3.0f));
+  assert(state.last_relative_motion_matrix.isApprox(Eigen::Matrix4f::Identity()));
+  assert(state.consecutive_rejected_updates == 0);
+  assert(state.last_accepted_pose_time_sec == 10.0);
+  assert(state.predicted_pose_time_sec == 10.0);
+}
+
+void test_accepted_measurement_initializes_when_empty()
+{
+  ll::PredictionStateSnapshot empty;
+  const auto state =
+    ll::updatePredictionStateFromAcceptedMeasurement(empty, pose_x(2.0f), 5.0);
+
+  assert(state.have_last_accepted_pose);
+  assert(near(state.last_accepted_pose_matrix(0, 3), 2.0f));
+  assert(near(state.predicted_pose_matrix(0, 3), 2.0f));
+}
+
+void test_accepted_measurement_updates_relative_motion_without_reject_streak()
+{
+  auto state = ll::resetPredictionState(pose_x(1.0f), 1.0);
+  state = ll::updatePredictionStateFromAcceptedMeasurement(state, pose_x(3.0f), 2.0);
+
+  assert(near(state.last_relative_motion_matrix(0, 3), 2.0f));
+  assert(near(state.last_accepted_pose_matrix(0, 3), 3.0f));
+  assert(near(state.predicted_pose_matrix(0, 3), 5.0f));
+  assert(state.consecutive_rejected_updates == 0);
+  assert(state.last_accepted_pose_time_sec == 2.0);
+  assert(state.predicted_pose_time_sec == 2.0);
+}
+
+void test_accepted_measurement_preserves_relative_motion_after_reject_streak()
+{
+  auto state = ll::resetPredictionState(pose_x(1.0f), 1.0);
+  state.last_relative_motion_matrix = pose_x(0.5f);
+  state.consecutive_rejected_updates = 3;
+
+  state = ll::updatePredictionStateFromAcceptedMeasurement(state, pose_x(3.0f), 2.0);
+
+  assert(near(state.last_relative_motion_matrix(0, 3), 0.5f));
+  assert(near(state.predicted_pose_matrix(0, 3), 3.5f));
+  assert(state.consecutive_rejected_updates == 0);
+}
+
+void test_choose_prediction_advance_mode()
+{
+  assert(
+    ll::choosePredictionAdvanceMode(false, true, true, true) ==
+    ll::PredictionAdvanceMode::kNone);
+  assert(
+    ll::choosePredictionAdvanceMode(true, true, true, true) ==
+    ll::PredictionAdvanceMode::kTwistPrediction);
+  assert(
+    ll::choosePredictionAdvanceMode(true, true, false, true) ==
+    ll::PredictionAdvanceMode::kPreviousDelta);
+  assert(
+    ll::choosePredictionAdvanceMode(true, false, false, false) ==
+    ll::PredictionAdvanceMode::kNone);
+}
+
+void test_advance_prediction_without_measurement()
+{
+  auto state = ll::resetPredictionState(pose_x(1.0f), 1.0);
+  state.predicted_pose_matrix = pose_x(3.0f);
+  state.last_relative_motion_matrix = pose_x(2.0f);
+
+  auto advanced = ll::advancePredictionWithoutMeasurement(
+    state, 2.0, ll::PredictionAdvanceMode::kPreviousDelta);
+  assert(near(advanced.predicted_pose_matrix(0, 3), 5.0f));
+  assert(advanced.predicted_pose_time_sec == 2.0);
+  assert(advanced.consecutive_rejected_updates == 1);
+
+  advanced = ll::advancePredictionWithoutMeasurement(
+    state, 3.0, ll::PredictionAdvanceMode::kTwistPrediction, pose_x(7.0f));
+  assert(near(advanced.predicted_pose_matrix(0, 3), 7.0f));
+  assert(advanced.predicted_pose_time_sec == 3.0);
+  assert(advanced.consecutive_rejected_updates == 1);
+
+  const auto unchanged = ll::advancePredictionWithoutMeasurement(
+    state, 4.0, ll::PredictionAdvanceMode::kNone);
+  assert(near(unchanged.predicted_pose_matrix(0, 3), 3.0f));
+  assert(unchanged.consecutive_rejected_updates == 0);
+}
+
+void test_rejected_measurement_updates_prediction_only()
+{
+  auto state = ll::resetPredictionState(pose_x(1.0f), 1.0);
+  state.last_relative_motion_matrix = pose_x(0.25f);
+
+  const auto updated = ll::updatePredictionFromRejectedMeasurement(state, pose_x(4.0f), 2.0);
+  assert(near(updated.last_accepted_pose_matrix(0, 3), 1.0f));
+  assert(near(updated.predicted_pose_matrix(0, 3), 4.0f));
+  assert(near(updated.last_relative_motion_matrix(0, 3), 0.25f));
+  assert(updated.predicted_pose_time_sec == 2.0);
+  assert(updated.consecutive_rejected_updates == 1);
+
+  ll::PredictionStateSnapshot empty;
+  const auto unchanged = ll::updatePredictionFromRejectedMeasurement(empty, pose_x(9.0f), 3.0);
+  assert(!unchanged.have_last_accepted_pose);
+  assert(near(unchanged.predicted_pose_matrix(0, 3), 0.0f));
+}
+
+int main()
+{
+  test_reset_prediction_state();
+  test_accepted_measurement_initializes_when_empty();
+  test_accepted_measurement_updates_relative_motion_without_reject_streak();
+  test_accepted_measurement_preserves_relative_motion_after_reject_streak();
+  test_choose_prediction_advance_mode();
+  test_advance_prediction_without_measurement();
+  test_rejected_measurement_updates_prediction_only();
+  return 0;
+}

--- a/test/test_recovery_supervisor.cpp
+++ b/test/test_recovery_supervisor.cpp
@@ -1,0 +1,146 @@
+#include "lidar_localization/recovery_supervisor.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <string>
+
+namespace ll = lidar_localization;
+
+void test_reinitialization_builders_map_fields()
+{
+  const auto params = ll::makeReinitializationTriggerParams(0.8, 10.0, 20.0, 30.0, 40.0);
+  assert(params.threshold == 0.8);
+  assert(params.gap_scale_sec == 10.0);
+  assert(params.seed_translation_scale_m == 20.0);
+  assert(params.reject_streak_scale == 30.0);
+  assert(params.fitness_explosion_threshold == 40.0);
+
+  const auto input = ll::makeReinitializationTriggerInput("registration_not_converged",
+      1.0, 2.0, 3.0, 4);
+  assert(input.status_message == "registration_not_converged");
+  assert(input.fitness_score == 1.0);
+  assert(input.seed_translation_since_accept_m == 2.0);
+  assert(input.accepted_gap_sec == 3.0);
+  assert(input.consecutive_rejected_updates == 4);
+}
+
+void test_non_failure_does_not_request_reinitialization()
+{
+  const auto decision = ll::computeReinitializationRequest(
+    ll::ReinitializationTriggerParams{},
+    ll::ReinitializationTriggerInput{
+      "ok",
+      1.0,
+      0.0,
+      0.0,
+      0});
+
+  assert(!decision.requested);
+  assert(decision.reason == "not_failure");
+  assert(decision.score == 0.0);
+}
+
+void test_target_unavailable_can_request_reinitialization()
+{
+  const auto decision = ll::computeReinitializationRequest(
+    ll::ReinitializationTriggerParams{},
+    ll::ReinitializationTriggerInput{
+      "local_map_crop_too_small",
+      std::numeric_limits<double>::quiet_NaN(),
+      100.0,
+      30.0,
+      200});
+
+  assert(decision.requested);
+  assert(decision.reason == "target_unavailable_reinit_requested");
+  assert(decision.score >= 0.95);
+}
+
+void test_fitness_explosion_reason_wins_for_rejected_measurement()
+{
+  const auto decision = ll::computeReinitializationRequest(
+    ll::ReinitializationTriggerParams{},
+    ll::ReinitializationTriggerInput{
+      "fitness_score_over_6_rejected",
+      1000.0,
+      100.0,
+      30.0,
+      200});
+
+  assert(decision.requested);
+  assert(decision.reason == "fitness_exploded_reinit_requested");
+}
+
+void test_recovery_state_and_action_classification()
+{
+  const ll::ReinitializationRequestDecision no_request{};
+  const ll::ReinitializationRequestDecision request{true, "test", 1.0};
+
+  assert(
+    ll::classifyRecoverySupervisorState(0, "ok", no_request, 0) ==
+    ll::RecoverySupervisorState::kTracking);
+  assert(
+    ll::classifyRecoverySupervisorState(1, "ok", no_request, 0) ==
+    ll::RecoverySupervisorState::kDegraded);
+  assert(
+    ll::classifyRecoverySupervisorState(0, "registration_not_converged", no_request, 0) ==
+    ll::RecoverySupervisorState::kRecovering);
+  assert(
+    ll::classifyRecoverySupervisorState(0, "ok", request, 0) ==
+    ll::RecoverySupervisorState::kReinitializationRequested);
+
+  assert(
+    ll::classifyRecoverySupervisorAction(0, "fitness_score_over_6_rejected", no_request, 0) ==
+    "reject_measurement");
+  assert(
+    ll::classifyRecoverySupervisorAction(0, "fitness_score_over_6_rejected_seeded", no_request, 0) ==
+    "reuse_rejected_seed_for_prediction");
+  assert(
+    ll::classifyRecoverySupervisorAction(0, "ok", no_request, 1) ==
+    "accept_measurement_after_recovery");
+  assert(
+    ll::classifyRecoverySupervisorAction(0, "ok", request, 0) ==
+    "request_reinitialization");
+}
+
+void test_recovery_supervisor_evaluator_pairs_state_and_action()
+{
+  const ll::ReinitializationRequestDecision no_request{};
+  const ll::ReinitializationRequestDecision request{true, "test", 1.0};
+
+  auto evaluation = ll::evaluateRecoverySupervisor(
+    0, "fitness_score_over_6_rejected", no_request, 2);
+  assert(evaluation.state == ll::RecoverySupervisorState::kRecovering);
+  assert(evaluation.action == "reject_measurement");
+
+  evaluation = ll::evaluateRecoverySupervisor(0, "ok", request, 0);
+  assert(evaluation.state == ll::RecoverySupervisorState::kReinitializationRequested);
+  assert(evaluation.action == "request_reinitialization");
+}
+
+void test_state_names_are_stable_diagnostic_contract()
+{
+  assert(std::string(ll::recoverySupervisorStateName(ll::RecoverySupervisorState::kTracking)) ==
+    "tracking");
+  assert(std::string(ll::recoverySupervisorStateName(ll::RecoverySupervisorState::kDegraded)) ==
+    "degraded");
+  assert(std::string(ll::recoverySupervisorStateName(ll::RecoverySupervisorState::kRecovering)) ==
+    "recovering");
+  assert(
+    std::string(
+      ll::recoverySupervisorStateName(ll::RecoverySupervisorState::kReinitializationRequested)) ==
+    "reinitialization_requested");
+}
+
+int main()
+{
+  test_reinitialization_builders_map_fields();
+  test_non_failure_does_not_request_reinitialization();
+  test_target_unavailable_can_request_reinitialization();
+  test_fitness_explosion_reason_wins_for_rejected_measurement();
+  test_recovery_state_and_action_classification();
+  test_recovery_supervisor_evaluator_pairs_state_and_action();
+  test_state_names_are_stable_diagnostic_contract();
+  return 0;
+}

--- a/test/test_recovery_supervisor_state_policy.cpp
+++ b/test/test_recovery_supervisor_state_policy.cpp
@@ -1,0 +1,78 @@
+#include "lidar_localization/recovery_supervisor_state_policy.hpp"
+
+#include <cassert>
+#include <cmath>
+
+namespace ll = lidar_localization;
+
+bool near(double lhs, double rhs)
+{
+  return std::abs(lhs - rhs) < 1.0e-12;
+}
+
+void test_initializes_entered_stamp_without_transition()
+{
+  const auto result = ll::updateRecoverySupervisorRuntimeState(
+    ll::RecoverySupervisorStateUpdateInput{
+      ll::RecoverySupervisorRuntimeState{},
+      ll::RecoverySupervisorState::kTracking,
+      "accept_measurement",
+      12.5});
+
+  assert(!result.transitioned);
+  assert(result.previous_state == ll::RecoverySupervisorState::kTracking);
+  assert(result.state.state == ll::RecoverySupervisorState::kTracking);
+  assert(result.state.action == "accept_measurement");
+  assert(near(result.state.entered_stamp_sec, 12.5));
+  assert(result.state.transition_count == 0);
+}
+
+void test_transition_updates_state_stamp_and_count()
+{
+  const auto result = ll::updateRecoverySupervisorRuntimeState(
+    ll::RecoverySupervisorStateUpdateInput{
+      ll::RecoverySupervisorRuntimeState{
+        ll::RecoverySupervisorState::kTracking,
+        "accept_measurement",
+        4.0,
+        2},
+      ll::RecoverySupervisorState::kRecovering,
+      "advance_prediction_without_measurement",
+      20.0});
+
+  assert(result.transitioned);
+  assert(result.previous_state == ll::RecoverySupervisorState::kTracking);
+  assert(result.state.state == ll::RecoverySupervisorState::kRecovering);
+  assert(result.state.action == "advance_prediction_without_measurement");
+  assert(near(result.state.entered_stamp_sec, 20.0));
+  assert(result.state.transition_count == 3);
+}
+
+void test_same_state_preserves_existing_stamp_and_count()
+{
+  const auto result = ll::updateRecoverySupervisorRuntimeState(
+    ll::RecoverySupervisorStateUpdateInput{
+      ll::RecoverySupervisorRuntimeState{
+        ll::RecoverySupervisorState::kDegraded,
+        "accept_measurement_with_warning",
+        8.0,
+        5},
+      ll::RecoverySupervisorState::kDegraded,
+      "reject_measurement",
+      30.0});
+
+  assert(!result.transitioned);
+  assert(result.previous_state == ll::RecoverySupervisorState::kDegraded);
+  assert(result.state.state == ll::RecoverySupervisorState::kDegraded);
+  assert(result.state.action == "reject_measurement");
+  assert(near(result.state.entered_stamp_sec, 8.0));
+  assert(result.state.transition_count == 5);
+}
+
+int main()
+{
+  test_initializes_entered_stamp_without_transition();
+  test_transition_updates_state_stamp_and_count();
+  test_same_state_preserves_existing_stamp_and_count();
+  return 0;
+}

--- a/test/test_registration_backend_policy.cpp
+++ b/test/test_registration_backend_policy.cpp
@@ -1,0 +1,62 @@
+#include "lidar_localization/registration_backend_policy.hpp"
+
+#include <cassert>
+#include <string>
+
+namespace ll = lidar_localization;
+
+void test_parse_registration_backend()
+{
+  assert(ll::parseRegistrationBackend("GICP") == ll::RegistrationBackend::kPclGicp);
+  assert(ll::parseRegistrationBackend("NDT") == ll::RegistrationBackend::kPclNdt);
+  assert(ll::parseRegistrationBackend("NDT_OMP") == ll::RegistrationBackend::kNdtOmp);
+  assert(ll::parseRegistrationBackend("GICP_OMP") == ll::RegistrationBackend::kGicpOmp);
+  assert(ll::parseRegistrationBackend("SMALL_GICP") == ll::RegistrationBackend::kSmallGicp);
+  assert(ll::parseRegistrationBackend("SMALL_VGICP") == ll::RegistrationBackend::kSmallVgicp);
+  assert(ll::parseRegistrationBackend("UNKNOWN") == ll::RegistrationBackend::kInvalid);
+}
+
+void test_filtered_target_and_initializer_classification()
+{
+  assert(ll::usesFilteredTarget(ll::RegistrationBackend::kPclGicp));
+  assert(ll::usesFilteredTarget(ll::RegistrationBackend::kGicpOmp));
+  assert(ll::usesFilteredTarget(ll::RegistrationBackend::kSmallGicp));
+  assert(ll::usesFilteredTarget(ll::RegistrationBackend::kSmallVgicp));
+  assert(!ll::usesFilteredTarget(ll::RegistrationBackend::kPclNdt));
+  assert(!ll::usesFilteredTarget(ll::RegistrationBackend::kNdtOmp));
+  assert(!ll::usesFilteredTarget(ll::RegistrationBackend::kInvalid));
+
+  assert(ll::supportsNdtInitializer("GICP"));
+  assert(ll::supportsNdtInitializer("SMALL_VGICP"));
+  assert(!ll::supportsNdtInitializer("NDT"));
+  assert(!ll::supportsNdtInitializer("UNKNOWN"));
+}
+
+void test_small_gicp_classification()
+{
+  assert(ll::isSmallGicpBackend(ll::RegistrationBackend::kSmallGicp));
+  assert(ll::isSmallGicpBackend(ll::RegistrationBackend::kSmallVgicp));
+  assert(!ll::isSmallGicpBackend(ll::RegistrationBackend::kGicpOmp));
+  assert(
+    std::string(ll::smallGicpRegistrationType(ll::RegistrationBackend::kSmallGicp)) == "GICP");
+  assert(
+    std::string(ll::smallGicpRegistrationType(ll::RegistrationBackend::kSmallVgicp)) == "VGICP");
+}
+
+void test_thread_count_resolution()
+{
+  assert(ll::resolveRegistrationThreadCount(4, 8) == 4);
+  assert(ll::resolveRegistrationThreadCount(0, 8) == 8);
+  assert(ll::resolveRegistrationThreadCount(-1, 8) == 8);
+  assert(ll::resolveRegistrationThreadCount(0, 0) == 1);
+  assert(ll::resolveRegistrationThreadCount(0, -2) == 1);
+}
+
+int main()
+{
+  test_parse_registration_backend();
+  test_filtered_target_and_initializer_classification();
+  test_small_gicp_classification();
+  test_thread_count_resolution();
+  return 0;
+}

--- a/test/test_registration_observation_policy.cpp
+++ b/test/test_registration_observation_policy.cpp
@@ -1,0 +1,55 @@
+#include "lidar_localization/registration_observation_policy.hpp"
+
+#include <cassert>
+#include <cmath>
+
+namespace ll = lidar_localization;
+
+bool near(double lhs, double rhs, double tolerance = 1.0e-5)
+{
+  return std::abs(lhs - rhs) < tolerance;
+}
+
+void test_registration_observation_extracts_translation_and_rpy()
+{
+  const double roll = 0.12;
+  const double pitch = -0.08;
+  const double yaw = 0.35;
+  const Eigen::Matrix4f pose = ll::makePoseMatrix(1.25, -2.5, 0.75, roll, pitch, yaw);
+
+  const auto observation = ll::makeRegistrationObservation(pose);
+
+  assert(near(observation.x, 1.25));
+  assert(near(observation.y, -2.5));
+  assert(near(observation.z, 0.75));
+  assert(near(observation.roll, roll));
+  assert(near(observation.pitch, pitch));
+  assert(near(observation.yaw, yaw));
+}
+
+void test_rotation_delta_deg_reports_relative_rotation()
+{
+  const auto reference = ll::makePoseMatrix(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+  const auto candidate = ll::makePoseMatrix(
+    0.0, 0.0, 0.0, 0.0, 0.0, ll::kRegistrationObservationPi / 2.0);
+
+  assert(near(ll::rotationDeltaDeg(reference, candidate), 90.0, 1.0e-4));
+}
+
+void test_pitch_extraction_clamps_small_numeric_overshoot()
+{
+  Eigen::Matrix4f pose = Eigen::Matrix4f::Identity();
+  pose(2, 0) = -1.00001f;
+
+  const auto observation = ll::makeRegistrationObservation(pose);
+
+  assert(near(observation.pitch, ll::kRegistrationObservationPi / 2.0, 1.0e-5));
+}
+
+int main()
+{
+  test_registration_observation_extracts_translation_and_rpy();
+  test_rotation_delta_deg_reports_relative_rotation();
+  test_pitch_extraction_clamps_small_numeric_overshoot();
+  return 0;
+}

--- a/test/test_registration_seed_policy.cpp
+++ b/test/test_registration_seed_policy.cpp
@@ -1,0 +1,101 @@
+#include "lidar_localization/registration_seed_policy.hpp"
+
+#include <cassert>
+#include <cmath>
+
+namespace ll = lidar_localization;
+
+void test_imu_preintegration_has_highest_priority_when_finite()
+{
+  const auto decision = ll::chooseRegistrationSeed(
+    ll::RegistrationSeedPolicyInput{
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true});
+
+  assert(decision.source == ll::RegistrationSeedSource::kImuPreintegration);
+  assert(decision.imu_prediction_ready);
+  assert(!decision.uses_prediction_state);
+}
+
+void test_non_finite_imu_prediction_blocks_lower_priority_sources()
+{
+  const auto decision = ll::chooseRegistrationSeed(
+    ll::RegistrationSeedPolicyInput{
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true});
+
+  assert(decision.source == ll::RegistrationSeedSource::kCurrentPose);
+  assert(!decision.imu_prediction_ready);
+  assert(decision.ignored_non_finite_imu_prediction);
+}
+
+void test_fallback_order_without_imu_candidate()
+{
+  ll::RegistrationSeedPolicyInput input;
+  input.use_gtsam_smoother = true;
+  input.gtsam_smoother_initialized = true;
+  input.use_twist_ekf = true;
+  input.twist_ekf_initialized = true;
+  input.use_twist_prediction = true;
+  input.have_last_accepted_pose = true;
+  input.has_latest_twist = true;
+  input.predict_pose_from_previous_delta = true;
+  assert(ll::chooseRegistrationSeed(input).source == ll::RegistrationSeedSource::kGtsamSmoother);
+
+  input.gtsam_smoother_initialized = false;
+  assert(ll::chooseRegistrationSeed(input).source == ll::RegistrationSeedSource::kTwistEkf);
+
+  input.twist_ekf_initialized = false;
+  assert(ll::chooseRegistrationSeed(input).source == ll::RegistrationSeedSource::kTwistPrediction);
+  assert(ll::chooseRegistrationSeed(input).uses_prediction_state);
+
+  input.has_latest_twist = false;
+  assert(ll::chooseRegistrationSeed(input).source == ll::RegistrationSeedSource::kPreviousDelta);
+  assert(ll::chooseRegistrationSeed(input).uses_prediction_state);
+
+  input.have_last_accepted_pose = false;
+  assert(ll::chooseRegistrationSeed(input).source == ll::RegistrationSeedSource::kCurrentPose);
+}
+
+void test_imu_sample_and_dt_helpers()
+{
+  assert(ll::hasNewImuSamples(2.0, 1.0));
+  assert(!ll::hasNewImuSamples(1.0, 1.0));
+
+  assert(std::abs(ll::clampPredictionDt(10.0, 9.8, 0.5) - 0.2) < 1.0e-9);
+  assert(ll::clampPredictionDt(10.0, 9.0, 0.5) == 0.5);
+  assert(ll::clampPredictionDt(9.0, 10.0, 0.5) == 0.0);
+  assert(ll::clampPredictionDt(NAN, 10.0, 0.5) == 0.0);
+  assert(ll::clampPredictionDt(10.0, 9.0, -1.0) == 0.0);
+}
+
+int main()
+{
+  test_imu_preintegration_has_highest_priority_when_finite();
+  test_non_finite_imu_prediction_blocks_lower_priority_sources();
+  test_fallback_order_without_imu_candidate();
+  test_imu_sample_and_dt_helpers();
+  return 0;
+}

--- a/test/test_reinitialization_latch_policy.cpp
+++ b/test/test_reinitialization_latch_policy.cpp
@@ -1,0 +1,120 @@
+#include "lidar_localization/reinitialization_latch_policy.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <string>
+
+namespace ll = lidar_localization;
+
+bool near(double lhs, double rhs)
+{
+  return std::abs(lhs - rhs) < 1.0e-12;
+}
+
+ll::ReinitializationRequestDecision request(
+  bool requested,
+  const std::string & reason,
+  double score)
+{
+  return {requested, reason, score};
+}
+
+void test_disabled_returns_decision_and_state_unchanged()
+{
+  const ll::ReinitializationRequestLatchState state{true, "prior_reason", 0.8, 12.0};
+  const auto decision = request(false, "current_reason", 0.2);
+
+  const auto result = ll::applyReinitializationRequestLatch(
+    ll::ReinitializationRequestLatchInput{false, state, decision, 30.0});
+
+  assert(result.state.latched == state.latched);
+  assert(result.state.reason == state.reason);
+  assert(near(result.state.score, state.score));
+  assert(near(result.state.stamp_sec, state.stamp_sec));
+  assert(result.decision.requested == decision.requested);
+  assert(result.decision.reason == decision.reason);
+  assert(near(result.decision.score, decision.score));
+}
+
+void test_no_request_and_not_latched_returns_unchanged()
+{
+  const ll::ReinitializationRequestLatchState state;
+  const auto decision = request(false, "not_failure", 0.1);
+
+  const auto result = ll::applyReinitializationRequestLatch(
+    ll::ReinitializationRequestLatchInput{true, state, decision, 30.0});
+
+  assert(!result.state.latched);
+  assert(result.state.reason == "not_requested");
+  assert(near(result.state.score, 0.0));
+  assert(near(result.state.stamp_sec, 0.0));
+  assert(result.decision.requested == decision.requested);
+  assert(result.decision.reason == decision.reason);
+  assert(near(result.decision.score, decision.score));
+}
+
+void test_first_request_latches_stamp_reason_and_score()
+{
+  const auto decision = request(true, "accepted_gap_reinit_requested", 0.97);
+
+  const auto result = ll::applyReinitializationRequestLatch(
+    ll::ReinitializationRequestLatchInput{
+      true,
+      ll::ReinitializationRequestLatchState{},
+      decision,
+      42.5});
+
+  assert(result.state.latched);
+  assert(result.state.reason == decision.reason);
+  assert(near(result.state.score, decision.score));
+  assert(near(result.state.stamp_sec, 42.5));
+  assert(result.decision.requested);
+  assert(result.decision.reason == decision.reason);
+  assert(near(result.decision.score, decision.score));
+}
+
+void test_latched_state_keeps_prior_reason_stamp_and_score()
+{
+  const ll::ReinitializationRequestLatchState state{
+    true, "first_reinit_requested", 0.92, 10.0};
+  const auto decision = request(false, "not_failure", 0.4);
+
+  const auto result = ll::applyReinitializationRequestLatch(
+    ll::ReinitializationRequestLatchInput{true, state, decision, 50.0});
+
+  assert(result.state.latched);
+  assert(result.state.reason == state.reason);
+  assert(near(result.state.score, state.score));
+  assert(near(result.state.stamp_sec, state.stamp_sec));
+  assert(result.decision.requested);
+  assert(result.decision.reason == state.reason);
+  assert(near(result.decision.score, state.score));
+}
+
+void test_latched_decision_score_uses_current_score_when_higher()
+{
+  const ll::ReinitializationRequestLatchState state{
+    true, "first_reinit_requested", 0.92, 10.0};
+  const auto decision = request(false, "fitness_exploded_reinit_requested", 1.4);
+
+  const auto result = ll::applyReinitializationRequestLatch(
+    ll::ReinitializationRequestLatchInput{true, state, decision, 50.0});
+
+  assert(result.state.latched);
+  assert(result.state.reason == state.reason);
+  assert(near(result.state.score, state.score));
+  assert(near(result.state.stamp_sec, state.stamp_sec));
+  assert(result.decision.requested);
+  assert(result.decision.reason == state.reason);
+  assert(near(result.decision.score, decision.score));
+}
+
+int main()
+{
+  test_disabled_returns_decision_and_state_unchanged();
+  test_no_request_and_not_latched_returns_unchanged();
+  test_first_request_latches_stamp_reason_and_score();
+  test_latched_state_keeps_prior_reason_stamp_and_score();
+  test_latched_decision_score_uses_current_score_when_higher();
+  return 0;
+}

--- a/test/test_reinitialization_request_output_policy.cpp
+++ b/test/test_reinitialization_request_output_policy.cpp
@@ -1,0 +1,52 @@
+#include "lidar_localization/reinitialization_request_output_policy.hpp"
+
+#include <cassert>
+#include <cmath>
+
+namespace ll = lidar_localization;
+
+bool near(double lhs, double rhs)
+{
+  return std::abs(lhs - rhs) < 1.0e-12;
+}
+
+void test_state_mirrors_decision_even_when_output_disabled()
+{
+  const auto result = ll::prepareReinitializationRequestOutput(
+    ll::ReinitializationRequestOutputInput{
+      false,
+      true,
+      ll::ReinitializationRequestDecision{true, "accepted_gap_reinit_requested", 0.96}});
+
+  assert(result.state.requested);
+  assert(result.state.reason == "accepted_gap_reinit_requested");
+  assert(near(result.state.score, 0.96));
+  assert(!result.should_publish);
+  assert(result.message_value);
+}
+
+void test_publish_requires_output_enabled_and_ready_publisher()
+{
+  const auto ready_result = ll::prepareReinitializationRequestOutput(
+    ll::ReinitializationRequestOutputInput{
+      true,
+      true,
+      ll::ReinitializationRequestDecision{false, "not_failure", 0.2}});
+  const auto missing_publisher_result = ll::prepareReinitializationRequestOutput(
+    ll::ReinitializationRequestOutputInput{
+      true,
+      false,
+      ll::ReinitializationRequestDecision{true, "requested", 0.9}});
+
+  assert(ready_result.should_publish);
+  assert(!ready_result.message_value);
+  assert(!missing_publisher_result.should_publish);
+  assert(missing_publisher_result.message_value);
+}
+
+int main()
+{
+  test_state_mirrors_decision_even_when_output_disabled();
+  test_publish_requires_output_enabled_and_ready_publisher();
+  return 0;
+}

--- a/test/test_scan_admission_policy.cpp
+++ b/test/test_scan_admission_policy.cpp
@@ -1,0 +1,112 @@
+#include "lidar_localization/scan_admission_policy.hpp"
+
+#include <cassert>
+
+namespace ll = lidar_localization;
+
+ll::ScanAdmissionInput ready_input()
+{
+  ll::ScanAdmissionInput input;
+  input.has_scan_message = true;
+  input.map_received = true;
+  input.initial_pose_received = true;
+  return input;
+}
+
+void test_shutdown_and_null_scan_do_not_store_or_update_time()
+{
+  auto input = ready_input();
+  input.shutting_down = true;
+  const auto shutting_down = ll::decideScanAdmission(input);
+  assert(!shutting_down.accepted);
+  assert(shutting_down.status == ll::ScanAdmissionStatus::kShuttingDown);
+  assert(!shutting_down.should_store_last_scan);
+  assert(!shutting_down.should_update_last_process_time);
+
+  input = ready_input();
+  input.has_scan_message = false;
+  const auto null_scan = ll::decideScanAdmission(input);
+  assert(!null_scan.accepted);
+  assert(null_scan.status == ll::ScanAdmissionStatus::kNullScan);
+  assert(null_scan.should_warn_null_scan);
+  assert(!null_scan.should_store_last_scan);
+}
+
+void test_waiting_for_map_or_pose_stores_last_scan_without_processing()
+{
+  auto input = ready_input();
+  input.map_received = false;
+  const auto waiting_for_map = ll::decideScanAdmission(input);
+  assert(!waiting_for_map.accepted);
+  assert(waiting_for_map.status == ll::ScanAdmissionStatus::kWaitingForMapOrInitialPose);
+  assert(waiting_for_map.should_store_last_scan);
+  assert(!waiting_for_map.should_update_last_process_time);
+
+  input = ready_input();
+  input.initial_pose_received = false;
+  const auto waiting_for_pose = ll::decideScanAdmission(input);
+  assert(!waiting_for_pose.accepted);
+  assert(waiting_for_pose.status == ll::ScanAdmissionStatus::kWaitingForMapOrInitialPose);
+  assert(waiting_for_pose.should_store_last_scan);
+}
+
+void test_min_scan_interval_throttles_without_time_update()
+{
+  auto input = ready_input();
+  input.min_scan_interval_sec = 0.1;
+  input.has_last_process_time = true;
+  input.elapsed_since_last_process_sec = 0.05;
+
+  const auto decision = ll::decideScanAdmission(input);
+  assert(!decision.accepted);
+  assert(decision.status == ll::ScanAdmissionStatus::kThrottledByMinScanInterval);
+  assert(decision.should_store_last_scan);
+  assert(!decision.should_update_last_process_time);
+
+  input.elapsed_since_last_process_sec = 0.1;
+  assert(ll::decideScanAdmission(input).accepted);
+}
+
+void test_crop_failure_guard_updates_time_and_only_activates_once()
+{
+  auto input = ready_input();
+  input.consecutive_crop_failures = 101;
+  input.crop_failure_guard_active = false;
+  input.have_last_accepted_pose = true;
+
+  const auto first_guard = ll::decideScanAdmission(input);
+  assert(!first_guard.accepted);
+  assert(first_guard.status == ll::ScanAdmissionStatus::kCropFailureGuard);
+  assert(first_guard.should_store_last_scan);
+  assert(first_guard.should_update_last_process_time);
+  assert(first_guard.should_activate_crop_failure_guard);
+  assert(first_guard.should_reset_prediction_to_last_accepted_pose);
+  assert(first_guard.should_log_crop_failure_guard_activation);
+
+  input.crop_failure_guard_active = true;
+  const auto active_guard = ll::decideScanAdmission(input);
+  assert(!active_guard.accepted);
+  assert(active_guard.should_update_last_process_time);
+  assert(!active_guard.should_activate_crop_failure_guard);
+  assert(!active_guard.should_reset_prediction_to_last_accepted_pose);
+  assert(!active_guard.should_log_crop_failure_guard_activation);
+}
+
+void test_ready_scan_is_accepted_and_updates_time()
+{
+  const auto decision = ll::decideScanAdmission(ready_input());
+  assert(decision.accepted);
+  assert(ll::isScanAdmissionAccepted(decision.status));
+  assert(decision.should_store_last_scan);
+  assert(decision.should_update_last_process_time);
+}
+
+int main()
+{
+  test_shutdown_and_null_scan_do_not_store_or_update_time();
+  test_waiting_for_map_or_pose_stores_last_scan_without_processing();
+  test_min_scan_interval_throttles_without_time_update();
+  test_crop_failure_guard_updates_time_and_only_activates_once();
+  test_ready_scan_is_accepted_and_updates_time();
+  return 0;
+}

--- a/test/test_scan_preprocessing_policy.cpp
+++ b/test/test_scan_preprocessing_policy.cpp
@@ -1,0 +1,78 @@
+#include "lidar_localization/scan_preprocessing_policy.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <string>
+
+namespace ll = lidar_localization;
+
+void test_direct_range_filter_path_requires_no_voxel_no_imu_and_same_frame()
+{
+  assert(ll::shouldUseDirectRangeFilter({false, false, "base_link", "base_link"}));
+  assert(!ll::shouldUseDirectRangeFilter({true, false, "base_link", "base_link"}));
+  assert(!ll::shouldUseDirectRangeFilter({false, true, "base_link", "base_link"}));
+  assert(!ll::shouldUseDirectRangeFilter({false, false, "livox_frame", "base_link"}));
+}
+
+void test_scan_xyz_field_availability()
+{
+  assert(ll::hasRequiredXyzFields({true, true, true}));
+  assert(!ll::hasRequiredXyzFields({false, true, true}));
+  assert(!ll::hasRequiredXyzFields({true, false, true}));
+  assert(!ll::hasRequiredXyzFields({true, true, false}));
+}
+
+void test_scan_preparation_status_priority_and_actions()
+{
+  assert(
+    ll::classifyPreparedScan(false, false, true) ==
+    ll::ScanPreparationStatus::kMissingXyzField);
+  assert(
+    ll::classifyPreparedScan(true, false, true) ==
+    ll::ScanPreparationStatus::kTransformUnavailable);
+  assert(
+    ll::classifyPreparedScan(true, true, true) ==
+    ll::ScanPreparationStatus::kFilteredScanEmpty);
+  assert(ll::classifyPreparedScan(true, true, false) == ll::ScanPreparationStatus::kReady);
+
+  assert(!ll::isPreparedScanReady(ll::ScanPreparationStatus::kFilteredScanEmpty));
+  assert(ll::isPreparedScanReady(ll::ScanPreparationStatus::kReady));
+  assert(ll::shouldAdvancePredictionAfterScanPreparationFailure(
+    ll::ScanPreparationStatus::kMissingXyzField));
+  assert(ll::shouldAdvancePredictionAfterScanPreparationFailure(
+    ll::ScanPreparationStatus::kFilteredScanEmpty));
+  assert(!ll::shouldAdvancePredictionAfterScanPreparationFailure(
+    ll::ScanPreparationStatus::kTransformUnavailable));
+  assert(
+    std::string(ll::scanPreparationStatusMessage(
+      ll::ScanPreparationStatus::kMissingXyzField)) == "scan_missing_xyz_field");
+}
+
+void test_range_is_horizontal_and_exclusive()
+{
+  assert(std::abs(ll::horizontalRange(3.0f, 4.0f) - 5.0) < 1.0e-9);
+  assert(ll::isPointInScanRange(3.0f, 4.0f, 100.0f, 1.0, 6.0));
+  assert(!ll::isPointInScanRange(3.0f, 4.0f, 0.0f, 5.0, 6.0));
+  assert(!ll::isPointInScanRange(3.0f, 4.0f, 0.0f, 1.0, 5.0));
+}
+
+void test_non_finite_points_are_rejected()
+{
+  const float nan = std::numeric_limits<float>::quiet_NaN();
+  const float inf = std::numeric_limits<float>::infinity();
+
+  assert(!ll::isPointInScanRange(nan, 0.0f, 0.0f, 0.0, 10.0));
+  assert(!ll::isPointInScanRange(0.0f, inf, 0.0f, 0.0, 10.0));
+  assert(!ll::isPointInScanRange(3.0f, 4.0f, nan, 0.0, 10.0));
+}
+
+int main()
+{
+  test_direct_range_filter_path_requires_no_voxel_no_imu_and_same_frame();
+  test_scan_xyz_field_availability();
+  test_scan_preparation_status_priority_and_actions();
+  test_range_is_horizontal_and_exclusive();
+  test_non_finite_points_are_rejected();
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Split localization decision logic into focused policy modules with isolated unit tests.
- Refactored the main component to localize alignment, recovery, backend, publishing, and diagnostics responsibilities.
- Added Jetson + Livox MID-360 legged robot bringup launch, params, docs, and doctor CLI.

## Validation
- `colcon build --symlink-install --packages-up-to lidar_localization_ros2`
- Targeted policy/MID360 suite: `29 tests, 0 errors, 0 failures, 0 skipped`
- `ros2 run lidar_localization_ros2 check_mid360_legged_bringup.py --help`
- `ros2 launch lidar_localization_ros2 mid360_legged_localization.launch.py --show-args`
- `git diff --check HEAD~2..HEAD`
