### PR TITLE
[codex] Document public validation snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Then choose the path that matches what you want to do:
 | Bring up Jetson + MID-360 on a legged robot | [MID-360 legged bringup](docs/mid360_legged_jetson.md) |
 | Run a self-contained Nav2 smoke path | [Recommended entry points](docs/v1_status.md#recommended-entry-points) |
 | Run public replay/regression checks | [Benchmarking](#benchmarking) |
+| Check the latest public validation snapshot | [Public validation log](docs/public_validation_log.md) |
 | Evaluate a rosbag against reference poses | [Benchmarking guide](docs/benchmarking.md) |
 | Plan the next relocalization/recovery work | [v1.1 relocalization plan](docs/v1_1_relocalization.md) |
 | Develop or compare recovery behavior | [Experiment-First Development](#experiment-first-development) |
@@ -585,6 +586,17 @@ Interpretation:
 
 - Istanbul has no IMU acceleration stream, so it is only used to confirm that the default-on IMU-capable preset does not regress a no-IMU public dataset
 - HDL is the public IMU smoke path; because it has no strong public GT and single-run throughput is noisy, the suite uses broad safety / throughput bounds there
+
+Latest recorded public replay snapshot:
+
+- [docs/public_validation_log.md](docs/public_validation_log.md)
+- `2026-05-22`, commit `b22dc5d`, `overall_pass=true`
+- Istanbul `60 s`: `1.458 m` translation RMSE, `0.397 deg` rotation RMSE, `106` matched samples
+- HDL `60 s` two-repeat median: pose rows `531.5 -> 550.5`, IMU-enabled alignment time `0.046874 s`
+
+This is not a Jetson + MID-360 hardware result. The MID-360 path is launch/configuration/build
+validated and covered by public replay regression, but real sensor, thermal, vibration, and measured
+extrinsics validation remains separate.
 
 For private or NC datasets, keep the raw bag paths outside the repository and use the manifest wrapper instead:
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -175,6 +175,14 @@ Interpretation:
 - Istanbul has no accelerometer stream, so it is only a default-on no-IMU safety check, not an IMU benefit benchmark
 - HDL has no strong public ground truth and single-run pose-row ratios are noisy, so the suite uses broad smoke bounds there rather than a strict acceptance benchmark
 
+Latest recorded public validation snapshot:
+
+- [public_validation_log.md](public_validation_log.md)
+- `2026-05-22`, commit `b22dc5d`, `overall_pass=true`
+- Istanbul `60 s`: `translation_rmse_m=1.458`, `rotation_rmse_deg=0.397`, `matched_sample_count=106`
+- HDL `60 s`, two repeats: median pose rows `531.5 -> 550.5`, IMU-enabled median alignment time `0.046874 s`
+- scope note: this is public rosbag replay validation, not Jetson + MID-360 hardware validation
+
 ### Run a manifest with health summary
 
 Single-run manifests use `benchmark_from_manifest`. After replay and trajectory evaluation, the

--- a/docs/mid360_legged_jetson.md
+++ b/docs/mid360_legged_jetson.md
@@ -5,6 +5,14 @@ quadruped or biped robots. It is a localization stack boundary: it does not
 own walking control, motor state estimation, global planning, or the MID-360
 driver process.
 
+Current validation status:
+
+- package build, policy/unit tests, and public replay regression have passed
+  after the MID-360 bringup merge
+- latest public replay snapshot:
+  [public_validation_log.md](public_validation_log.md#2026-05-22-main-after-mid-360-bringup-merge)
+- Jetson + MID-360 hardware validation has not been run in this workspace
+
 ## Runtime Contract
 
 Required inputs:

--- a/docs/public_validation_log.md
+++ b/docs/public_validation_log.md
@@ -1,0 +1,54 @@
+# Public Validation Log
+
+This file records reproducible public-data validation snapshots. It is not a
+hardware field-test log.
+
+## 2026-05-22 Main After MID-360 Bringup Merge
+
+- commit: `b22dc5d`
+- source branch: `main`
+- validation command:
+
+```bash
+source scripts/setup_local_env.sh
+scripts/run_public_regression_suite.sh \
+  --output-dir /tmp/lidarloc_public_regression_suite_20260522_mid360_main \
+  --report-dir ../artifacts/public/public_regression_suite_20260522_mid360_main \
+  --ros-domain-base 210 \
+  --hdl-repeat-count 2
+```
+
+Datasets:
+
+- Autoware Istanbul localization ROS 2 bag, `60 s`
+- official `hdl_localization` `hdl_400` sample converted to ROS 2, `60 s`
+
+Result:
+
+- overall: `pass`
+- Istanbul: `pass`
+  - pose rows: `108`
+  - matched samples: `106`
+  - translation RMSE: `1.458 m`
+  - rotation RMSE: `0.397 deg`
+  - IMU prediction active rows: `0`
+- HDL: `pass`
+  - runs: `2 baseline / 2 candidate`
+  - pose rows median: `531.5 -> 550.5`
+  - alignment-time median: `0.046578 s -> 0.046874 s`
+  - IMU prediction active rows median for the IMU-enabled candidate: `4.5`
+  - max IMU disable fallback events: `1`
+
+Artifacts:
+
+- `artifacts/public/public_regression_suite_20260522_mid360_main/summary.json`
+- `artifacts/public/public_regression_suite_20260522_mid360_main/summary.md`
+
+Interpretation:
+
+- This validates the merged software stack against public replay data.
+- This does not validate Livox MID-360 packet conversion, Jetson thermal limits,
+  legged-robot vibration, measured extrinsics, or real `odom -> base_link`
+  behavior.
+- The MID-360 path is therefore launch/configuration/build validated and public
+  replay regression checked, but not hardware validated.


### PR DESCRIPTION
## Summary

- add a public validation log for the 2026-05-22 main replay run after the MID-360 bringup merge
- link the snapshot from README, benchmarking docs, and MID-360 bringup docs
- clearly separate public rosbag replay validation from Jetson + MID-360 hardware validation

## Validation

- `git diff --check`
- Public replay suite already run on `main` at commit `b22dc5d`:
  - Istanbul 60 s: translation RMSE 1.458 m, rotation RMSE 0.397 deg, 106 matched samples
  - HDL 60 s, two repeats: overall pass, IMU-enabled path used, max fallback events 1

## Scope

Docs only. No runtime code changes.
