### PR TITLE
[codex] Document release regression snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,9 +590,10 @@ Interpretation:
 Latest recorded public replay snapshot:
 
 - [docs/public_validation_log.md](docs/public_validation_log.md)
-- `2026-05-22`, commit `b22dc5d`, `overall_pass=true`
-- Istanbul `60 s`: `1.458 m` translation RMSE, `0.397 deg` rotation RMSE, `106` matched samples
-- HDL `60 s` two-repeat median: pose rows `531.5 -> 550.5`, IMU-enabled alignment time `0.046874 s`
+- `2026-05-22`, commit `2a5f11f`, release regression `overall_pass=true`
+- Istanbul `60 s`: `1.176 m` translation RMSE, `0.393 deg` rotation RMSE, `104` matched samples
+- HDL `60 s` two-repeat median: pose rows `558.5 -> 553.5`, IMU-enabled alignment time `0.042911 s`
+- Nav2 reinitialization supervisor `150 s`: requested rows `944 -> 7`, recommended run `configured_initial_pose_count1`
 
 This is not a Jetson + MID-360 hardware result. The MID-360 path is launch/configuration/build
 validated and covered by public replay regression, but real sensor, thermal, vibration, and measured

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -178,10 +178,11 @@ Interpretation:
 Latest recorded public validation snapshot:
 
 - [public_validation_log.md](public_validation_log.md)
-- `2026-05-22`, commit `b22dc5d`, `overall_pass=true`
-- Istanbul `60 s`: `translation_rmse_m=1.458`, `rotation_rmse_deg=0.397`, `matched_sample_count=106`
-- HDL `60 s`, two repeats: median pose rows `531.5 -> 550.5`, IMU-enabled median alignment time `0.046874 s`
-- scope note: this is public rosbag replay validation, not Jetson + MID-360 hardware validation
+- `2026-05-22`, commit `2a5f11f`, release regression `overall_pass=true`
+- Istanbul `60 s`: `translation_rmse_m=1.176`, `rotation_rmse_deg=0.393`, `matched_sample_count=104`
+- HDL `60 s`, two repeats: median pose rows `558.5 -> 553.5`, IMU-enabled median alignment time `0.042911 s`
+- Nav2 reinitialization supervisor `150 s`: requested rows `944 -> 7`, recommended run `configured_initial_pose_count1`
+- scope note: this is public replay and controlled Nav2 regression validation, not Jetson + MID-360 hardware validation
 
 ### Run a manifest with health summary
 

--- a/docs/public_validation_log.md
+++ b/docs/public_validation_log.md
@@ -3,6 +3,60 @@
 This file records reproducible public-data validation snapshots. It is not a
 hardware field-test log.
 
+## 2026-05-22 Main Release Regression
+
+- commit: `2a5f11f`
+- source branch: `main`
+- validation command:
+
+```bash
+source scripts/setup_local_env.sh
+scripts/run_release_regression_suite.sh \
+  --work-dir /tmp/lidarloc_release_regression_suite_20260522_main \
+  --report-dir ../artifacts/public/release_regression_suite_20260522_main \
+  --public-ros-domain-base 220 \
+  --nav2-ros-domain-base 226 \
+  --hdl-repeat-count 2
+```
+
+Result:
+
+- release regression: `pass`
+- public regression suite: `pass`
+  - Istanbul `60 s`: `pass`
+    - pose rows: `106`
+    - matched samples: `104`
+    - translation RMSE: `1.176 m`
+    - rotation RMSE: `0.393 deg`
+    - IMU prediction active rows: `0`
+  - HDL `60 s`: `pass`
+    - runs: `2 baseline / 2 candidate`
+    - pose rows median: `558.5 -> 553.5`
+    - alignment-time median: `0.043065 s -> 0.042911 s`
+    - IMU prediction active rows median for the IMU-enabled candidate: `6.5`
+    - max IMU disable fallback events: `1`
+- Nav2 reinitialization-supervisor regression: `pass`
+  - recommended run: `configured_initial_pose_count1`
+  - baseline goal status: `SUCCEEDED`
+  - candidate goal status: `SUCCEEDED`
+  - reinitialization requested rows: `944 -> 7`
+  - candidate OK rows after first trigger: `6`
+
+Artifacts:
+
+- `artifacts/public/release_regression_suite_20260522_main/summary.json`
+- `artifacts/public/release_regression_suite_20260522_main/summary.md`
+- `artifacts/public/release_regression_suite_20260522_main/public_regression_suite/summary.json`
+- `artifacts/public/release_regression_suite_20260522_main/nav2_reinit_supervisor_regression_150/regression_result.json`
+
+Interpretation:
+
+- This is the current release-style validation boundary for public replay and
+  controlled Nav2 recovery behavior on `main`.
+- This still does not validate Livox MID-360 packet conversion, Jetson thermal
+  limits, legged-robot vibration, measured extrinsics, or real `odom ->
+  base_link` behavior.
+
 ## 2026-05-22 Main After MID-360 Bringup Merge
 
 - commit: `b22dc5d`


### PR DESCRIPTION
## Summary

- record the 2026-05-22 release regression snapshot on main
- update README and benchmarking docs so the latest validation points at the release-style gate
- keep the scope boundary explicit: public replay and controlled Nav2 regression passed; Jetson + MID-360 hardware remains unvalidated

## Validation

- `git diff --check`
- `scripts/run_release_regression_suite.sh --work-dir /tmp/lidarloc_release_regression_suite_20260522_main --report-dir ../artifacts/public/release_regression_suite_20260522_main --public-ros-domain-base 220 --nav2-ros-domain-base 226 --hdl-repeat-count 2`
  - overall pass: true
  - public regression suite pass: true
  - Nav2 reinitialization-supervisor regression pass: true
  - requested rows: 944 -> 7

## Scope

Docs only. No runtime code changes.
