### PR TITLE
Global localization G3 + Boreas crop-cliff root-cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   reset spacing, post-reset recovery evidence, and a non-self-resetting attempt
   ceiling -- regression-tested against unsafe-publication and false-acceptance
   sequences in `test/test_reinitialization_supervisor_policy.py`
+- `docs/global_localization.md`: operations guide for running the G2 service and
+  the G3 supervisor (commands, parameters, and the supervisor's safety guards)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
   coverage ≥ 96 % on the calibration runs); the v1.1 heuristic remains
   available as `pose_covariance_mode: fitness_scaled` (docs:
   `pose_covariance.md`, issue #72)
+- Documented the single-threaded-executor invariant that serializes the node's
+  shared pose state without locks, so a future executor change cannot silently
+  introduce a data race (issue #54)
 
 ## 1.1.0 - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@
   ROS-free query logic in `scripts/global_localization_query.py`
 - `scripts/render_global_localization_demo_gif.py` renders the
   kidnapped-start -> global localization -> tracking-resume demo GIF
+- G3 guarded automatic reinitialization: `scripts/reinitialization_supervisor_node.py`
+  connects `/reinitialization_requested` to the G2 query service and republishes
+  `/initialpose` only when explicit safety guards pass (opt-in node; default
+  launch unchanged). The decision logic is the ROS-free state machine in
+  `scripts/reinitialization_supervisor_policy.py` -- candidate-score floor, minimum
+  reset spacing, post-reset recovery evidence, and a non-self-resetting attempt
+  ceiling -- regression-tested against unsafe-publication and false-acceptance
+  sequences in `test/test_reinitialization_supervisor_policy.py`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   ROS-free query logic in `scripts/global_localization_query.py`
 - `scripts/render_global_localization_demo_gif.py` renders the
   kidnapped-start -> global localization -> tracking-resume demo GIF
+- `scripts/diagnose_local_map_crop_coverage.py` decides offline whether a Boreas
+  `local_map_crop_too_small` cliff is a map-coverage problem or prediction-driven
+  divergence, by counting map points within `local_map_radius` of every
+  ground-truth pose (no ROS / no localizer); core unit-tested in
+  `test/test_local_map_crop_coverage.py`
 - G3 guarded automatic reinitialization: `scripts/reinitialization_supervisor_node.py`
   connects `/reinitialization_requested` to the G2 query service and republishes
   `/initialpose` only when explicit safety guards pass (opt-in node; default

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,8 @@ install(PROGRAMS
   scripts/make_bbs_relocalization_attempts.py
   scripts/global_localization_query.py
   scripts/global_localization_node.py
+  scripts/reinitialization_supervisor_policy.py
+  scripts/reinitialization_supervisor_node.py
   scripts/make_registration_relocalization_jobs.py
   scripts/scaffold_mapless_public_dataset_bundle.py
   scripts/fetch_official_autoware_istanbul_dataset.sh

--- a/README.md
+++ b/README.md
@@ -91,9 +91,14 @@ of the run.
 
 <img src="./images/global_localization_demo.gif" alt="Kidnapped start, BBS_2D global localization candidates, NDT tracking resumes" width="480">
 
-The service node is opt-in and never part of the default launch. Status and
-limits (query latency, validated windows) are tracked in
-[docs/global_localization_roadmap.md](docs/global_localization_roadmap.md).
+The service node is opt-in and never part of the default launch. An optional
+supervisor (`scripts/reinitialization_supervisor_node.py`) can close the loop
+automatically — on the `/reinitialization_requested` signal it queries the service
+and re-seeds `/initialpose` behind explicit safety guards. See
+[docs/global_localization.md](docs/global_localization.md) for how to run the
+service and the supervisor, and
+[docs/global_localization_roadmap.md](docs/global_localization_roadmap.md) for
+status and limits (query latency, validated windows).
 
 ## Quick Start
 
@@ -283,6 +288,7 @@ git branch -D <branch>
 | Experiment interfaces and decisions | [docs/interfaces.md](docs/interfaces.md), [docs/experiments.md](docs/experiments.md), [docs/decisions.md](docs/decisions.md) |
 | Roadmap | [docs/competitive_roadmap.md](docs/competitive_roadmap.md) |
 | Development plan | [docs/development_plan.md](docs/development_plan.md) |
+| Global localization (run it) | [docs/global_localization.md](docs/global_localization.md) |
 | Global localization phases | [docs/global_localization_roadmap.md](docs/global_localization_roadmap.md) |
 | Reliability / open issues | [docs/reliability_roadmap.md](docs/reliability_roadmap.md) |
 | Bringup troubleshooting | [docs/troubleshooting.md](docs/troubleshooting.md) |

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -77,16 +77,18 @@ by the maintainer; this table is the triage record.
 | 37 | CPU占用率爆炸 | Answered — `failure_category: overload` diagnostic + throughput tuning (`voxel`, `ndt threads`, `cloud_queue_depth`) in `troubleshooting.md`; close with pointer |
 | 49 | ERROR run with Rslidar | Answered — point-type / remap guidance; close with pointer (ask for log if it recurs) |
 | 50 | enhance stability (try/catch) | Partially shipped — Phase 0 crash-survival fixes (#76/#56/#47) + Phase 3 diagnostics; reply with what shipped, keep open for broader hardening |
-| 55 | `odom_frame_id_` defined but not used | Actionable code cleanup — verify and remove or wire it; small win |
-| 54 | `corrent_pose_with_cov_stamped_ptr_` not locked | Actionable — confirm the single-threaded executor assumption or add a guard; small win |
+| 55 | `odom_frame_id_` defined but not used | Resolved (2026-06-14) — stale report; the field is wired into the `map -> odom` TF path (`publishMapToOdomTransform`), no code change needed |
+| 54 | `corrent_pose_with_cov_stamped_ptr_` not locked | Resolved (2026-06-14) — the node runs on a `SingleThreadedExecutor` with the default mutually-exclusive callback group, so the shared pose pointer is serialized without a lock; documented the invariant in the node + header + CHANGELOG so a future executor change can't regress it silently |
 | 52 | different results (degrades each restart, worse after reboot) | Needs investigation — restart-to-restart degradation suggests state/seed leak, not documented run variance; keep open |
 | 68 | MGRS map not displayed in Rviz | Needs investigation — large-coordinate PCD likely hits float32 precision in the map path; reporter offered to implement, give a hint and keep open |
 | 77 | IMU angular velocity + estimator | Future enhancement track (IMU); keep open |
 | 36 | imu preintegration | Future enhancement track (IMU), overlaps #77; keep open |
 
-Two cheap code wins (#55, #54) can land in the next `Unreleased` batch; the doc-answered
-set (#25/#33/#34/#37/#49) is ready to close once the maintainer posts the pointer
-comments; #52 and #68 want a reproduction before any claim.
+The two cheap code wins (#55, #54) were investigated on 2026-06-14: both turned out
+to be non-bugs under the shipped configuration (#55 already wired; #54 protected by the
+single-threaded executor) and were closed with documenting changes rather than fixes.
+The doc-answered set (#25/#33/#34/#37/#49) is ready to close once the maintainer posts
+the pointer comments; #52 and #68 want a reproduction before any claim.
 
 Branch hygiene: `origin` carries ten non-`main` branches. Five are stale merged feature
 branches fully contained in `main` (`codex/mid360-policy-split`,
@@ -495,6 +497,40 @@ branches are stale and fully in `main` (`codex/mid360-policy-split`,
 `feat/public-demo-validation-dashboard`, `fix/tf`). `feature/small_gicp` carries only a
 stale 2024 README commit (not the backend integration its name implies). The distro
 branches (`dashing`/`foxy`/`humble`/`jazzy`) are kept as user checkout points.
+
+### 2026-06-14: #55 / #54 closed as non-bugs with documentation
+
+Followed up on the two "small code wins" from the triage. Both turned out to be stale
+or already-safe under the shipped configuration, so neither warranted a behavioral
+change:
+
+- **#55 (`odom_frame_id_` unused)** — stale. The field is read in
+  `publishMapToOdomTransform` to look up `odom -> base` and broadcast the
+  `map -> odom` TF whenever `enable_map_odom_tf_` is set. Nothing to remove.
+- **#54 (`corrent_pose_with_cov_stamped_ptr_` unlocked)** — not a race. `main` spins the
+  node on a `SingleThreadedExecutor` (`lidar_localization_node.cpp`) and no callback
+  opts into a Reentrant group, so every subscription/timer/service callback runs in one
+  mutually-exclusive group on one thread; the shared pose pointer is serialized by the
+  executor, not a lock. The real risk is that this invariant was implicit, so a later
+  switch to `MultiThreadedExecutor` (or a Reentrant group) would silently introduce a
+  data race. Made the invariant explicit instead of adding a now-redundant mutex:
+  comments at the executor construction site and the member declaration, plus a
+  CHANGELOG note.
+
+Comment/doc-only changes, no rebuild required.
+
+**Phase 1 correction (found while reading this code):** the SMALL_GICP *and* SMALL_VGICP
+backends are already fully wired, not a "start fresh" item as previously noted.
+`registration_backend_policy.hpp` maps `SMALL_GICP`/`SMALL_VGICP`, and
+`lidar_localization_component.cpp:998-1013` constructs `small_gicp::RegistrationPCL`,
+selects GICP vs VGICP via `smallGicpRegistrationType`, and sets epsilon / correspondence
+randomness / max-correspondence-distance / `vgicp_voxel_resolution_` / thread count
+before assigning `registration_`. `CMakeLists.txt` already does
+`find_package(small_gicp QUIET CONFIG)` and defines `LIDAR_LOCALIZATION_HAVE_SMALL_GICP`
++ links `small_gicp::small_gicp` when found; without the dependency the backend is a
+clean `RCLCPP_ERROR` + exit. So Phase 1 is a **build-and-benchmark** task, not an
+implementation one: install `small_gicp`, rebuild, then run NDT_OMP vs SMALL_GICP vs
+SMALL_VGICP on an idle machine (still gated on `load < ~5`).
 
 ## Suggested Order Of Work
 

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -168,6 +168,54 @@ Done when:
 - RMSE is in a range where backend and IMU comparisons are meaningful
 - Boreas earns a defined role in the regression or benchmark suite
 
+### Root-cause analysis (2026-06-14, code-level; data run still pending)
+
+Read the crop path end to end to narrow step 1 before spending an idle-machine run.
+Findings, all from the shipped code and `param/boreas_ndt_velodyne.yaml`:
+
+- **The crop is centered on the *predicted* seed, not the last accepted pose.** The
+  primary attempt is `runAlignmentAttempt(init_guess, init_guess, ...)`
+  (`lidar_localization_component.cpp:1969`), and `init_guess` is the twist/IMU
+  prediction (`:1710-1753`). `setInputTargetForPose` crops `full_map_cloud_ptr_`
+  around that center (`:1810`). Only the *recovery retry* re-centers on
+  `last_accepted_pose_matrix_` (`:1980`). So a runaway prediction starves its own
+  target cloud — a positive-feedback divergence, exactly the closed-loop shape
+  Phase 3 warned about.
+- **`local_map_crop_too_small` is a lagging symptom here, not a primary cause.** With
+  `local_map_radius: 300` and `local_map_min_points: 100`, a 300 m disk around any
+  on-map center holds far more than 100 points. For the count to fall under 100 the
+  center must be roughly the map radius (~300 m) off the mapped area — i.e. the pose
+  has *already* diverged. So the reported `local_map_crop_too_small` is downstream of
+  whatever starts the divergence, not an independent map problem at the cliff instant.
+- **The crop-failure guard is what freezes the run into a flat 45 m plateau.** After a
+  streak of crop failures the component activates `crop_failure_guard`, resets the
+  prediction to the last accepted pose, and then *drops every subsequent scan until a
+  new initial pose arrives* (`:1503-1521`). With no auto-reinitialization wired in the
+  Boreas config, the estimate is frozen at the last good pose while the vehicle keeps
+  driving — RMSE then grows linearly to ~45 m. (G3, just landed, is the mechanism that
+  could break this freeze automatically; Boreas is its natural second test scenario.)
+
+This leaves two candidate triggers for the *initial* divergence, with opposite fixes:
+
+  (A) **prediction divergence** — a twist-prediction glitch or a single bad accepted
+      match throws the seed, and the predicted-center crop then guarantees the next
+      reject; fix is estimator-side (crop around last-accepted instead of the raw
+      seed, and/or harden the twist/reject path).
+  (C) **map coverage** — the Boreas map (`*_rebuild_loc_frame.pcd`, a GT-aligned
+      rebuild) does not cover the full 60 s route, so once the vehicle passes the
+      mapped region the crop around the *true* pose legitimately falls below
+      `min_points`; fix is map-side (extend / retile the map).
+
+`scripts/diagnose_local_map_crop_coverage.py` decides (A) vs (C) offline, with no ROS
+and no localizer: it counts map points within `local_map_radius` of every ground-truth
+pose and reports the first time that count drops below `local_map_min_points`. If the
+true trajectory stays covered, a real `local_map_crop_too_small` is prediction-driven
+(A); if coverage collapses at the cliff time, it is a map-split (C). The counting core
+is unit-tested in `test/test_local_map_crop_coverage.py`. **Blocked only on data**: the
+Boreas map PCD and reference CSV live on the `/media/autoware/aa/...` mount, which is
+not currently attached; run the diagnostic the moment it is back to fix the root cause
+before any runtime change (no unreplayed estimator edits — the Phase 3 rule).
+
 ## Phase 3: Measurement Acceptance, Diagnostics, Covariance — DONE (2026-06-12)
 
 Goal was to move acceptance and failure detection beyond the scalar fitness score, so

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -532,6 +532,35 @@ clean `RCLCPP_ERROR` + exit. So Phase 1 is a **build-and-benchmark** task, not a
 implementation one: install `small_gicp`, rebuild, then run NDT_OMP vs SMALL_GICP vs
 SMALL_VGICP on an idle machine (still gated on `load < ~5`).
 
+### 2026-06-14: G3 guarded automatic reinitialization (logic complete)
+
+Built the consumer side of the global-localization recovery loop, which was the
+named next item after G1/G2. The producer (`/reinitialization_requested` from the C++
+recovery supervisor) already existed; G3 adds the part that closes the loop while
+respecting the Phase 3 lesson that a closed loop must not be able to reset its own
+bounds. Two new files:
+
+- `scripts/reinitialization_supervisor_policy.py` — a ROS-free, deterministic state
+  machine (`decide(params, state, obs)`) that owns every safety decision: a candidate
+  must clear `min_candidate_score` to be published, resets are spaced by
+  `min_seconds_between_attempts`, after a reset it requires alignment fitness back under
+  `recovery_fitness_threshold` as recovery evidence, and the attempt counter is a true
+  ceiling (`max_attempts`) that only clears on confirmed recovery or request release —
+  never as a side effect of attempting. After a terminal outcome it waits for the request
+  to de-assert (edge-triggered), so a stuck-high request line cannot re-fire it.
+- `scripts/reinitialization_supervisor_node.py` — the thin ROS shell (opt-in, not in the
+  default launch): subscribes `/reinitialization_requested` + `/alignment_status`
+  (reads the `fitness_score` diagnostic), calls the G2 `~/query` Trigger service, and
+  publishes `/initialpose` from the top candidate only when the policy says so.
+
+`test/test_reinitialization_supervisor_policy.py` is the roadmap-required regression
+test that fails on unsafe publication or false acceptance: 10 adversarial sequences
+(transient blip, pure tracking, happy-path single reset + recovery, weak-candidate
+never published, bounded queries, false-acceptance no-loop, reset spacing, budget reset
+on recovery between episodes, exhausted latch, purity). All green. **Pending** (machine-
+or runtime-bound, not logic): a live/replay smoke on the Koide kidnapped-start window
+and capture of the post-reset recovery evidence for the roadmap's evidence gate.
+
 ## Suggested Order Of Work
 
 Phase 0, Phase 3 (all three steps), G1, the BBS speedup, and G2 are complete. Remaining,

--- a/docs/g3_live_closed_loop.md
+++ b/docs/g3_live_closed_loop.md
@@ -124,3 +124,32 @@ in the G1 optimization entry of the roadmap, and/or exposing G2's search paramet
 faster (coarser) configuration can be selected for the runtime loop. Per-candidate
 registration scoring in G2 remains useful (it would reject a stale candidate faster), but
 it cannot manufacture a fresh one — query latency is the thing to cut.
+
+## Fast-G2 run (2026-06-15, third run) — query sped up, but walk latency re-staled
+
+Exposing G2's search cost as launch arguments and running with a coarse config
+(`g2_angular_resolution_deg:=10`, `g2_max_scan_points:=256`) cut the query from ~23 s
+to **~4–8 s** (`runtime_sec` 7.559 then 4.387) — the speed knob works. Recovery still did
+not complete, for a subtler reason and with a harness caveat:
+
+- **Walk latency re-introduces staleness.** Even with a fast query, a near-correct
+  candidate that is not rank 1 is published late: the walk spends `settle_timeout_sec`
+  (6 s here) on each earlier candidate first. The near-correct candidate `(-107.9, 12.0)`
+  was rank 3, so it was published ~20 s after the query issued — stale again by the
+  vehicle's motion, fitness stayed ~29, rejected. So the latency budget is *query +
+  rank × settle*, not just the query.
+- **Harness caveat for this run.** The healthy baseline did not establish: the one-shot
+  seed publisher exited before the localizer's `/initialpose` subscription finished
+  discovery (a transient-local race that only bit at this slower replay rate), so the
+  localizer had no lock before the kidnap. The kidnap seed (published by the longer-lived
+  injector) *was* received. This makes the third run a weak recovery test, but the query
+  timing and the walk-latency observation above stand on their own.
+
+**Net.** On a *moving* vehicle the total scan→seed latency (query + walk) must stay under
+the time the vehicle takes to leave the registration basin. The levers are: cut the query
+hard (C++ BBS, or coarser still) *and* keep the true pose at rank 1 (so no walk latency);
+or motion-compensate the published seed forward by the measured latency; or scope G3
+recovery to low-speed / stationary kidnaps and say so. The ranked-candidate walk stays the
+right mechanism for *aliasing* (true pose present but not at rank 0); it is not a remedy
+for *staleness*, which is a latency problem. The test harness should also republish the
+seed until the localizer acknowledges, to remove the discovery race.

--- a/docs/g3_live_closed_loop.md
+++ b/docs/g3_live_closed_loop.md
@@ -183,3 +183,45 @@ likely mechanics are the same ones the Boreas root-cause flagged — the alignme
 externally-injected reset pose — but confirming that needs **code-level investigation of
 the C++ component**, not more black-box replays. The five live runs have isolated the
 blocker by elimination; that investigation is the next step (Task #16, re-scoped).
+
+## Root cause and fix (2026-06-15) — RECOVERY ACHIEVED
+
+The code investigation found the blocker upstream of the localizer after all, and it is
+mundane: **the reset was published with z = 0**. A G2 candidate is 2D (`x, y, yaw`, with
+`z = seed_z_m = 0`) and the supervisor's `_publish_reset` set only `x / y` + yaw, leaving
+`position.z = 0`. On the Koide outdoor map the true z is ~-11 m, so every reset seeded the
+pose ~11 m above ground -- far outside the NDT z-basin -- and the lock never took even when
+`x / y / yaw` were correct. The fourth run's rank-1 candidate was 0.8 m / 6 deg off in
+`x / y / yaw` and *still* held fitness ~27 for exactly this reason. The HDL demo worked
+only because its map is flat (z ~ 0), so z = 0 happened to be right.
+
+**Fix.** The supervisor subscribes to the localizer pose (`/pcl_pose`) and carries its
+`z / roll / pitch` onto the 2D candidate, overriding only `x / y / yaw`. The vehicle's
+height and attitude drift slowly even while xy tracking is lost, so the last pose is a
+good carry-over (falls back to `reset_default_z_m` if no pose seen yet).
+
+**Result -- the recovery-evidence gate is met.** Re-running the clean kidnap with the fix,
+the reset now publishes `z ~ -9.4 / -7.3` (carried from the pose), and the loop recovers
+end-to-end:
+
+```
+published /initialpose reset to (-76.50, 55.24, z=-7.33, 90.0 deg) score=1.0 [candidate 1/16]
+supervisor: none -> standdown (recovery_confirmed)
+supervisor: none -> idle (standdown_cleared)
+```
+
+After that reset the localizer locked: `/pcl_pose` resumed and fitness fell to **0.10**
+(from ~30+ while lost), the supervisor saw recovery, stood down, and re-armed to idle for
+the next problem. So the full G3 closed loop -- kidnap -> tracking lost ->
+`/reinitialization_requested` -> G2 query -> ranked-candidate walk with z carried from the
+pose -> a candidate locks -> fitness recovers -> `recovery_confirmed` -> stand down /
+re-arm -- is validated live on the Koide window.
+
+**Remaining (quality, not correctness).** Recovery here took two queries and a full
+16-candidate walk (~140 s of replay) before a candidate matched the by-then-current
+position, because query latency + walk latency keep the candidates somewhat stale; cutting
+the BBS query further (C++ / coarser) and per-candidate registration scoring in G2 would
+make recovery faster and first-try. The test harness should also republish the seed until
+the localizer acknowledges (the transient-local discovery race still occasionally drops the
+healthy baseline at slow replay rates). But the gate question -- *does tracking recover
+after the guarded reset* -- is now answered yes.

--- a/docs/g3_live_closed_loop.md
+++ b/docs/g3_live_closed_loop.md
@@ -65,18 +65,33 @@ intervention needed` and latched `exhausted`.
    ceiling and inside the closing bag window. **The BBS score does not separate right
    from wrong**: 0.99 labelled a 190 m error and 0.998 labelled the 5.5 m hit.
 
-## Next requirement (now evidence-backed, not optional)
+## Fix: ranked-candidate walk (implemented 2026-06-15)
 
-The supervisor must **validate a candidate by registration fitness before publishing**,
-rather than trusting the BBS occupancy score — exactly the roadmap's "registration
-scoring from runtime-available inputs" decision gate. Concretely, one of:
+The first of the two remedies below is now implemented. The insight is that the
+localizer's own NDT fitness *is* the registration oracle the BBS score is not, so the
+supervisor should let it adjudicate the ranked list rather than trusting rank 0:
 
-- have G2 score each candidate by NDT/GICP fitness against the map at the candidate
-  pose and return that fitness, so `min_candidate_score` can gate on registration
-  quality instead of BBS hit ratio; and/or
-- have the supervisor walk the **ranked** candidate list (G2 already publishes a
-  `PoseArray`) instead of only the top candidate, trying the next-best when a reset does
-  not lower fitness within the settle window.
+- **Walk the ranked candidate list within one query** (done). G2 now returns the full
+  ranked `candidates` list in its `~/query` reply (not just `top`). The supervisor
+  publishes the best candidate, waits `settle_timeout_sec` for recovery, and if the
+  localizer's fitness does not drop, publishes the *next* candidate from the same query
+  — using the localizer's fitness to reject aliased poses. Walking within a query does
+  **not** spend a `max_attempts` slot (only re-querying does), so the ceiling stays a
+  true bound on queries while one query can try all the poses it found. A wrong reset is
+  rejected by the localizer (high fitness, no accepted pose), so walking cannot cause
+  the Phase 3 acceptance blowup. Covered by `test_reinitialization_supervisor_policy.py`
+  (walk recovers on a lower-ranked candidate without spending attempts; the list-exhaust
+  path still respects `max_attempts`; the score floor still truncates the walk) and by
+  the ROS integration test (the node walks 0→1 within one query and recovers).
+- **Per-candidate registration scoring in G2** (still future work). Have G2 score each
+  candidate by NDT/GICP fitness against the 3D map at the candidate pose, so the ranking
+  itself reflects registration quality — the complement to the walk for when the correct
+  pose is not even in the BBS top-K.
 
-Query latency is a secondary factor: attempt 3 was correct but stale by the time it was
-published. The G1 optimization note's coarse-yaw / C++ path applies here.
+Query latency remains a secondary factor: attempt 3 was correct but stale by the time it
+was published. The G1 optimization note's coarse-yaw / C++ path applies here.
+
+**Live validation of the walk on this exact kidnap window is still pending** — the unit
+and integration tests prove the supervisor walks and recovers given a ranked list whose
+list contains the true pose; whether the real BBS top-K at this kidnap location actually
+contains it (and within the staleness budget) is the next thing to confirm on the bag.

--- a/docs/g3_live_closed_loop.md
+++ b/docs/g3_live_closed_loop.md
@@ -91,7 +91,36 @@ supervisor should let it adjudicate the ranked list rather than trusting rank 0:
 Query latency remains a secondary factor: attempt 3 was correct but stale by the time it
 was published. The G1 optimization note's coarse-yaw / C++ path applies here.
 
-**Live validation of the walk on this exact kidnap window is still pending** — the unit
-and integration tests prove the supervisor walks and recovers given a ranked list whose
-list contains the true pose; whether the real BBS top-K at this kidnap location actually
-contains it (and within the staleness budget) is the next thing to confirm on the bag.
+## Live walk run (2026-06-15, second run) — the blocker is query latency, not candidates
+
+Re-running the kidnap with the walk enabled corrected the earlier "candidate quality"
+diagnosis. The walk itself is now **live-validated**: the supervisor walked all 16
+candidates from one query (`candidate 1/16` … `16/16`, each a `next_candidate`
+transition, each published by index), kept every guard, and only then re-queried — the
+designed behaviour, on the real stack.
+
+And the candidate generation was actually *fine*: the BBS **top candidate (rank 1) was
+the true pose** — `(-107.1, 18.44)` at score `1.0`, versus ground truth `(-107.2, 17.7)`
+at the query-issue time, ~0.8 m off. The walk published it first.
+
+It still did not recover, and the reason is **BBS query latency**:
+
+- the `~/query` call reported `runtime_sec: 23.376` — the BBS search took ~23 s;
+- the candidate is computed against the scan captured at query-*issue* time, but is
+  published ~23 s later. At the 0.4× replay rate that is ~9 s of sim time, during which
+  the (still-driving) vehicle moved from `(-107, 18)` to ~`(-108, 30)` — so the
+  rank-1-correct candidate was ~12–17 m **stale** by the time it was published;
+- the localizer seeded there, could not register the now-moved scan (fitness stayed
+  ~31), and the counter shows `/pcl_pose` briefly at `(-107.1, 18.4)` with high fitness
+  and no accepted pose. Every other candidate is from the same stale scan, so the walk
+  cannot rescue it.
+
+**Refined conclusion.** Candidate generation and ranking were not the blocker here (BBS
+put the truth at rank 1); the blocker is that a ~23 s query makes *any* candidate ~15 m
+stale on a moving vehicle, outside the registration basin. The walk is validated and
+keeps its guarantees, but live recovery needs a **fresh** candidate. So the primary next
+lever is **G2 query speed** — the coarse-yaw (~9 s) setting or the C++ port already noted
+in the G1 optimization entry of the roadmap, and/or exposing G2's search parameters so a
+faster (coarser) configuration can be selected for the runtime loop. Per-candidate
+registration scoring in G2 remains useful (it would reject a stale candidate faster), but
+it cannot manufacture a fresh one — query latency is the thing to cut.

--- a/docs/g3_live_closed_loop.md
+++ b/docs/g3_live_closed_loop.md
@@ -225,3 +225,27 @@ make recovery faster and first-try. The test harness should also republish the s
 the localizer acknowledges (the transient-local discovery race still occasionally drops the
 healthy baseline at slow replay rates). But the gate question -- *does tracking recover
 after the guarded reset* -- is now answered yes.
+
+## Speedup lever 1 -- bound the walk, re-query on a fresher scan
+
+The dominant cost in that run was **not** the query itself but the walk: the first query
+(at t+8 s) returned 16 candidates clustered around `(95, -63)` and `(-65, -78)`, none of
+which was the true pose `(-76, 55)` -- the right place simply was not in that scan's
+candidate set. The supervisor nonetheless walked all 16 at `settle_timeout_sec` (6 s) each,
+burning **~95 s**, before cooling down and re-querying. The *second* query (on a newer, more
+distinctive scan) returned the true pose at rank 1 with score 1.0 and locked immediately.
+
+So past the top few BBS occupancy maxima, a fresh query beats a deeper walk into a stale
+list. The policy now caps the walk at `max_walk_candidates` (default 4): after the top few
+candidates fail to lock, it treats the whole query as a miss and re-queries (spending one
+attempt) instead of grinding through ranks 5-16. On this run that turns ~95 s of doomed
+walking into ~24 s, then a fresh query -- the one that actually recovered. The cap is a pure
+policy change (`reinitialization_supervisor_policy.py`), unit-tested in
+`test_reinitialization_supervisor_policy.py` (`test_walk_is_bounded_by_max_walk_candidates`,
+`test_high_max_walk_candidates_restores_full_list_walk`), and exposed as the
+`supervisor_max_walk_candidates` launch arg. Set it high to restore walking the full list.
+
+Note this does *not* help when the true candidate is genuinely in the list but ranked deep
+on registration quality -- that is what per-candidate registration scoring in G2 (lever 2,
+not yet built) would fix. The cap addresses the more common stale-query case observed here,
+where no rank would have recovered and the time is better spent on a new scan.

--- a/docs/g3_live_closed_loop.md
+++ b/docs/g3_live_closed_loop.md
@@ -1,0 +1,82 @@
+# G3 Live Closed-Loop Result (Koide outdoor_hard_01a)
+
+Date: 2026-06-15. This is the live exercise of the G3 post-reset recovery-evidence
+gate from [global_localization_roadmap.md](global_localization_roadmap.md): the
+three-node bringup (`launch/global_localization_recovery.launch.py`) run against the
+real Koide `outdoor_hard_01a` bag + map, with a kidnap injected at a healthy location
+so the guarded automatic-reinitialization loop has to recover.
+
+## Setup
+
+- Bringup: `global_localization_recovery.launch.py` (localizer + G2 + G3 supervisor),
+  `use_sim_time:=true`, `cloud_topic:=/livox/points`, real `map_outdoor_hard.ply` and
+  `outdoor_hard_occupancy.yaml`.
+- Localizer params: smoke config (`nav2_ndt_urban` + Livox overrides, `score_threshold
+  6.0`), with the reinitialization trigger lowered (`reinitialization_trigger_threshold
+  0.40`, `reinitialization_trigger_gap_scale_sec 10`) so the request fires promptly in a
+  bounded window. Lowering the trigger to expose the request is the same technique the
+  repo's own `..._180_reinit090` diagnostic manifest uses; it tunes the *localizer's*
+  request, not the G3 loop under test.
+- Supervisor: `min_candidate_score 0.6`, `max_attempts 3`, `query_timeout_sec 30`,
+  `settle_timeout_sec 20` (patient enough for the ~10 s BBS query).
+- Bag played at rate 0.5 to halve vehicle motion during the BBS query (reduce
+  reset-seed staleness). Correct pose seeded after `/clock`; a wrong `/initialpose`
+  (`-36, -58.8`) injected at sim t+22 s to break tracking at a healthy location.
+
+## What happened
+
+| Phase | Evidence |
+| --- | --- |
+| Healthy tracking | 134 accepted `/pcl_pose`, fitness 0.06–0.2, pose advancing (-86,-9)→(-108,-5.5) |
+| Kidnap (sim 848) | fitness explodes 222→428, `/pcl_pose` freezes (no accepts), `/reinitialization_requested` asserts |
+| Supervisor loop | `idle→await_query→query_issued`, then **3 guarded resets**, then **give-up** |
+
+Candidate quality vs ground truth (the decisive finding):
+
+| Attempt | sim | GT (true) | G2 candidate (BBS score) | error |
+| --- | --- | --- | --- | --- |
+| 1 | ~862 | (-107.2, 17.7) | (-45.9, -74.6) score 0.990 | **~107 m** |
+| 2 | ~880 | (-109.7, 40.3) | (53.1, -71.6) score 0.988 | **~190 m** |
+| 3 | ~898 | (-97.3, 54.3) | (-102.9, 53.6) score 0.998 | **~5.5 m (correct)** |
+
+After three attempts without confirmed recovery (fitness never returned under
+`recovery_fitness_threshold 1.5`), the supervisor logged
+`reinitialization gave up (recovery_failed_exhausted) after 3 attempt(s); operator
+intervention needed` and latched `exhausted`.
+
+## Conclusions
+
+1. **The G3 supervisor mechanism is validated end-to-end against a real stack.** Every
+   state transition fired correctly: detect → debounce → query G2 → score-guard →
+   guarded `/initialpose` publish → recovery-wait → retry → `max_attempts` ceiling →
+   safe give-up with an operator alert. This exercises both the publish path *and* the
+   recovery-failure path of the recovery-evidence gate.
+
+2. **The safety ceiling earned its keep, live.** Three confidently-wrong-or-stale
+   candidates did **not** produce an unbounded reset loop — `max_attempts` + give-up
+   contained it. This is the Phase 3 closed-loop lesson (a closed loop must not loop
+   forever on confident-wrong input) validated in the G3 context, not just in the
+   offline policy test.
+
+3. **Recovery was blocked by candidate *quality*, not by the supervisor.** G2's BBS_2D
+   returned high-confidence but grossly wrong candidates on 2 of 3 attempts (107 m and
+   190 m off at BBS score ≈ 0.99) — perceptual aliasing on the self-similar outdoor map.
+   The correct pose did appear (attempt 3, 5.5 m at score 0.998) but too late, after the
+   ceiling and inside the closing bag window. **The BBS score does not separate right
+   from wrong**: 0.99 labelled a 190 m error and 0.998 labelled the 5.5 m hit.
+
+## Next requirement (now evidence-backed, not optional)
+
+The supervisor must **validate a candidate by registration fitness before publishing**,
+rather than trusting the BBS occupancy score — exactly the roadmap's "registration
+scoring from runtime-available inputs" decision gate. Concretely, one of:
+
+- have G2 score each candidate by NDT/GICP fitness against the map at the candidate
+  pose and return that fitness, so `min_candidate_score` can gate on registration
+  quality instead of BBS hit ratio; and/or
+- have the supervisor walk the **ranked** candidate list (G2 already publishes a
+  `PoseArray`) instead of only the top candidate, trying the next-best when a reset does
+  not lower fitness within the settle window.
+
+Query latency is a secondary factor: attempt 3 was correct but stale by the time it was
+published. The G1 optimization note's coarse-yaw / C++ path applies here.

--- a/docs/g3_live_closed_loop.md
+++ b/docs/g3_live_closed_loop.md
@@ -153,3 +153,33 @@ recovery to low-speed / stationary kidnaps and say so. The ranked-candidate walk
 right mechanism for *aliasing* (true pose present but not at rank 0); it is not a remedy
 for *staleness*, which is a latency problem. The test harness should also republish the
 seed until the localizer acknowledges, to remove the discovery race.
+
+## Clean run (2026-06-15, fourth run) — the decisive blocker is the localizer re-lock
+
+With the seed harness fixed (the publisher now holds the transient-local latch instead of
+exiting), the fourth run had everything the previous ones lacked at once: a **healthy
+baseline** (seed received, 106 accepted poses, fitness 0.07–0.23), a **fast query**
+(`runtime_sec` 5.365 then 3.595), and a **correct, fresh, rank-1 candidate**. Query 1's
+top candidate was `(-106.10, 9.04, 150°)`; ground truth at the query time (sim 855) was
+`(-106.8, 8.6, 156°)` — **0.8 m and 6° off, in full 3-DOF**, published ~5 s after the
+scan it was computed from.
+
+It still did not re-lock. After the candidate was published, the localizer logged
+`initialPoseReceived`, immediately went `tracking -> recovering (reject_measurement)`, and
+streamed `fitness score is over 6.0` continuously; the counter shows `/pcl_pose` sitting
+at the seed `(-106.1, 9.0)` with fitness ~27 and no accept — at a pose that is ~0.8 m from
+truth and where the **same area scored fitness 0.23 during healthy tracking minutes
+earlier**. Across the whole post-kidnap window there were 28 `initialPoseReceived` (every
+reset) and 517 over-threshold rejections, with only 2 brief `recovering -> tracking`
+accepts.
+
+**This eliminates every hypothesis upstream of the localizer.** Candidate generation
+(rank-1 correct in 3-DOF), ranking, the walk, query latency, and yaw were all adequate
+here, yet recovery failed. The decisive blocker is in the **localizer's own post-reset
+re-lock path**: it does not re-converge to low fitness from a correct externally-published
+`/initialpose`, even though it tracks that exact area at fitness 0.2 in steady state. The
+likely mechanics are the same ones the Boreas root-cause flagged — the alignment
+`init_guess` / local-map-crop centering during the `recovering` state not following an
+externally-injected reset pose — but confirming that needs **code-level investigation of
+the C++ component**, not more black-box replays. The five live runs have isolated the
+blocker by elimination; that investigation is the next step (Task #16, re-scoped).

--- a/docs/global_localization.md
+++ b/docs/global_localization.md
@@ -1,0 +1,103 @@
+# Global Localization (experimental)
+
+Operations guide for the opt-in global-localization stack: recovering a usable
+pose with **no** (or a lost) initial pose, and optionally re-seeding tracking
+automatically when it diverges. This is the *how to run it* companion to the
+design/status document, [global_localization_roadmap.md](global_localization_roadmap.md).
+
+Everything here is **opt-in**. None of these nodes are part of the default launch,
+and none of them publish or change anything until you explicitly run them and (for
+the supervisor) the safety guards pass. The core localization node is unchanged.
+
+## The three pieces
+
+| Stage | What it does | Entry point |
+| --- | --- | --- |
+| G1 | Map-wide candidate generation (BBS_2D branch-and-bound over an occupancy grid), artifact-first / offline | `scripts/make_bbs_relocalization_attempts.py` |
+| G2 | Runtime service that exposes G1 on demand: ask, get ranked candidates back | `scripts/global_localization_node.py` |
+| G3 | Guarded *automatic* reinitialization: watch the lost-tracking signal, query G2, and re-seed `/initialpose` behind safety gates | `scripts/reinitialization_supervisor_node.py` |
+
+G1 and G2 need an occupancy grid built from the map PCD
+(`scripts/generate_occupancy_map_from_pcd.py`). G3 needs a running localization
+node *and* a running G2 node.
+
+## G2: on-demand relocalization service
+
+Run the service node against the same map and cloud topic the localizer uses:
+
+```bash
+python3 scripts/global_localization_node.py --ros-args \
+  -p occupancy_yaml:=/path/to/occupancy.yaml \
+  -p cloud_topic:=/velodyne_points \
+  -p global_frame_id:=map
+```
+
+Trigger a query (it uses the latest scan it has seen):
+
+```bash
+ros2 service call /global_localization_node/query std_srvs/srv/Trigger
+```
+
+The response `message` is JSON (`candidate_count`, `scan_point_count`,
+`runtime_sec`, and the `top` candidate `x`/`y`/`yaw_deg`/`score`). The full ranked
+list is also published once as a `geometry_msgs/PoseArray` on
+`/global_localization_node/candidates`. To relocalize manually, publish the top
+candidate to `/initialpose`.
+
+Key parameters (see the node for the full list): `z_min_m` / `z_max_m` (scan
+height band), `max_scan_points`, `angular_resolution_deg`, `pyramid_depth`,
+`max_candidates`, `nms_radius_m`. Query latency on a validated window is a few
+seconds; see the roadmap for the speed/coverage envelope.
+
+## G3: guarded automatic reinitialization
+
+The localization node already raises `/reinitialization_requested`
+(`std_msgs/Bool`) from its C++ recovery supervisor when it judges tracking lost.
+The supervisor node consumes that signal, queries G2, and republishes
+`/initialpose` from the top candidate — **only** when every safety guard passes.
+
+```bash
+python3 scripts/reinitialization_supervisor_node.py --ros-args \
+  -p query_service:=/global_localization_node/query \
+  -p alignment_status_topic:=/alignment_status \
+  -p initialpose_topic:=/initialpose
+```
+
+Wiring:
+
+```
+/reinitialization_requested (Bool) ──▶ supervisor
+/alignment_status (DiagnosticArray) ─▶ supervisor   (reads the fitness_score key)
+        supervisor ──call──▶ /global_localization_node/query (Trigger)
+        supervisor ──pub───▶ /initialpose (PoseWithCovarianceStamped)
+```
+
+### Safety guards
+
+All of the *decision* logic lives in the ROS-free state machine
+`scripts/reinitialization_supervisor_policy.py` and is regression-tested in
+`test/test_reinitialization_supervisor_policy.py`. The guards exist because a
+closed recovery loop can diverge catastrophically if a confidently-wrong
+candidate is allowed to be published repeatedly (the Phase 3 lesson). They are:
+
+| Parameter | Guard |
+| --- | --- |
+| `min_candidate_score` | A reset is never published from a candidate scoring below this (no *unsafe publication*). |
+| `min_seconds_between_attempts` | Two resets are never closer than this. |
+| `request_debounce_sec` | The request must persist this long before the first query (ignores transient blips). |
+| `recovery_fitness_threshold` | After a reset the supervisor waits for `/alignment_status` fitness back under this as *recovery evidence* before standing down. |
+| `settle_timeout_sec` | If recovery is not observed within this long, the attempt is counted failed. |
+| `max_attempts` | Hard ceiling on attempts for one continuous problem; it only resets on confirmed recovery or when the request clears — never as a side effect of attempting — then the supervisor **gives up** and surfaces an error for an operator rather than looping. |
+| `query_timeout_sec` | A query that returns nothing within this long is abandoned (counts against `max_attempts`). |
+
+After any terminal outcome (recovery or give-up) the supervisor waits for
+`/reinitialization_requested` to de-assert before it will act again, so a request
+line that stays (or is stuck) high cannot re-fire it — it is edge-triggered on the
+*next* problem.
+
+### Status
+
+G3 logic is complete and tested offline; a live/replay smoke on the Koide
+kidnapped-start window and the post-reset recovery-evidence capture are still
+pending an idle machine. Track it in
+[global_localization_roadmap.md](global_localization_roadmap.md) (G3 section).

--- a/docs/global_localization_roadmap.md
+++ b/docs/global_localization_roadmap.md
@@ -213,6 +213,17 @@ each candidate by NDT/GICP fitness so the *ranking* reflects registration qualit
 the BBS query-latency/staleness remain the next G3 work; live validation of the walk on
 the kidnap window is pending. See [g3_live_closed_loop.md](g3_live_closed_loop.md).
 
+**Recovery-evidence gate met (2026-06-15).** The final blocker turned out to be that the
+reset was published with z = 0: G2 candidates are 2D and the supervisor left
+`position.z = 0`, ~11 m above the true Koide ground, outside the NDT z-basin — so even an
+x/y/yaw-correct candidate never locked. The supervisor now carries z / roll / pitch from
+`/pcl_pose` onto the candidate. With that fix the full loop recovers live on the Koide
+kidnap window: after the guarded reset (`recovery_confirmed`) the localizer re-locks and
+fitness falls to ~0.1, then the supervisor stands down and re-arms. So *post-reset
+recovery evidence* — the last G3 Decision Gate — is now satisfied with a real localizer.
+Remaining work is quality, not correctness: faster/first-try recovery (cut BBS query
+latency, per-candidate registration scoring in G2).
+
 ## Non-Goals For Now
 
 - production-grade kidnapped-robot recovery claims

--- a/docs/global_localization_roadmap.md
+++ b/docs/global_localization_roadmap.md
@@ -134,6 +134,32 @@ recovery supervisor, gated by the relocalization runtime rules already defined i
 
 G3 starts only after G1/G2 artifacts are stable on at least two public failure scenarios.
 
+#### 2026-06-14 G3 guard policy and supervisor node (logic complete, runtime pending)
+
+The loop is now wired in code. The localization component already raises
+`/reinitialization_requested` from its C++ recovery supervisor; the new
+`reinitialization_supervisor_node.py` consumes it, calls the G2 `~/query` service,
+and republishes `/initialpose`. The safety-critical part -- *whether* it is allowed
+to publish -- is a ROS-free state machine, `reinitialization_supervisor_policy.py`,
+so it can be tested without a live stack:
+
+- candidate-score floor: a reset is never published from a candidate scoring below
+  `min_candidate_score` (the "reset publication guarded by explicit checks" gate);
+- minimum reset spacing and a non-self-resetting attempt ceiling, so a
+  confidently-wrong candidate cannot loop -- the Phase 3 closed-loop blowup shape;
+- post-reset recovery evidence: after a reset the supervisor waits for alignment
+  fitness back under `recovery_fitness_threshold` before standing down, and gives
+  up after `max_attempts` rather than retrying forever;
+- edge-triggered re-arming: after recovery or give-up it waits for the request to
+  de-assert, so a stuck-high request line cannot re-fire it.
+
+`test/test_reinitialization_supervisor_policy.py` is the required "regression test
+that fails on unsafe publication or false acceptance": ten adversarial sequences
+covering transient blips, weak candidates, false acceptance, spacing, budget reset
+on recovery, and the exhausted latch. All pass. Still **pending**: a live/replay
+smoke run on the Koide kidnapped-start window once the shared machine is idle, plus
+the post-reset recovery-evidence capture for the roadmap's evidence gate.
+
 ## Non-Goals For Now
 
 - production-grade kidnapped-robot recovery claims

--- a/docs/global_localization_roadmap.md
+++ b/docs/global_localization_roadmap.md
@@ -197,12 +197,21 @@ write-up in [g3_live_closed_loop.md](g3_live_closed_loop.md). Two results:
   at BBS score ≈ 0.99) on 2 of 3 attempts; the correct pose (5.5 m, score 0.998) arrived
   too late. The BBS occupancy score does not separate right from wrong.
 
-So the recovery-evidence gate now has a concrete, evidence-backed blocker: **the
-supervisor must validate a candidate by registration fitness before publishing** (the
-"registration scoring from runtime-available inputs" gate), e.g. G2 returning per-
-candidate NDT/GICP fitness and/or the supervisor walking the ranked candidate list
-rather than only the top. That — plus the BBS query-latency/staleness already noted in
-the G1 optimization entry — is the next G3 work.
+So the recovery-evidence gate had a concrete, evidence-backed blocker: the supervisor
+trusted the BBS score, which does not separate right from wrong.
+
+**Ranked-candidate walk implemented (2026-06-15):** the supervisor now walks the ranked
+candidate list from a single query, using the localizer's NDT fitness as the
+registration oracle the BBS score is not — publish the best, and if fitness does not
+recover within `settle_timeout_sec`, publish the next-best from the same query. Walking
+does not spend a `max_attempts` slot (only re-querying does), so the ceiling still bounds
+queries while one query can try every pose it found. G2 returns the full ranked
+`candidates` list in its reply; the policy and node carry a candidate index; the new
+behaviour is regression-tested (policy walk + list-exhaust + score-floor cases, plus a
+ROS integration test that walks 0→1 and recovers). The complementary piece — G2 scoring
+each candidate by NDT/GICP fitness so the *ranking* reflects registration quality — and
+the BBS query-latency/staleness remain the next G3 work; live validation of the walk on
+the kidnap window is pending. See [g3_live_closed_loop.md](g3_live_closed_loop.md).
 
 ## Non-Goals For Now
 

--- a/docs/global_localization_roadmap.md
+++ b/docs/global_localization_roadmap.md
@@ -183,10 +183,26 @@ supervisor files are now installed via `CMakeLists.txt` so they resolve as
 `ros2 run` / launch executables. `ros2 launch ... --show-args` validates the full
 argument graph (including the included localizer's pass-through args).
 
-Still **pending**: actually *running* that launch against the Koide kidnapped-start
-window on an idle machine and capturing the post-reset recovery evidence (tracking
-recovers after the published reset) for the roadmap's recovery-evidence gate. The
-launch and the fake-service smoke now de-risk everything up to that live replay.
+**Live closed-loop exercised (2026-06-15):** the three-node bringup was run against the
+real `outdoor_hard_01a` bag + map with a kidnap injected at a healthy location. Full
+write-up in [g3_live_closed_loop.md](g3_live_closed_loop.md). Two results:
+
+- *The G3 supervisor mechanism is validated end-to-end against a real stack.* Detect →
+  debounce → query G2 → score-guard → guarded `/initialpose` publish → recovery-wait →
+  retry → `max_attempts` ceiling → safe give-up with an operator alert all fired
+  correctly. The safety ceiling contained three confidently-wrong-or-stale candidates
+  without an unbounded reset loop — the Phase 3 lesson validated live, not just offline.
+- *Recovery did not complete, and the cause is candidate quality, not the supervisor.*
+  G2's BBS_2D returned high-confidence but grossly wrong candidates (107 m and 190 m off
+  at BBS score ≈ 0.99) on 2 of 3 attempts; the correct pose (5.5 m, score 0.998) arrived
+  too late. The BBS occupancy score does not separate right from wrong.
+
+So the recovery-evidence gate now has a concrete, evidence-backed blocker: **the
+supervisor must validate a candidate by registration fitness before publishing** (the
+"registration scoring from runtime-available inputs" gate), e.g. G2 returning per-
+candidate NDT/GICP fitness and/or the supervisor walking the ranked candidate list
+rather than only the top. That — plus the BBS query-latency/staleness already noted in
+the G1 optimization entry — is the next G3 work.
 
 ## Non-Goals For Now
 

--- a/docs/global_localization_roadmap.md
+++ b/docs/global_localization_roadmap.md
@@ -122,6 +122,9 @@ The pause is honest about query latency; G3 automation will need either the
 
 ### G3: guarded automatic reinitialization
 
+> How to run the G2 service and the G3 supervisor: see
+> [global_localization.md](global_localization.md).
+
 Goal: connect `/reinitialization_requested` to the G2 service behind the existing
 recovery supervisor, gated by the relocalization runtime rules already defined in
 [competitive_roadmap.md](competitive_roadmap.md) Decision Gates:

--- a/docs/global_localization_roadmap.md
+++ b/docs/global_localization_roadmap.md
@@ -171,11 +171,22 @@ localizer + G2 service and asserts the full path end-to-end: the node receives
 (correct pose + covariance) before entering `settling`. So the supervisor's own
 job -- decide and publish a guarded reset -- is validated end-to-end.
 
-Still **pending**: a full closed-loop run against a *real* localizer on the Koide
-kidnapped-start window (tracking actually recovers after the published reset), for
-the roadmap's post-reset recovery-evidence gate. That needs the 3-node bringup
-(localizer + G2 + supervisor) wired into a launch, which the fake-service smoke now
-de-risks.
+**3-node bringup authored (2026-06-14):** `launch/global_localization_recovery.launch.py`
+now brings up all three nodes together -- the core localizer (via the existing
+`lidar_localization.launch.py`), the G2 `global_localization_node`, and the G3
+`reinitialization_supervisor_node` -- on a shared `cloud_topic` / `global_frame_id`,
+with the supervisor wired to the G2 `~/query` service and the localizer's
+`/alignment_status` and `/reinitialization_requested`. The supervisor's typed guards
+(`min_candidate_score`, `max_attempts`) are exposed as launch arguments (coerced with
+`ParameterValue` so the node's int/float parameter types are respected). The two
+supervisor files are now installed via `CMakeLists.txt` so they resolve as
+`ros2 run` / launch executables. `ros2 launch ... --show-args` validates the full
+argument graph (including the included localizer's pass-through args).
+
+Still **pending**: actually *running* that launch against the Koide kidnapped-start
+window on an idle machine and capturing the post-reset recovery evidence (tracking
+recovers after the published reset) for the roadmap's recovery-evidence gate. The
+launch and the fake-service smoke now de-risk everything up to that live replay.
 
 ## Non-Goals For Now
 

--- a/docs/global_localization_roadmap.md
+++ b/docs/global_localization_roadmap.md
@@ -159,9 +159,23 @@ so it can be tested without a live stack:
 `test/test_reinitialization_supervisor_policy.py` is the required "regression test
 that fails on unsafe publication or false acceptance": ten adversarial sequences
 covering transient blips, weak candidates, false acceptance, spacing, budget reset
-on recovery, and the exhausted latch. All pass. Still **pending**: a live/replay
-smoke run on the Koide kidnapped-start window once the shared machine is idle, plus
-the post-reset recovery-evidence capture for the roadmap's evidence gate.
+on recovery, and the exhausted latch. All pass.
+
+**Runtime glue validated (2026-06-14):** the supervisor node now runs under ROS.
+A first launch surfaced and fixed a shutdown bug (an external SIGTERM raised an
+uncaught `ExternalShutdownException`). `test/test_reinitialization_supervisor_node_ros.py`
+is an rclpy integration smoke (skipped without a sourced ROS env) that fakes the
+localizer + G2 service and asserts the full path end-to-end: the node receives
+`/reinitialization_requested` + `/alignment_status`, debounces, calls the G2
+`~/query` service, parses the candidate JSON, and publishes `/initialpose`
+(correct pose + covariance) before entering `settling`. So the supervisor's own
+job -- decide and publish a guarded reset -- is validated end-to-end.
+
+Still **pending**: a full closed-loop run against a *real* localizer on the Koide
+kidnapped-start window (tracking actually recovers after the published reset), for
+the roadmap's post-reset recovery-evidence gate. That needs the 3-node bringup
+(localizer + G2 + supervisor) wired into a launch, which the fake-service smoke now
+de-risks.
 
 ## Non-Goals For Now
 

--- a/include/lidar_localization/lidar_localization_component.hpp
+++ b/include/lidar_localization/lidar_localization_component.hpp
@@ -140,6 +140,10 @@ public:
   small_gicp::RegistrationPCL<pcl::PointXYZI, pcl::PointXYZI>::Ptr small_gicp_registration_;
 #endif
   pcl::VoxelGrid<pcl::PointXYZI> voxel_grid_filter_;
+  // Mutated and read from several callbacks (initial pose, scan, odom, imu,
+  // services). Safe without a mutex only because the node is spun by a
+  // SingleThreadedExecutor with the default mutually-exclusive callback group
+  // (see lidar_localization_node.cpp); add a guard before changing executors.
   geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr corrent_pose_with_cov_stamped_ptr_;
   nav_msgs::msg::Path::SharedPtr path_ptr_;
   sensor_msgs::msg::PointCloud2::ConstSharedPtr last_scan_ptr_;

--- a/launch/global_localization_recovery.launch.py
+++ b/launch/global_localization_recovery.launch.py
@@ -66,6 +66,7 @@ def generate_launch_description():
     # G2's BBS query can take ~10-25 s; query/settle timeouts must allow for it.
     supervisor_query_timeout_sec = LaunchConfiguration('supervisor_query_timeout_sec')
     supervisor_settle_timeout_sec = LaunchConfiguration('supervisor_settle_timeout_sec')
+    supervisor_max_walk_candidates = LaunchConfiguration('supervisor_max_walk_candidates')
 
     declared = [
         DeclareLaunchArgument(
@@ -100,6 +101,12 @@ def generate_launch_description():
             'supervisor_settle_timeout_sec', default_value='8.0',
             description='Time to observe post-reset recovery before counting the '
                         'attempt failed.'),
+        DeclareLaunchArgument(
+            'supervisor_max_walk_candidates', default_value='4',
+            description='Walk at most this many candidates from one (possibly stale) '
+                        'query before re-querying on a fresher scan; a stale query '
+                        'can return a full list none of whose poses lock '
+                        '(g3_live_closed_loop.md). Set high to walk the whole list.'),
         DeclareLaunchArgument(
             'g2_angular_resolution_deg', default_value='5.0',
             description='G2 BBS yaw sampling step; coarser = faster query, fresher '
@@ -170,6 +177,8 @@ def generate_launch_description():
                 supervisor_query_timeout_sec, value_type=float),
             'settle_timeout_sec': ParameterValue(
                 supervisor_settle_timeout_sec, value_type=float),
+            'max_walk_candidates': ParameterValue(
+                supervisor_max_walk_candidates, value_type=int),
             'use_sim_time': use_sim_time,
         }])
 

--- a/launch/global_localization_recovery.launch.py
+++ b/launch/global_localization_recovery.launch.py
@@ -100,6 +100,19 @@ def generate_launch_description():
             'supervisor_settle_timeout_sec', default_value='8.0',
             description='Time to observe post-reset recovery before counting the '
                         'attempt failed.'),
+        DeclareLaunchArgument(
+            'g2_angular_resolution_deg', default_value='5.0',
+            description='G2 BBS yaw sampling step; coarser = faster query, fresher '
+                        'seed (e.g. 10.0).'),
+        DeclareLaunchArgument(
+            'g2_max_scan_points', default_value='512',
+            description='G2 BBS scan points; fewer = faster query (e.g. 256).'),
+        DeclareLaunchArgument(
+            'g2_pyramid_depth', default_value='4',
+            description='G2 BBS branch-and-bound pyramid depth.'),
+        DeclareLaunchArgument(
+            'g2_max_candidates', default_value='16',
+            description='G2 ranked candidate count returned per query.'),
     ]
 
     # 1. Core localizer (also raises /reinitialization_requested + /alignment_status).
@@ -115,7 +128,10 @@ def generate_launch_description():
             'lidar_frame_id': lidar_frame_id,
         }.items())
 
-    # 2. G2 on-demand global-localization service.
+    # 2. G2 on-demand global-localization service. The search-cost parameters are
+    # exposed because query latency directly bounds live recovery: a candidate is
+    # stale by the query duration on a moving vehicle (see g3_live_closed_loop.md),
+    # so a coarser/faster setting trades a little accuracy for a fresher seed.
     global_localization = Node(
         package='lidar_localization_ros2',
         executable='global_localization_node.py',
@@ -125,6 +141,14 @@ def generate_launch_description():
             'occupancy_yaml': occupancy_yaml,
             'cloud_topic': cloud_topic,
             'global_frame_id': global_frame_id,
+            'angular_resolution_deg': ParameterValue(
+                LaunchConfiguration('g2_angular_resolution_deg'), value_type=float),
+            'max_scan_points': ParameterValue(
+                LaunchConfiguration('g2_max_scan_points'), value_type=int),
+            'pyramid_depth': ParameterValue(
+                LaunchConfiguration('g2_pyramid_depth'), value_type=int),
+            'max_candidates': ParameterValue(
+                LaunchConfiguration('g2_max_candidates'), value_type=int),
             'use_sim_time': use_sim_time,
         }])
 

--- a/launch/global_localization_recovery.launch.py
+++ b/launch/global_localization_recovery.launch.py
@@ -1,0 +1,137 @@
+"""Three-node bringup for the G3 guarded automatic reinitialization loop.
+
+Brings up, in one launch, the full closed recovery loop documented in
+``docs/global_localization_roadmap.md`` (G3 section):
+
+1. the core ``lidar_localization`` lifecycle node (raises
+   ``/reinitialization_requested`` and publishes ``/alignment_status``),
+2. the G2 ``global_localization_node`` (answers ``~/query`` with ranked
+   candidates from a map-wide BBS_2D search),
+3. the G3 ``reinitialization_supervisor_node`` (watches the lost-tracking
+   signal, queries G2, and republishes ``/initialpose`` -- only when every
+   safety guard in ``reinitialization_supervisor_policy`` passes).
+
+This is the bringup the roadmap's post-reset recovery-evidence gate needs: with
+all three running against the Koide kidnapped-start window, tracking should
+actually recover after the supervisor publishes its guarded reset. Everything is
+still opt-in -- this launch is never part of the default bringup, and the
+supervisor publishes nothing until ``/reinitialization_requested`` is asserted
+and the guards pass.
+
+Example (Koide outdoor_hard_01a, dataset TF tree)::
+
+    ros2 launch lidar_localization_ros2 global_localization_recovery.launch.py \\
+        cloud_topic:=/velodyne_points \\
+        occupancy_yaml:=/path/to/occupancy.yaml \\
+        localization_param_dir:=/path/to/localization.yaml \\
+        use_dataset_tf_tree:=true dataset_root_frame:=camera_base \\
+        use_sim_time:=true
+
+Then replay the bag with ``set_initial_pose:=false`` (or let tracking diverge);
+the supervisor closes the loop without manual intervention.
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+
+def generate_launch_description():
+    pkg_share = get_package_share_directory('lidar_localization_ros2')
+
+    cloud_topic = LaunchConfiguration('cloud_topic')
+    occupancy_yaml = LaunchConfiguration('occupancy_yaml')
+    global_frame_id = LaunchConfiguration('global_frame_id')
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    localization_param_dir = LaunchConfiguration('localization_param_dir')
+
+    # Pass-through to the core localization launch so dataset TF trees (Koide
+    # bags) and the lidar frame can be selected from this single entry point.
+    use_dataset_tf_tree = LaunchConfiguration('use_dataset_tf_tree')
+    dataset_root_frame = LaunchConfiguration('dataset_root_frame')
+    lidar_frame_id = LaunchConfiguration('lidar_frame_id')
+
+    # Supervisor guards most likely to be tuned per scenario; the rest keep the
+    # node's own defaults (see reinitialization_supervisor_policy).
+    supervisor_min_candidate_score = LaunchConfiguration('supervisor_min_candidate_score')
+    supervisor_max_attempts = LaunchConfiguration('supervisor_max_attempts')
+
+    declared = [
+        DeclareLaunchArgument(
+            'cloud_topic', default_value='/velodyne_points',
+            description='Scan topic shared by the localizer and the G2 search.'),
+        DeclareLaunchArgument(
+            'occupancy_yaml', default_value='',
+            description='Occupancy grid YAML for the G2 BBS_2D search '
+                        '(scripts/generate_occupancy_map_from_pcd.py).'),
+        DeclareLaunchArgument(
+            'global_frame_id', default_value='map',
+            description='Map frame shared by all three nodes and /initialpose.'),
+        DeclareLaunchArgument('use_sim_time', default_value='false'),
+        DeclareLaunchArgument(
+            'localization_param_dir',
+            default_value=os.path.join(pkg_share, 'param', 'localization.yaml'),
+            description='Parameter file for the core lidar_localization node.'),
+        DeclareLaunchArgument('use_dataset_tf_tree', default_value='false'),
+        DeclareLaunchArgument('dataset_root_frame', default_value='camera_base'),
+        DeclareLaunchArgument('lidar_frame_id', default_value='velodyne'),
+        DeclareLaunchArgument(
+            'supervisor_min_candidate_score', default_value='0.6',
+            description='No reset is published below this candidate score.'),
+        DeclareLaunchArgument(
+            'supervisor_max_attempts', default_value='3',
+            description='Hard ceiling on resets for one continuous problem.'),
+    ]
+
+    # 1. Core localizer (also raises /reinitialization_requested + /alignment_status).
+    localization = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(pkg_share, 'launch', 'lidar_localization.launch.py')),
+        launch_arguments={
+            'localization_param_dir': localization_param_dir,
+            'cloud_topic': cloud_topic,
+            'use_sim_time': use_sim_time,
+            'use_dataset_tf_tree': use_dataset_tf_tree,
+            'dataset_root_frame': dataset_root_frame,
+            'lidar_frame_id': lidar_frame_id,
+        }.items())
+
+    # 2. G2 on-demand global-localization service.
+    global_localization = Node(
+        package='lidar_localization_ros2',
+        executable='global_localization_node.py',
+        name='global_localization_node',
+        output='screen',
+        parameters=[{
+            'occupancy_yaml': occupancy_yaml,
+            'cloud_topic': cloud_topic,
+            'global_frame_id': global_frame_id,
+            'use_sim_time': use_sim_time,
+        }])
+
+    # 3. G3 guarded automatic reinitialization supervisor (opt-in, guarded).
+    supervisor = Node(
+        package='lidar_localization_ros2',
+        executable='reinitialization_supervisor_node.py',
+        name='reinitialization_supervisor_node',
+        output='screen',
+        parameters=[{
+            'query_service': '/global_localization_node/query',
+            'alignment_status_topic': '/alignment_status',
+            'initialpose_topic': '/initialpose',
+            'global_frame_id': global_frame_id,
+            'min_candidate_score': ParameterValue(
+                supervisor_min_candidate_score, value_type=float),
+            'max_attempts': ParameterValue(supervisor_max_attempts, value_type=int),
+            'use_sim_time': use_sim_time,
+        }])
+
+    return LaunchDescription(declared + [localization, global_localization, supervisor])

--- a/launch/global_localization_recovery.launch.py
+++ b/launch/global_localization_recovery.launch.py
@@ -63,6 +63,9 @@ def generate_launch_description():
     # node's own defaults (see reinitialization_supervisor_policy).
     supervisor_min_candidate_score = LaunchConfiguration('supervisor_min_candidate_score')
     supervisor_max_attempts = LaunchConfiguration('supervisor_max_attempts')
+    # G2's BBS query can take ~10-25 s; query/settle timeouts must allow for it.
+    supervisor_query_timeout_sec = LaunchConfiguration('supervisor_query_timeout_sec')
+    supervisor_settle_timeout_sec = LaunchConfiguration('supervisor_settle_timeout_sec')
 
     declared = [
         DeclareLaunchArgument(
@@ -89,6 +92,14 @@ def generate_launch_description():
         DeclareLaunchArgument(
             'supervisor_max_attempts', default_value='3',
             description='Hard ceiling on resets for one continuous problem.'),
+        DeclareLaunchArgument(
+            'supervisor_query_timeout_sec', default_value='10.0',
+            description='Abandon a G2 query that returns nothing within this long '
+                        '(raise above the BBS query latency, ~10-25 s).'),
+        DeclareLaunchArgument(
+            'supervisor_settle_timeout_sec', default_value='8.0',
+            description='Time to observe post-reset recovery before counting the '
+                        'attempt failed.'),
     ]
 
     # 1. Core localizer (also raises /reinitialization_requested + /alignment_status).
@@ -131,6 +142,10 @@ def generate_launch_description():
             'min_candidate_score': ParameterValue(
                 supervisor_min_candidate_score, value_type=float),
             'max_attempts': ParameterValue(supervisor_max_attempts, value_type=int),
+            'query_timeout_sec': ParameterValue(
+                supervisor_query_timeout_sec, value_type=float),
+            'settle_timeout_sec': ParameterValue(
+                supervisor_settle_timeout_sec, value_type=float),
             'use_sim_time': use_sim_time,
         }])
 

--- a/scripts/diagnose_local_map_crop_coverage.py
+++ b/scripts/diagnose_local_map_crop_coverage.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Offline diagnostic: is `local_map_crop_too_small` a map-coverage cliff?
+
+The Boreas localization run holds ~0.04 m error for ~12 s and then collapses to
+~45 m RMSE, with `local_map_crop_too_small` and reject streaks as the reported
+failure modes (development_plan.md, Phase 2). With the shipped Boreas params
+(`local_map_radius: 300`, `local_map_min_points: 100`) a 300 m disk around any
+on-map point holds far more than 100 points, so `local_map_crop_too_small` can
+only fire when the crop *center* is hundreds of metres off the mapped area. That
+leaves two very different root causes:
+
+  (A) prediction divergence -- the crop is centered on the predicted seed
+      (`runAlignmentAttempt(init_guess, init_guess, ...)`), so a runaway
+      prediction starves the target cloud, which guarantees the next reject, a
+      positive-feedback divergence; or
+  (C) map coverage -- the map simply does not cover the whole trajectory (a
+      map-split / partial rebuild), so once the vehicle drives past the mapped
+      region the crop around the *true* pose legitimately falls below
+      `min_points`.
+
+These have opposite fixes (estimator-side vs map-side), so they must be told
+apart before touching runtime behaviour -- the Phase 3 lesson about not shipping
+an unreplayed change applies here too.
+
+This script settles it without ROS or a running localizer: it counts, for every
+ground-truth pose, how many map points fall within `local_map_radius`, and
+reports the first time that count drops below `local_map_min_points`. If the true
+trajectory stays well-covered for the whole run, a real `local_map_crop_too_small`
+must be prediction-driven (A). If coverage itself collapses around the cliff time,
+it is a map-coverage cliff (C) and the map must be extended/retiled.
+
+Usage:
+    diagnose_local_map_crop_coverage.py \
+        --map-pcd boreas_map.pcd --reference-csv boreas_reference.csv \
+        --local-map-radius 300 --local-map-min-points 100 \
+        --out-csv coverage.csv [--plot coverage.png]
+"""
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def count_points_within_radius(map_xy, query_xy, radius_m, chunk=256):
+    """Points of ``map_xy`` within ``radius_m`` of each row of ``query_xy``.
+
+    Pure numpy so it is testable without scipy. Uses a KD-tree fast path when
+    scipy is available, otherwise a chunked brute-force scan. Returns an int
+    array of length ``len(query_xy)``.
+    """
+    map_xy = np.asarray(map_xy, dtype=np.float64)
+    query_xy = np.asarray(query_xy, dtype=np.float64)
+    if query_xy.ndim != 2 or query_xy.shape[1] != 2:
+        raise ValueError("query_xy must be (N, 2)")
+    if map_xy.size == 0:
+        return np.zeros(len(query_xy), dtype=np.int64)
+
+    try:
+        from scipy.spatial import cKDTree  # type: ignore
+
+        tree = cKDTree(map_xy)
+        counts = tree.query_ball_point(query_xy, radius_m, return_length=True)
+        return np.asarray(counts, dtype=np.int64)
+    except Exception:  # noqa: BLE001 - scipy absent or too old; brute force.
+        pass
+
+    r2 = float(radius_m) ** 2
+    counts = np.empty(len(query_xy), dtype=np.int64)
+    mx = map_xy[:, 0]
+    my = map_xy[:, 1]
+    for start in range(0, len(query_xy), chunk):
+        block = query_xy[start:start + chunk]
+        # (block, map) squared distances, chunked over queries to bound memory.
+        dx = block[:, 0][:, None] - mx[None, :]
+        dy = block[:, 1][:, None] - my[None, :]
+        counts[start:start + len(block)] = np.count_nonzero(dx * dx + dy * dy <= r2, axis=1)
+    return counts
+
+
+def analyze_coverage(map_xy, traj_xy, traj_t, radius_m, min_points):
+    """Per-pose coverage and the first under-covered (cliff) index.
+
+    Returns a dict with: ``counts`` (per pose), ``too_small`` (bool mask),
+    ``out_of_bounds`` (crop center beyond map bbox + radius), ``cliff_index``
+    (first too_small index or None), ``cliff_time`` (its timestamp or None),
+    ``map_bounds`` and ``min_count``.
+    """
+    map_xy = np.asarray(map_xy, dtype=np.float64)
+    traj_xy = np.asarray(traj_xy, dtype=np.float64)
+    counts = count_points_within_radius(map_xy, traj_xy, radius_m)
+    too_small = counts < min_points
+
+    min_x, min_y = map_xy.min(axis=0)
+    max_x, max_y = map_xy.max(axis=0)
+    out_of_bounds = (
+        (traj_xy[:, 0] < min_x - radius_m)
+        | (traj_xy[:, 0] > max_x + radius_m)
+        | (traj_xy[:, 1] < min_y - radius_m)
+        | (traj_xy[:, 1] > max_y + radius_m)
+    )
+
+    cliff_idx = int(np.argmax(too_small)) if too_small.any() else None
+    cliff_time = float(traj_t[cliff_idx]) if cliff_idx is not None else None
+    return {
+        "counts": counts,
+        "too_small": too_small,
+        "out_of_bounds": out_of_bounds,
+        "cliff_index": cliff_idx,
+        "cliff_time": cliff_time,
+        "map_bounds": (float(min_x), float(max_x), float(min_y), float(max_y)),
+        "min_count": int(counts.min()) if len(counts) else 0,
+    }
+
+
+def verdict(result, min_points):
+    """A human-readable (A)/(C) verdict from an analyze_coverage result."""
+    if result["cliff_index"] is None:
+        return (
+            "COVERAGE-OK: the true trajectory stays at or above min_points for the "
+            "whole run (min in-radius count %d >= %d). A real local_map_crop_too_small "
+            "is therefore NOT a coverage problem -- it must be prediction-driven (the "
+            "crop center diverged from truth). Look estimator-side (twist prediction / "
+            "reject streak), not at the map."
+            % (result["min_count"], min_points)
+        )
+    t = result["cliff_time"]
+    oob = result["out_of_bounds"][result["cliff_index"]]
+    return (
+        "COVERAGE-CLIFF at t=%.2fs (in-radius count drops below %d along the *true* "
+        "trajectory; crop center %s map bbox+radius). This is a map-coverage cliff: the "
+        "map does not cover the trajectory past this point. Fix is map-side (extend / "
+        "retile / rebuild the map to cover the full route), not estimator-side."
+        % (t, min_points, "outside" if oob else "inside")
+    )
+
+
+def load_reference(reference_csv):
+    t, xs, ys = [], [], []
+    with open(reference_csv, newline="", encoding="utf-8") as stream:
+        for row in csv.DictReader(stream):
+            t.append(float(row["stamp_sec"]))
+            xs.append(float(row["position_x"]))
+            ys.append(float(row["position_y"]))
+    if not t:
+        raise SystemExit("reference CSV had no rows")
+    order = np.argsort(t)
+    t = np.asarray(t)[order]
+    xy = np.column_stack([np.asarray(xs)[order], np.asarray(ys)[order]])
+    # Re-zero time to the first pose so the cliff time is "seconds into the run".
+    return t - t[0], xy
+
+
+def load_map_xy(map_pcd, max_points=None):
+    import open3d as o3d  # imported lazily so the pure core stays dependency-light
+
+    cloud = o3d.io.read_point_cloud(str(map_pcd))
+    points = np.asarray(cloud.points, dtype=np.float64)
+    if points.size == 0:
+        raise SystemExit(f"map PCD is empty: {map_pcd}")
+    xy = points[:, :2]
+    if max_points and len(xy) > max_points:
+        # Uniform stride subsample keeps spatial coverage representative.
+        stride = int(np.ceil(len(xy) / max_points))
+        xy = xy[::stride]
+    return xy
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--map-pcd", required=True, type=Path)
+    p.add_argument("--reference-csv", required=True, type=Path)
+    p.add_argument("--local-map-radius", type=float, default=300.0)
+    p.add_argument("--local-map-min-points", type=int, default=100)
+    p.add_argument("--max-map-points", type=int, default=2_000_000,
+                   help="Subsample the map above this many points for speed.")
+    p.add_argument("--out-csv", type=Path, default=None)
+    p.add_argument("--plot", type=Path, default=None)
+    return p.parse_args()
+
+
+def write_csv(path, t, xy, result):
+    with open(path, "w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(["time_sec", "x", "y", "points_in_radius", "too_small", "out_of_bounds"])
+        for i in range(len(t)):
+            writer.writerow([
+                f"{t[i]:.3f}", f"{xy[i, 0]:.3f}", f"{xy[i, 1]:.3f}",
+                int(result["counts"][i]), int(result["too_small"][i]),
+                int(result["out_of_bounds"][i]),
+            ])
+
+
+def render_plot(path, t, result, min_points):
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except Exception as exc:  # noqa: BLE001
+        print(f"(plot skipped: matplotlib unavailable: {exc})", file=sys.stderr)
+        return
+    fig, ax = plt.subplots(figsize=(9, 4))
+    ax.plot(t, result["counts"], label="map points within radius")
+    ax.axhline(min_points, color="red", linestyle="--", label=f"min_points={min_points}")
+    if result["cliff_index"] is not None:
+        ax.axvline(result["cliff_time"], color="orange", linestyle=":",
+                   label=f"cliff t={result['cliff_time']:.1f}s")
+    ax.set_xlabel("time into run (s)")
+    ax.set_ylabel("in-radius map points")
+    ax.set_yscale("symlog")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(path, dpi=120)
+    print(f"wrote plot {path}")
+
+
+def main():
+    args = parse_args()
+    t, xy = load_reference(args.reference_csv)
+    map_xy = load_map_xy(args.map_pcd, args.max_map_points)
+    result = analyze_coverage(map_xy, xy, t, args.local_map_radius, args.local_map_min_points)
+
+    print(f"poses: {len(t)}  map points (after subsample): {len(map_xy)}")
+    print("map bbox x[%.1f, %.1f] y[%.1f, %.1f]" % result["map_bounds"])
+    print("in-radius count: min %d, median %d, max %d" % (
+        result["min_count"], int(np.median(result["counts"])), int(result["counts"].max())))
+    print(verdict(result, args.local_map_min_points))
+
+    if args.out_csv:
+        write_csv(args.out_csv, t, xy, result)
+        print(f"wrote per-pose coverage {args.out_csv}")
+    if args.plot:
+        render_plot(args.plot, t, result, args.local_map_min_points)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diagnose_local_map_crop_coverage.py
+++ b/scripts/diagnose_local_map_crop_coverage.py
@@ -71,8 +71,11 @@ def count_points_within_radius(map_xy, query_xy, radius_m, chunk=256):
     counts = np.empty(len(query_xy), dtype=np.int64)
     mx = map_xy[:, 0]
     my = map_xy[:, 1]
-    for start in range(0, len(query_xy), chunk):
-        block = query_xy[start:start + chunk]
+    # Bound the (chunk x map) intermediate so a large map cannot OOM the fallback:
+    # cap ~20M float64 elements (~160 MB) per temporary.
+    eff_chunk = max(1, min(chunk, int(20_000_000 // max(1, len(map_xy)))))
+    for start in range(0, len(query_xy), eff_chunk):
+        block = query_xy[start:start + eff_chunk]
         # (block, map) squared distances, chunked over queries to bound memory.
         dx = block[:, 0][:, None] - mx[None, :]
         dy = block[:, 1][:, None] - my[None, :]
@@ -80,7 +83,7 @@ def count_points_within_radius(map_xy, query_xy, radius_m, chunk=256):
     return counts
 
 
-def analyze_coverage(map_xy, traj_xy, traj_t, radius_m, min_points):
+def analyze_coverage(map_xy, traj_xy, traj_t, radius_m, min_points, count_scale=1):
     """Per-pose coverage and the first under-covered (cliff) index.
 
     Returns a dict with: ``counts`` (per pose), ``too_small`` (bool mask),
@@ -90,7 +93,9 @@ def analyze_coverage(map_xy, traj_xy, traj_t, radius_m, min_points):
     """
     map_xy = np.asarray(map_xy, dtype=np.float64)
     traj_xy = np.asarray(traj_xy, dtype=np.float64)
-    counts = count_points_within_radius(map_xy, traj_xy, radius_m)
+    # Scale by the subsample stride so we compare a full-map estimate against the
+    # absolute min_points (a strided map otherwise reports a false cliff).
+    counts = count_points_within_radius(map_xy, traj_xy, radius_m) * int(count_scale)
     too_small = counts < min_points
 
     min_x, min_y = map_xy.min(axis=0)
@@ -161,11 +166,13 @@ def load_map_xy(map_pcd, max_points=None):
     if points.size == 0:
         raise SystemExit(f"map PCD is empty: {map_pcd}")
     xy = points[:, :2]
+    stride = 1
     if max_points and len(xy) > max_points:
-        # Uniform stride subsample keeps spatial coverage representative.
+        # Uniform stride subsample keeps spatial coverage representative; the
+        # caller scales counts by `stride` so min_points stays comparable.
         stride = int(np.ceil(len(xy) / max_points))
         xy = xy[::stride]
-    return xy
+    return xy, stride
 
 
 def parse_args():
@@ -175,8 +182,10 @@ def parse_args():
     p.add_argument("--reference-csv", required=True, type=Path)
     p.add_argument("--local-map-radius", type=float, default=300.0)
     p.add_argument("--local-map-min-points", type=int, default=100)
-    p.add_argument("--max-map-points", type=int, default=2_000_000,
-                   help="Subsample the map above this many points for speed.")
+    p.add_argument("--max-map-points", type=int, default=None,
+                   help="Optional: subsample the map above this many points for "
+                        "speed; counts are scaled back by the stride so min_points "
+                        "stays comparable (an estimate). Default: no subsample.")
     p.add_argument("--out-csv", type=Path, default=None)
     p.add_argument("--plot", type=Path, default=None)
     return p.parse_args()
@@ -220,9 +229,13 @@ def render_plot(path, t, result, min_points):
 def main():
     args = parse_args()
     t, xy = load_reference(args.reference_csv)
-    map_xy = load_map_xy(args.map_pcd, args.max_map_points)
-    result = analyze_coverage(map_xy, xy, t, args.local_map_radius, args.local_map_min_points)
+    map_xy, stride = load_map_xy(args.map_pcd, args.max_map_points)
+    result = analyze_coverage(
+        map_xy, xy, t, args.local_map_radius, args.local_map_min_points, count_scale=stride)
 
+    if stride > 1:
+        print(f"NOTE: map subsampled by stride {stride}; in-radius counts are "
+              f"estimated (raw count x {stride}).")
     print(f"poses: {len(t)}  map points (after subsample): {len(map_xy)}")
     print("map bbox x[%.1f, %.1f] y[%.1f, %.1f]" % result["map_bounds"])
     print("in-radius count: min %d, median %d, max %d" % (

--- a/scripts/global_localization_node.py
+++ b/scripts/global_localization_node.py
@@ -117,19 +117,25 @@ class GlobalLocalizationNode(Node):
             pose_array.poses.append(pose)
         self.candidates_pub.publish(pose_array)
 
+        ranked = [
+            {
+                "x": round(c.x_m, 3),
+                "y": round(c.y_m, 3),
+                "yaw_deg": round(math.degrees(c.yaw_rad), 1),
+                "score": round(c.score, 4),
+            }
+            for c in result.candidates
+        ]
         summary = {
             "candidate_count": len(result.candidates),
             "scan_point_count": result.scan_point_count,
             "runtime_sec": round(runtime_sec, 3),
+            # Full ranked list (high-to-low) so a consumer can walk past an
+            # aliased top candidate; "top" kept for back-compat.
+            "candidates": ranked,
         }
-        if result.candidates:
-            top = result.candidates[0]
-            summary["top"] = {
-                "x": round(top.x_m, 3),
-                "y": round(top.y_m, 3),
-                "yaw_deg": round(math.degrees(top.yaw_rad), 1),
-                "score": round(top.score, 4),
-            }
+        if ranked:
+            summary["top"] = ranked[0]
         response.success = bool(result.candidates)
         response.message = json.dumps(summary)
         self.get_logger().info("query answered: %s" % response.message)

--- a/scripts/reinitialization_supervisor_node.py
+++ b/scripts/reinitialization_supervisor_node.py
@@ -40,6 +40,28 @@ from std_srvs.srv import Trigger
 import reinitialization_supervisor_policy as rsp
 
 
+def _roll_pitch_from_quat(x: float, y: float, z: float, w: float):
+    """Extract (roll, pitch) from a quaternion (yaw is taken from the candidate)."""
+    sinr_cosp = 2.0 * (w * x + y * z)
+    cosr_cosp = 1.0 - 2.0 * (x * x + y * y)
+    roll = math.atan2(sinr_cosp, cosr_cosp)
+    sinp = max(-1.0, min(1.0, 2.0 * (w * y - z * x)))
+    pitch = math.asin(sinp)
+    return roll, pitch
+
+
+def _quat_from_rpy(roll: float, pitch: float, yaw: float):
+    """Quaternion (x, y, z, w) from roll/pitch/yaw (ZYX convention)."""
+    cy, sy = math.cos(yaw * 0.5), math.sin(yaw * 0.5)
+    cp, sp = math.cos(pitch * 0.5), math.sin(pitch * 0.5)
+    cr, sr = math.cos(roll * 0.5), math.sin(roll * 0.5)
+    x = sr * cp * cy - cr * sp * sy
+    y = cr * sp * cy + sr * cp * sy
+    z = cr * cp * sy - sr * sp * cy
+    w = cr * cp * cy + sr * sp * sy
+    return x, y, z, w
+
+
 class ReinitializationSupervisorNode(Node):
     def __init__(self) -> None:
         super().__init__("reinitialization_supervisor_node")
@@ -50,6 +72,10 @@ class ReinitializationSupervisorNode(Node):
         self.declare_parameter("query_service", "/global_localization_node/query")
         self.declare_parameter("global_frame_id", "map")
         self.declare_parameter("tick_period_sec", 0.5)
+        # Localizer pose output, used to carry z / roll / pitch onto a 2D candidate.
+        self.declare_parameter("pose_topic", "/pcl_pose")
+        # Fallback z if no pose has been observed yet (e.g. a cold kidnapped start).
+        self.declare_parameter("reset_default_z_m", 0.0)
         # Initial-pose covariance to advertise on a reset (diagonal x, y, yaw).
         self.declare_parameter("reset_position_std_m", 0.5)
         self.declare_parameter("reset_yaw_std_rad", 0.25)
@@ -78,10 +104,20 @@ class ReinitializationSupervisorNode(Node):
         self.global_frame_id = self.get_parameter("global_frame_id").value
         self.position_std = float(self.get_parameter("reset_position_std_m").value)
         self.yaw_std = float(self.get_parameter("reset_yaw_std_rad").value)
+        self.reset_default_z = float(self.get_parameter("reset_default_z_m").value)
 
         # Latest observed signals.
         self._requested = False
         self._fitness = None
+        # Latest z / roll / pitch from the localizer pose. A G2 candidate is 2D
+        # (x, y, yaw, z=0); on an outdoor map the true z can be tens of metres from
+        # zero, which seeds the reset outside the registration z-basin and the lock
+        # never takes. The vehicle's height and attitude drift slowly even while xy
+        # tracking is lost, so the most recent pose's z / roll / pitch are a good
+        # carry-over -- we override only x / y / yaw from the candidate.
+        self._last_pose_z = None
+        self._last_pose_roll = 0.0
+        self._last_pose_pitch = 0.0
         # One-shot service reply delivered to the policy once: a tuple of ranked
         # candidate scores (high-to-low), or () for a reply that carried no usable
         # candidate. None means no reply is pending this tick.
@@ -101,6 +137,9 @@ class ReinitializationSupervisorNode(Node):
         self.create_subscription(
             DiagnosticArray, self.get_parameter("alignment_status_topic").value,
             self._on_alignment_status, 10)
+        self.create_subscription(
+            PoseWithCovarianceStamped, self.get_parameter("pose_topic").value,
+            self._on_pose, 10)
         self.initialpose_pub = self.create_publisher(
             PoseWithCovarianceStamped, self.get_parameter("initialpose_topic").value,
             reliable)
@@ -126,6 +165,12 @@ class ReinitializationSupervisorNode(Node):
                     except ValueError:
                         pass
                     return
+
+    def _on_pose(self, msg: PoseWithCovarianceStamped) -> None:
+        p = msg.pose.pose
+        self._last_pose_z = float(p.position.z)
+        self._last_pose_roll, self._last_pose_pitch = _roll_pitch_from_quat(
+            p.orientation.x, p.orientation.y, p.orientation.z, p.orientation.w)
 
     # --- main loop -----------------------------------------------------------
 
@@ -202,13 +247,22 @@ class ReinitializationSupervisorNode(Node):
             return
         top = self._candidates[candidate_index]
         yaw = math.radians(top["yaw_deg"])
+        # The candidate is 2D (x, y, yaw); carry z / roll / pitch from the last
+        # localizer pose so the seed lands in the registration z-basin on a non-flat
+        # map. Fall back to the configured default z if no pose seen yet.
+        z = self._last_pose_z if self._last_pose_z is not None else self.reset_default_z
+        qx, qy, qz, qw = _quat_from_rpy(
+            self._last_pose_roll, self._last_pose_pitch, yaw)
         msg = PoseWithCovarianceStamped()
         msg.header.stamp = self.get_clock().now().to_msg()
         msg.header.frame_id = self.global_frame_id
         msg.pose.pose.position.x = float(top["x"])
         msg.pose.pose.position.y = float(top["y"])
-        msg.pose.pose.orientation.z = math.sin(yaw / 2.0)
-        msg.pose.pose.orientation.w = math.cos(yaw / 2.0)
+        msg.pose.pose.position.z = float(z)
+        msg.pose.pose.orientation.x = qx
+        msg.pose.pose.orientation.y = qy
+        msg.pose.pose.orientation.z = qz
+        msg.pose.pose.orientation.w = qw
         cov = [0.0] * 36
         cov[0] = self.position_std ** 2          # x
         cov[7] = self.position_std ** 2          # y
@@ -216,9 +270,9 @@ class ReinitializationSupervisorNode(Node):
         msg.pose.covariance = cov
         self.initialpose_pub.publish(msg)
         self.get_logger().warn(
-            "published /initialpose reset to (%.2f, %.2f, %.1f deg) score=%s "
+            "published /initialpose reset to (%.2f, %.2f, z=%.2f, %.1f deg) score=%s "
             "[candidate %d/%d]"
-            % (top["x"], top["y"], top["yaw_deg"], top["score"],
+            % (top["x"], top["y"], z, top["yaw_deg"], top["score"],
                candidate_index + 1, len(self._candidates)))
 
 

--- a/scripts/reinitialization_supervisor_node.py
+++ b/scripts/reinitialization_supervisor_node.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""G3 guarded automatic reinitialization node.
+
+Closes the global-localization recovery loop: it watches the localization
+component's `/reinitialization_requested` signal (raised by the C++ recovery
+supervisor when tracking is judged lost) and, behind the safety guards in
+``reinitialization_supervisor_policy``, queries the G2 global-localization
+service and republishes `/initialpose` to reseed tracking.
+
+All of the *decision* logic -- when to query, when it is safe to publish a reset,
+when to give up -- lives in the ROS-free policy module and is regression-tested in
+``test/test_reinitialization_supervisor_policy.py``. This node is only the I/O
+shell: subscribe, call the service, publish, and feed observations to the policy.
+
+Opt-in only, exactly like the G2 node: it is never part of the default launch and
+publishes nothing until `/reinitialization_requested` is asserted and every guard
+in the policy is satisfied.
+
+Wiring::
+
+    /reinitialization_requested (std_msgs/Bool)      --in-->  supervisor
+    /alignment_status (diagnostic_msgs/DiagnosticArray) --in--> supervisor (fitness)
+    <query_service> (std_srvs/Trigger)               <--call-- supervisor
+    /initialpose (geometry_msgs/PoseWithCovarianceStamped) <-pub- supervisor
+"""
+
+import json
+import math
+import time
+
+import rclpy
+from diagnostic_msgs.msg import DiagnosticArray
+from geometry_msgs.msg import PoseWithCovarianceStamped
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+from std_msgs.msg import Bool
+from std_srvs.srv import Trigger
+
+import reinitialization_supervisor_policy as rsp
+
+
+class ReinitializationSupervisorNode(Node):
+    def __init__(self) -> None:
+        super().__init__("reinitialization_supervisor_node")
+
+        self.declare_parameter("reinitialization_topic", "/reinitialization_requested")
+        self.declare_parameter("alignment_status_topic", "/alignment_status")
+        self.declare_parameter("initialpose_topic", "/initialpose")
+        self.declare_parameter("query_service", "/global_localization_node/query")
+        self.declare_parameter("global_frame_id", "map")
+        self.declare_parameter("tick_period_sec", 0.5)
+        # Initial-pose covariance to advertise on a reset (diagonal x, y, yaw).
+        self.declare_parameter("reset_position_std_m", 0.5)
+        self.declare_parameter("reset_yaw_std_rad", 0.25)
+        # Guard policy parameters (see reinitialization_supervisor_policy).
+        self.declare_parameter("request_debounce_sec", 1.0)
+        self.declare_parameter("min_seconds_between_attempts", 5.0)
+        self.declare_parameter("max_attempts", 3)
+        self.declare_parameter("min_candidate_score", 0.6)
+        self.declare_parameter("query_timeout_sec", 10.0)
+        self.declare_parameter("settle_timeout_sec", 8.0)
+        self.declare_parameter("recovery_fitness_threshold", 1.5)
+
+        self.params = rsp.SupervisorParams(
+            request_debounce_sec=float(self.get_parameter("request_debounce_sec").value),
+            min_seconds_between_attempts=float(
+                self.get_parameter("min_seconds_between_attempts").value),
+            max_attempts=int(self.get_parameter("max_attempts").value),
+            min_candidate_score=float(self.get_parameter("min_candidate_score").value),
+            query_timeout_sec=float(self.get_parameter("query_timeout_sec").value),
+            settle_timeout_sec=float(self.get_parameter("settle_timeout_sec").value),
+            recovery_fitness_threshold=float(
+                self.get_parameter("recovery_fitness_threshold").value),
+        )
+        self.state = rsp.initial_state()
+
+        self.global_frame_id = self.get_parameter("global_frame_id").value
+        self.position_std = float(self.get_parameter("reset_position_std_m").value)
+        self.yaw_std = float(self.get_parameter("reset_yaw_std_rad").value)
+
+        # Latest observed signals.
+        self._requested = False
+        self._fitness = None
+        # One-shot service reply: (score, pose-dict) delivered to the policy once.
+        self._pending_reply = None
+        self._query_in_flight = False
+        # The candidate most recently approved for publication.
+        self._last_top = None
+
+        reliable = QoSProfile(depth=1)
+        reliable.reliability = ReliabilityPolicy.RELIABLE
+
+        self.create_subscription(
+            Bool, self.get_parameter("reinitialization_topic").value,
+            self._on_reinit, reliable)
+        self.create_subscription(
+            DiagnosticArray, self.get_parameter("alignment_status_topic").value,
+            self._on_alignment_status, 10)
+        self.initialpose_pub = self.create_publisher(
+            PoseWithCovarianceStamped, self.get_parameter("initialpose_topic").value,
+            reliable)
+        self.query_client = self.create_client(
+            Trigger, self.get_parameter("query_service").value)
+
+        self.create_timer(
+            float(self.get_parameter("tick_period_sec").value), self._tick)
+        self.get_logger().info(
+            "reinitialization supervisor ready (opt-in); guards=%s" % (self.params,))
+
+    # --- subscriptions -------------------------------------------------------
+
+    def _on_reinit(self, msg: Bool) -> None:
+        self._requested = bool(msg.data)
+
+    def _on_alignment_status(self, msg: DiagnosticArray) -> None:
+        for status in msg.status:
+            for kv in status.values:
+                if kv.key == "fitness_score":
+                    try:
+                        self._fitness = float(kv.value)
+                    except ValueError:
+                        pass
+                    return
+
+    # --- main loop -----------------------------------------------------------
+
+    def _tick(self) -> None:
+        now = time.monotonic()
+        score = None
+        if self._pending_reply is not None:
+            score, self._last_top = self._pending_reply
+            self._pending_reply = None
+
+        obs = rsp.SupervisorObservation(
+            now_sec=now,
+            reinitialization_requested=self._requested,
+            best_candidate_score=score,
+            best_fitness=self._fitness,
+        )
+        decision = rsp.decide(self.params, self.state, obs)
+        self.state = decision.state
+
+        if decision.action == rsp.ACTION_QUERY:
+            self._issue_query()
+        elif decision.action == rsp.ACTION_PUBLISH_RESET:
+            self._publish_reset()
+        elif decision.action == rsp.ACTION_GIVE_UP:
+            self.get_logger().error(
+                "reinitialization gave up (%s) after %d attempt(s); operator "
+                "intervention needed" % (decision.reason, self.state.attempts))
+
+        if decision.reason not in ("tracking", "settling", "cooldown", "standdown",
+                                   "exhausted", "awaiting_candidates"):
+            self.get_logger().info(
+                "supervisor: %s -> %s (%s)"
+                % (decision.action, self.state.name, decision.reason))
+
+    def _issue_query(self) -> None:
+        if not self.query_client.service_is_ready():
+            self.get_logger().warn("query service not available; will retry")
+            return
+        future = self.query_client.call_async(Trigger.Request())
+        future.add_done_callback(self._on_query_response)
+        self._query_in_flight = True
+
+    def _on_query_response(self, future) -> None:
+        self._query_in_flight = False
+        try:
+            response = future.result()
+        except Exception as exc:  # noqa: BLE001 - log and let the policy time out
+            self.get_logger().warn("query call failed: %s" % exc)
+            return
+        if not response.success:
+            self.get_logger().info("query returned no candidate: %s" % response.message)
+            # Deliver a sub-threshold score so the policy counts a failed attempt.
+            self._pending_reply = (float("-inf"), None)
+            return
+        try:
+            summary = json.loads(response.message)
+            top = summary["top"]
+            score = float(top["score"])
+        except (ValueError, KeyError) as exc:
+            self.get_logger().warn("could not parse query reply: %s" % exc)
+            self._pending_reply = (float("-inf"), None)
+            return
+        self._pending_reply = (score, top)
+
+    def _publish_reset(self) -> None:
+        if self._last_top is None:
+            self.get_logger().error("publish_reset requested with no candidate; skipping")
+            return
+        top = self._last_top
+        yaw = math.radians(top["yaw_deg"])
+        msg = PoseWithCovarianceStamped()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = self.global_frame_id
+        msg.pose.pose.position.x = float(top["x"])
+        msg.pose.pose.position.y = float(top["y"])
+        msg.pose.pose.orientation.z = math.sin(yaw / 2.0)
+        msg.pose.pose.orientation.w = math.cos(yaw / 2.0)
+        cov = [0.0] * 36
+        cov[0] = self.position_std ** 2          # x
+        cov[7] = self.position_std ** 2          # y
+        cov[35] = self.yaw_std ** 2              # yaw
+        msg.pose.covariance = cov
+        self.initialpose_pub.publish(msg)
+        self.get_logger().warn(
+            "published /initialpose reset to (%.2f, %.2f, %.1f deg) score=%s"
+            % (top["x"], top["y"], top["yaw_deg"], top["score"]))
+
+
+def main() -> None:
+    rclpy.init()
+    node = ReinitializationSupervisorNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reinitialization_supervisor_node.py
+++ b/scripts/reinitialization_supervisor_node.py
@@ -82,11 +82,15 @@ class ReinitializationSupervisorNode(Node):
         # Latest observed signals.
         self._requested = False
         self._fitness = None
-        # One-shot service reply: (score, pose-dict) delivered to the policy once.
+        # One-shot service reply delivered to the policy once: a tuple of ranked
+        # candidate scores (high-to-low), or () for a reply that carried no usable
+        # candidate. None means no reply is pending this tick.
         self._pending_reply = None
         self._query_in_flight = False
-        # The candidate most recently approved for publication.
-        self._last_top = None
+        # Ranked candidate poses from the most recent query reply, indexed by the
+        # policy's candidate_index when it asks for a publish (the ranked-candidate
+        # walk -- see reinitialization_supervisor_policy).
+        self._candidates = []
 
         reliable = QoSProfile(depth=1)
         reliable.reliability = ReliabilityPolicy.RELIABLE
@@ -127,15 +131,15 @@ class ReinitializationSupervisorNode(Node):
 
     def _tick(self) -> None:
         now = time.monotonic()
-        score = None
+        candidate_scores = None
         if self._pending_reply is not None:
-            score, self._last_top = self._pending_reply
+            candidate_scores = self._pending_reply
             self._pending_reply = None
 
         obs = rsp.SupervisorObservation(
             now_sec=now,
             reinitialization_requested=self._requested,
-            best_candidate_score=score,
+            candidate_scores=candidate_scores,
             best_fitness=self._fitness,
         )
         decision = rsp.decide(self.params, self.state, obs)
@@ -144,7 +148,7 @@ class ReinitializationSupervisorNode(Node):
         if decision.action == rsp.ACTION_QUERY:
             self._issue_query()
         elif decision.action == rsp.ACTION_PUBLISH_RESET:
-            self._publish_reset()
+            self._publish_reset(decision.candidate_index)
         elif decision.action == rsp.ACTION_GIVE_UP:
             self.get_logger().error(
                 "reinitialization gave up (%s) after %d attempt(s); operator "
@@ -173,24 +177,30 @@ class ReinitializationSupervisorNode(Node):
             return
         if not response.success:
             self.get_logger().info("query returned no candidate: %s" % response.message)
-            # Deliver a sub-threshold score so the policy counts a failed attempt.
-            self._pending_reply = (float("-inf"), None)
+            # Empty reply -> the policy counts a failed attempt.
+            self._candidates = []
+            self._pending_reply = ()
             return
         try:
             summary = json.loads(response.message)
-            top = summary["top"]
-            score = float(top["score"])
-        except (ValueError, KeyError) as exc:
+            candidates = summary.get("candidates")
+            if not candidates:
+                # Back-compat with a G2 that only reports the single "top" candidate.
+                candidates = [summary["top"]]
+            scores = tuple(float(c["score"]) for c in candidates)
+        except (ValueError, KeyError, TypeError) as exc:
             self.get_logger().warn("could not parse query reply: %s" % exc)
-            self._pending_reply = (float("-inf"), None)
+            self._candidates = []
+            self._pending_reply = ()
             return
-        self._pending_reply = (score, top)
+        self._candidates = candidates
+        self._pending_reply = scores
 
-    def _publish_reset(self) -> None:
-        if self._last_top is None:
+    def _publish_reset(self, candidate_index: int = 0) -> None:
+        if not self._candidates or candidate_index >= len(self._candidates):
             self.get_logger().error("publish_reset requested with no candidate; skipping")
             return
-        top = self._last_top
+        top = self._candidates[candidate_index]
         yaw = math.radians(top["yaw_deg"])
         msg = PoseWithCovarianceStamped()
         msg.header.stamp = self.get_clock().now().to_msg()
@@ -206,8 +216,10 @@ class ReinitializationSupervisorNode(Node):
         msg.pose.covariance = cov
         self.initialpose_pub.publish(msg)
         self.get_logger().warn(
-            "published /initialpose reset to (%.2f, %.2f, %.1f deg) score=%s"
-            % (top["x"], top["y"], top["yaw_deg"], top["score"]))
+            "published /initialpose reset to (%.2f, %.2f, %.1f deg) score=%s "
+            "[candidate %d/%d]"
+            % (top["x"], top["y"], top["yaw_deg"], top["score"],
+               candidate_index + 1, len(self._candidates)))
 
 
 def main() -> None:

--- a/scripts/reinitialization_supervisor_node.py
+++ b/scripts/reinitialization_supervisor_node.py
@@ -87,6 +87,7 @@ class ReinitializationSupervisorNode(Node):
         self.declare_parameter("query_timeout_sec", 10.0)
         self.declare_parameter("settle_timeout_sec", 8.0)
         self.declare_parameter("recovery_fitness_threshold", 1.5)
+        self.declare_parameter("max_walk_candidates", 4)
 
         self.params = rsp.SupervisorParams(
             request_debounce_sec=float(self.get_parameter("request_debounce_sec").value),
@@ -98,6 +99,7 @@ class ReinitializationSupervisorNode(Node):
             settle_timeout_sec=float(self.get_parameter("settle_timeout_sec").value),
             recovery_fitness_threshold=float(
                 self.get_parameter("recovery_fitness_threshold").value),
+            max_walk_candidates=int(self.get_parameter("max_walk_candidates").value),
         )
         self.state = rsp.initial_state()
 

--- a/scripts/reinitialization_supervisor_node.py
+++ b/scripts/reinitialization_supervisor_node.py
@@ -31,6 +31,7 @@ import time
 import rclpy
 from diagnostic_msgs.msg import DiagnosticArray
 from geometry_msgs.msg import PoseWithCovarianceStamped
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rclpy.qos import QoSProfile, ReliabilityPolicy
 from std_msgs.msg import Bool
@@ -214,11 +215,14 @@ def main() -> None:
     node = ReinitializationSupervisorNode()
     try:
         rclpy.spin(node)
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, ExternalShutdownException):
+        # Normal shutdown paths: Ctrl-C, or an external SIGTERM / context
+        # shutdown (the latter raises ExternalShutdownException from spin).
         pass
     finally:
         node.destroy_node()
-        rclpy.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/scripts/reinitialization_supervisor_policy.py
+++ b/scripts/reinitialization_supervisor_policy.py
@@ -53,6 +53,13 @@ poses it actually found. A wrong reset is rejected by the localizer (high fitnes
 accepted pose), so walking cannot cause the Phase 3 *acceptance* blowup -- it only
 changes which seed is offered next.
 
+The walk is bounded by ``max_walk_candidates``: the same live run showed a *stale*
+query can return a full ranked list none of whose poses lock, so walking all 16 burned
+~95 s at ``settle_timeout_sec`` each before the next query -- on a newer, more
+distinctive scan -- produced the candidate that recovered. Past the top few occupancy
+maxima a fresh query beats a deeper walk, so the supervisor abandons the query after
+``max_walk_candidates`` and re-queries (spending one attempt) instead.
+
 These map directly onto the G3 Decision Gates in
 ``docs/global_localization_roadmap.md``. ``test_reinitialization_supervisor_policy.py``
 fails if any of them regress.
@@ -113,6 +120,16 @@ class SupervisorParams:
     settle_timeout_sec: float = 8.0
     # Post-reset alignment fitness at or below this counts as recovered.
     recovery_fitness_threshold: float = 1.5
+    # Walk at most this many candidates from one query (counting the top one)
+    # before abandoning the whole query and re-querying with a fresh scan. The
+    # 2026-06-15 live run (docs/g3_live_closed_loop.md) showed a stale query can
+    # return a full ranked list none of whose poses lock, so walking all 16 just
+    # burned ~95 s at settle_timeout_sec each before the *next* query -- on a
+    # newer, more distinctive scan -- produced the candidate that recovered. Past
+    # the top few BBS occupancy maxima a fresh query beats a deeper walk, so cap
+    # the walk and spend the time on a new scan instead. Set very high to restore
+    # walking the entire list.
+    max_walk_candidates: int = 4
 
 
 @dataclass(frozen=True)
@@ -276,6 +293,7 @@ def decide(
             # spending another attempt -- only re-querying consumes max_attempts.
             next_index = state.candidate_index + 1
             if (next_index < len(state.candidate_scores)
+                    and next_index < params.max_walk_candidates
                     and state.candidate_scores[next_index] >= params.min_candidate_score):
                 return SupervisorDecision(
                     ACTION_PUBLISH_RESET, "next_candidate",

--- a/scripts/reinitialization_supervisor_policy.py
+++ b/scripts/reinitialization_supervisor_policy.py
@@ -36,6 +36,23 @@ non-self-resetting bounds:
 * the attempt counter only resets on a confirmed recovery or when the request
   clears, never as a side effect of attempting -- so it is a true ceiling.
 
+Ranked-candidate walk -- the live-run lesson
+--------------------------------------------
+The 2026-06-15 live closed-loop run (docs/g3_live_closed_loop.md) showed the
+*candidate score is not a registration score*: G2's BBS occupancy score labelled a
+190 m-wrong candidate 0.99 and the 5.5 m-correct one 0.998, so the score floor alone
+cannot separate them. The localizer's own NDT fitness *can* (that is what its
+`score_threshold` does). So when a query returns a ranked list, the supervisor walks
+it: it publishes the top candidate, waits ``settle_timeout_sec`` for the localizer to
+show recovery (fitness under ``recovery_fitness_threshold``), and if it does not,
+publishes the *next* candidate from the same query -- using the localizer's fitness as
+the registration oracle -- before spending another ``max_attempts`` slot on a fresh
+query. Walking within one query does not consume an attempt; only re-querying does, so
+``max_attempts`` stays a true ceiling on queries while letting one query try all the
+poses it actually found. A wrong reset is rejected by the localizer (high fitness, no
+accepted pose), so walking cannot cause the Phase 3 *acceptance* blowup -- it only
+changes which seed is offered next.
+
 These map directly onto the G3 Decision Gates in
 ``docs/global_localization_roadmap.md``. ``test_reinitialization_supervisor_policy.py``
 fails if any of them regress.
@@ -50,8 +67,8 @@ Conventions
   a clock, so replays are exact.
 """
 
-from dataclasses import dataclass, replace
-from typing import Optional
+from dataclasses import dataclass, field, replace
+from typing import Optional, Tuple
 
 # Supervisor states. The names mirror the C++ RecoverySupervisorState vocabulary
 # where they overlap so the two halves of the loop read consistently in logs.
@@ -110,6 +127,12 @@ class SupervisorState:
     last_reset_sec: Optional[float] = None
     # When the current cooldown began.
     cooldown_since_sec: Optional[float] = None
+    # Ranked candidate scores (high-to-low) from the query currently being walked,
+    # and the index of the candidate published most recently. Set when a query
+    # reply is consumed; used to walk to the next-best candidate on a failed settle
+    # without spending another attempt.
+    candidate_scores: Tuple[float, ...] = field(default_factory=tuple)
+    candidate_index: int = 0
 
 
 @dataclass(frozen=True)
@@ -117,8 +140,13 @@ class SupervisorObservation:
     now_sec: float
     reinitialization_requested: bool
     # Best candidate score from the most recent service reply, if one is ready
-    # this tick (None while no fresh reply is available).
+    # this tick (None while no fresh reply is available). Back-compat shorthand for
+    # a single-candidate reply; prefer ``candidate_scores`` for the full ranked list.
     best_candidate_score: Optional[float] = None
+    # Full ranked candidate scores (high-to-low) from the most recent reply, if one
+    # is ready this tick. When present it supersedes ``best_candidate_score`` and
+    # enables the ranked-candidate walk. None while no fresh reply is available.
+    candidate_scores: Optional[Tuple[float, ...]] = None
     # Current alignment fitness, if known (lower is better).
     best_fitness: Optional[float] = None
 
@@ -128,6 +156,9 @@ class SupervisorDecision:
     action: str
     reason: str
     state: SupervisorState
+    # On ACTION_PUBLISH_RESET, which candidate (rank index, 0 = best) the node must
+    # publish. The node holds the ranked candidate poses from the last query reply.
+    candidate_index: int = 0
 
 
 def initial_state() -> SupervisorState:
@@ -141,6 +172,23 @@ def _cooldown(state: SupervisorState, now_sec: float, reason: str) -> Supervisor
         replace(state, name=STATE_COOLDOWN, cooldown_since_sec=now_sec,
                 query_issued_sec=None),
     )
+
+
+def _resolve_candidate_scores(
+    obs: SupervisorObservation,
+) -> Optional[Tuple[float, ...]]:
+    """Return the ranked candidate scores ready this tick, or None if no reply.
+
+    Prefers the full ranked ``candidate_scores`` list; falls back to the
+    single-candidate ``best_candidate_score`` shorthand for back-compat. An empty
+    tuple means a reply arrived but carried no usable candidate (distinct from None,
+    which means no reply yet).
+    """
+    if obs.candidate_scores is not None:
+        return tuple(obs.candidate_scores)
+    if obs.best_candidate_score is not None:
+        return (obs.best_candidate_score,)
+    return None
 
 
 def decide(
@@ -190,15 +238,21 @@ def decide(
             replace(state, name=STATE_AWAIT_CANDIDATES, query_issued_sec=now))
 
     if name == STATE_AWAIT_CANDIDATES:
-        if obs.best_candidate_score is not None:
-            if obs.best_candidate_score >= params.min_candidate_score:
+        reply_scores = _resolve_candidate_scores(obs)
+        if reply_scores is not None:
+            if reply_scores and reply_scores[0] >= params.min_candidate_score:
+                # Publish the best candidate and start walking the ranked list.
                 return SupervisorDecision(
                     ACTION_PUBLISH_RESET, "reset_published",
                     replace(state, name=STATE_SETTLING, last_reset_sec=now,
-                            query_issued_sec=None, attempts=state.attempts + 1))
-            # Confidently-bad candidate: never publish it; count the attempt.
+                            query_issued_sec=None, attempts=state.attempts + 1,
+                            candidate_scores=tuple(reply_scores), candidate_index=0),
+                    candidate_index=0)
+            # Empty list or confidently-bad best candidate: never publish; count attempt.
             return _cooldown(
-                replace(state, attempts=state.attempts + 1), now, "weak_candidate_rejected")
+                replace(state, attempts=state.attempts + 1,
+                        candidate_scores=(), candidate_index=0),
+                now, "weak_candidate_rejected")
         # No candidates yet -- wait, or abandon on timeout.
         if (state.query_issued_sec is not None
                 and now - state.query_issued_sec >= params.query_timeout_sec):
@@ -215,14 +269,27 @@ def decide(
             return SupervisorDecision(
                 ACTION_NONE, "recovery_confirmed",
                 replace(state, name=STATE_STANDDOWN, attempts=0, last_reset_sec=None,
-                        cooldown_since_sec=None))
+                        cooldown_since_sec=None, candidate_scores=(), candidate_index=0))
         if state.last_reset_sec is not None and now - state.last_reset_sec >= params.settle_timeout_sec:
-            # Reset did not take. Give up if exhausted, else cool down and retry.
+            # This candidate did not take. Walk to the next-best candidate from the
+            # same query (the localizer's fitness is the registration oracle) before
+            # spending another attempt -- only re-querying consumes max_attempts.
+            next_index = state.candidate_index + 1
+            if (next_index < len(state.candidate_scores)
+                    and state.candidate_scores[next_index] >= params.min_candidate_score):
+                return SupervisorDecision(
+                    ACTION_PUBLISH_RESET, "next_candidate",
+                    replace(state, last_reset_sec=now, candidate_index=next_index),
+                    candidate_index=next_index)
+            # Ranked list exhausted: the whole query failed. Give up if the attempt
+            # ceiling is reached, else cool down and re-query.
             if state.attempts >= params.max_attempts:
                 return SupervisorDecision(
                     ACTION_GIVE_UP, "recovery_failed_exhausted",
                     replace(state, name=STATE_EXHAUSTED))
-            return _cooldown(state, now, "recovery_unconfirmed")
+            return _cooldown(
+                replace(state, candidate_scores=(), candidate_index=0),
+                now, "recovery_unconfirmed")
         return SupervisorDecision(ACTION_NONE, "settling", state)
 
     if name == STATE_COOLDOWN:

--- a/scripts/reinitialization_supervisor_policy.py
+++ b/scripts/reinitialization_supervisor_policy.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""ROS-free guard policy for G3 automatic reinitialization.
+
+The localization component already decides *when* recovery is needed and
+publishes `/reinitialization_requested` (std_msgs/Bool) from its C++ recovery
+supervisor. G3 closes the loop: on a sustained request it queries the G2
+global-localization service, and -- only if the result clears explicit safety
+gates -- republishes `/initialpose` to reseed tracking.
+
+This module is the safety brain of that loop, deliberately separated from ROS so
+it can be exhaustively regression-tested. It is a deterministic reducer:
+
+    decide(params, state, observation) -> SupervisorDecision
+
+The node threads the returned ``state`` back in on the next tick and performs the
+returned ``action`` (query the service, publish a reset, or surface a give-up).
+
+Why a guard at all -- the Phase 3 lesson
+----------------------------------------
+The degraded-acceptance work (development_plan.md, 2026-06-12) showed that a
+closed loop which feeds its own corrections back into an acceptance decision can
+diverge catastrophically (0.58 m -> 62.7 m) even when every single-shot fixture
+looked healthy, because the budget that was supposed to bound bad acceptances was
+reset by the very acceptances it was meant to limit. A reinitialization loop has
+the same failure shape: a confidently-scored-but-wrong candidate can be published
+forever if nothing bounds the attempts. So the guard here is built around hard,
+non-self-resetting bounds:
+
+* never publish a candidate whose score is below ``min_candidate_score``
+  (no *unsafe publication*);
+* never publish two resets closer than ``min_seconds_between_attempts``;
+* after a reset, require *post-reset recovery evidence* (fitness back under
+  ``recovery_fitness_threshold`` within ``settle_timeout_sec``) before standing
+  down -- and if it never recovers, give up after ``max_attempts`` instead of
+  looping (no *false-acceptance loop*);
+* the attempt counter only resets on a confirmed recovery or when the request
+  clears, never as a side effect of attempting -- so it is a true ceiling.
+
+These map directly onto the G3 Decision Gates in
+``docs/global_localization_roadmap.md``. ``test_reinitialization_supervisor_policy.py``
+fails if any of them regress.
+
+Conventions
+-----------
+* Candidate ``score`` is "higher is better" (BBS hit ratio, ~0.99 on a good lock),
+  matching ``GlobalLocalizationCandidate.score``.
+* ``fitness`` is "lower is better" (NDT/GICP alignment fitness), matching the
+  localization component's ``/alignment_status`` fitness.
+* All times are monotonic seconds supplied by the caller; the module never reads
+  a clock, so replays are exact.
+"""
+
+from dataclasses import dataclass, replace
+from typing import Optional
+
+# Supervisor states. The names mirror the C++ RecoverySupervisorState vocabulary
+# where they overlap so the two halves of the loop read consistently in logs.
+STATE_IDLE = "idle"
+STATE_AWAIT_QUERY = "await_query"
+STATE_AWAIT_CANDIDATES = "await_candidates"
+STATE_SETTLING = "settling"
+STATE_COOLDOWN = "cooldown"
+# Terminal-but-recoverable: the loop reached an outcome (recovered, or gave up)
+# and now waits for the request to de-assert before it will act again. This makes
+# the supervisor edge-triggered on the *next* problem rather than re-firing on a
+# request line that is still (or stuck) high -- the Phase 3 lesson that a bound
+# must not be cleared by the act it bounds. The C++ recovery supervisor is
+# expected to drop /reinitialization_requested once tracking recovers, providing
+# that clean edge; this state also protects us if it does not.
+STATE_STANDDOWN = "standdown"
+STATE_EXHAUSTED = "exhausted"
+
+# Actions the node must carry out for a decision.
+ACTION_NONE = "none"
+ACTION_QUERY = "query"
+ACTION_PUBLISH_RESET = "publish_reset"
+ACTION_GIVE_UP = "give_up"
+
+
+@dataclass(frozen=True)
+class SupervisorParams:
+    # A request must stay asserted this long before the first query, so a single
+    # transient blip does not trigger a reset.
+    request_debounce_sec: float = 1.0
+    # Minimum spacing between two reset publications (and between attempts).
+    min_seconds_between_attempts: float = 5.0
+    # Hard ceiling on attempts for one continuous problem before giving up.
+    max_attempts: int = 3
+    # Candidates scoring below this are never published.
+    min_candidate_score: float = 0.6
+    # If the service does not return candidates within this long after a query,
+    # the attempt is abandoned (counts against max_attempts).
+    query_timeout_sec: float = 10.0
+    # After a reset, how long to wait for recovery evidence before declaring the
+    # attempt failed.
+    settle_timeout_sec: float = 8.0
+    # Post-reset alignment fitness at or below this counts as recovered.
+    recovery_fitness_threshold: float = 1.5
+
+
+@dataclass(frozen=True)
+class SupervisorState:
+    name: str = STATE_IDLE
+    attempts: int = 0
+    # When the current sustained request was first seen (for debounce).
+    request_since_sec: Optional[float] = None
+    # When the in-flight query was issued (for query_timeout).
+    query_issued_sec: Optional[float] = None
+    # When the most recent reset was published (for settle/cooldown spacing).
+    last_reset_sec: Optional[float] = None
+    # When the current cooldown began.
+    cooldown_since_sec: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class SupervisorObservation:
+    now_sec: float
+    reinitialization_requested: bool
+    # Best candidate score from the most recent service reply, if one is ready
+    # this tick (None while no fresh reply is available).
+    best_candidate_score: Optional[float] = None
+    # Current alignment fitness, if known (lower is better).
+    best_fitness: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class SupervisorDecision:
+    action: str
+    reason: str
+    state: SupervisorState
+
+
+def initial_state() -> SupervisorState:
+    return SupervisorState()
+
+
+def _cooldown(state: SupervisorState, now_sec: float, reason: str) -> SupervisorDecision:
+    return SupervisorDecision(
+        ACTION_NONE,
+        reason,
+        replace(state, name=STATE_COOLDOWN, cooldown_since_sec=now_sec,
+                query_issued_sec=None),
+    )
+
+
+def decide(
+    params: SupervisorParams,
+    state: SupervisorState,
+    obs: SupervisorObservation,
+) -> SupervisorDecision:
+    """Advance the supervisor one tick and return the action to take.
+
+    Pure and deterministic: identical (params, state, obs) always yield the same
+    decision and next state. The returned ``state`` must be threaded back in.
+    """
+    now = obs.now_sec
+    requested = obs.reinitialization_requested
+
+    # Track how long the request has been continuously asserted, for debounce.
+    if requested:
+        request_since = state.request_since_sec if state.request_since_sec is not None else now
+    else:
+        request_since = None
+    state = replace(state, request_since_sec=request_since)
+
+    name = state.name
+
+    if name == STATE_IDLE:
+        if not requested:
+            return SupervisorDecision(ACTION_NONE, "tracking", state)
+        if now - request_since < params.request_debounce_sec:
+            return SupervisorDecision(ACTION_NONE, "request_debouncing", state)
+        # Sustained request: move toward a query (cooldown handled in AWAIT_QUERY).
+        return SupervisorDecision(
+            ACTION_NONE, "request_armed", replace(state, name=STATE_AWAIT_QUERY))
+
+    if name == STATE_AWAIT_QUERY:
+        if not requested:
+            return SupervisorDecision(
+                ACTION_NONE, "request_cleared", replace(state, name=STATE_IDLE, attempts=0))
+        if state.attempts >= params.max_attempts:
+            return SupervisorDecision(
+                ACTION_GIVE_UP, "attempts_exhausted", replace(state, name=STATE_EXHAUSTED))
+        # Respect spacing relative to the previous reset, if any.
+        if (state.last_reset_sec is not None
+                and now - state.last_reset_sec < params.min_seconds_between_attempts):
+            return SupervisorDecision(ACTION_NONE, "spacing_hold", state)
+        return SupervisorDecision(
+            ACTION_QUERY, "query_issued",
+            replace(state, name=STATE_AWAIT_CANDIDATES, query_issued_sec=now))
+
+    if name == STATE_AWAIT_CANDIDATES:
+        if obs.best_candidate_score is not None:
+            if obs.best_candidate_score >= params.min_candidate_score:
+                return SupervisorDecision(
+                    ACTION_PUBLISH_RESET, "reset_published",
+                    replace(state, name=STATE_SETTLING, last_reset_sec=now,
+                            query_issued_sec=None, attempts=state.attempts + 1))
+            # Confidently-bad candidate: never publish it; count the attempt.
+            return _cooldown(
+                replace(state, attempts=state.attempts + 1), now, "weak_candidate_rejected")
+        # No candidates yet -- wait, or abandon on timeout.
+        if (state.query_issued_sec is not None
+                and now - state.query_issued_sec >= params.query_timeout_sec):
+            return _cooldown(
+                replace(state, attempts=state.attempts + 1), now, "query_timeout")
+        return SupervisorDecision(ACTION_NONE, "awaiting_candidates", state)
+
+    if name == STATE_SETTLING:
+        recovered = (obs.best_fitness is not None
+                     and obs.best_fitness <= params.recovery_fitness_threshold)
+        if recovered:
+            # Confirmed recovery: stand down and clear the ceiling, but wait for
+            # the request to de-assert before re-arming (edge-triggered next time).
+            return SupervisorDecision(
+                ACTION_NONE, "recovery_confirmed",
+                replace(state, name=STATE_STANDDOWN, attempts=0, last_reset_sec=None,
+                        cooldown_since_sec=None))
+        if state.last_reset_sec is not None and now - state.last_reset_sec >= params.settle_timeout_sec:
+            # Reset did not take. Give up if exhausted, else cool down and retry.
+            if state.attempts >= params.max_attempts:
+                return SupervisorDecision(
+                    ACTION_GIVE_UP, "recovery_failed_exhausted",
+                    replace(state, name=STATE_EXHAUSTED))
+            return _cooldown(state, now, "recovery_unconfirmed")
+        return SupervisorDecision(ACTION_NONE, "settling", state)
+
+    if name == STATE_COOLDOWN:
+        if state.cooldown_since_sec is not None and now - state.cooldown_since_sec < params.min_seconds_between_attempts:
+            return SupervisorDecision(ACTION_NONE, "cooldown", state)
+        if state.attempts >= params.max_attempts:
+            return SupervisorDecision(
+                ACTION_GIVE_UP, "attempts_exhausted", replace(state, name=STATE_EXHAUSTED))
+        if not requested:
+            return SupervisorDecision(
+                ACTION_NONE, "request_cleared", replace(state, name=STATE_IDLE, attempts=0))
+        return SupervisorDecision(
+            ACTION_NONE, "cooldown_elapsed",
+            replace(state, name=STATE_AWAIT_QUERY, cooldown_since_sec=None))
+
+    if name == STATE_STANDDOWN:
+        # Wait for the request to clear, then re-arm for the next problem.
+        if not requested:
+            return SupervisorDecision(
+                ACTION_NONE, "standdown_cleared",
+                replace(state, name=STATE_IDLE, attempts=0, request_since_sec=None))
+        return SupervisorDecision(ACTION_NONE, "standdown", state)
+
+    if name == STATE_EXHAUSTED:
+        # Latched until the underlying problem clears (request drops) -- the node
+        # should surface this to an operator rather than retry silently.
+        if not requested:
+            return SupervisorDecision(
+                ACTION_NONE, "exhausted_cleared",
+                replace(state, name=STATE_IDLE, attempts=0, last_reset_sec=None,
+                        cooldown_since_sec=None))
+        return SupervisorDecision(ACTION_NONE, "exhausted", state)
+
+    raise ValueError(f"unknown supervisor state: {name!r}")

--- a/src/lidar_localization_node.cpp
+++ b/src/lidar_localization_node.cpp
@@ -4,6 +4,12 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
   {
+    // SingleThreadedExecutor is intentional: every subscription, timer and
+    // service callback runs in the default mutually-exclusive callback group
+    // on one thread, so the node's shared mutable state (e.g.
+    // corrent_pose_with_cov_stamped_ptr_) is serialized without locks. Switching
+    // to a MultiThreadedExecutor or adding a Reentrant callback group would
+    // introduce data races and requires guarding that state first.
     rclcpp::executors::SingleThreadedExecutor executor;
     rclcpp::NodeOptions options;
     std::shared_ptr<PCLLocalization> pcl_l = std::make_shared<PCLLocalization>(options);

--- a/test/test_local_map_crop_coverage.py
+++ b/test/test_local_map_crop_coverage.py
@@ -62,6 +62,21 @@ def test_no_cliff_when_trajectory_stays_inside_map():
     assert "prediction-driven" in v
 
 
+def test_count_scale_compensates_for_subsampling():
+    # Dense map: the full-map in-radius count is well above min_points, but a
+    # stride-4 subsample alone undercounts ~4x and would trip a false cliff.
+    map_xy = grid_map(-100, 100, -100, 100, step=1.0)
+    t = np.arange(0, 10, 1.0)
+    xy = np.column_stack([np.linspace(-20, 20, len(t)), np.zeros(len(t))])
+    sub = map_xy[::4]
+    raw = cov.analyze_coverage(sub, xy, t, radius_m=15.0, min_points=400)
+    scaled = cov.analyze_coverage(sub, xy, t, radius_m=15.0, min_points=400, count_scale=4)
+    # Unscaled strided counts trip the absolute threshold (the bug)...
+    assert raw["cliff_index"] is not None
+    # ...scaling back by the stride restores a true-negative (no false cliff).
+    assert scaled["cliff_index"] is None
+
+
 def test_out_of_bounds_flag_tracks_bbox_plus_radius():
     map_xy = grid_map(0, 100, 0, 100, step=2.0)
     t = np.array([0.0, 1.0])

--- a/test/test_local_map_crop_coverage.py
+++ b/test/test_local_map_crop_coverage.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Unit tests for the local-map-crop coverage diagnostic core.
+
+Exercises the pure, dependency-light functions (no PCD, no scipy required --
+the brute-force path is used on small synthetic arrays) so the (A) vs (C) verdict
+logic is pinned independently of any Boreas data.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import diagnose_local_map_crop_coverage as cov  # noqa: E402
+
+
+def grid_map(x0, x1, y0, y1, step=1.0):
+    xs = np.arange(x0, x1 + step, step)
+    ys = np.arange(y0, y1 + step, step)
+    gx, gy = np.meshgrid(xs, ys)
+    return np.column_stack([gx.ravel(), gy.ravel()])
+
+
+def test_count_within_radius_matches_brute_force_definition():
+    map_xy = grid_map(0, 10, 0, 10, step=1.0)  # 121 points on a unit grid
+    # A radius-1.0 disk around (5,5) covers (5,5) and its 4 axis neighbours.
+    counts = cov.count_points_within_radius(map_xy, np.array([[5.0, 5.0]]), 1.0)
+    assert counts[0] == 5
+
+
+def test_empty_map_returns_zero_counts():
+    counts = cov.count_points_within_radius(np.empty((0, 2)), np.array([[0.0, 0.0]]), 5.0)
+    assert counts.tolist() == [0]
+
+
+def test_coverage_cliff_detected_when_trajectory_leaves_map():
+    # Map covers x in [0, 100]; vehicle drives straight out to x = 200.
+    map_xy = grid_map(0, 100, -5, 5, step=1.0)
+    t = np.arange(0, 40, 1.0)
+    xy = np.column_stack([np.linspace(0, 200, len(t)), np.zeros(len(t))])
+    result = cov.analyze_coverage(map_xy, xy, t, radius_m=10.0, min_points=20)
+    assert result["cliff_index"] is not None
+    # The cliff must land near where x passes ~100 + radius margin, i.e. well
+    # into the second half of the run, never at the start.
+    assert result["cliff_time"] > t[len(t) // 2]
+    assert "COVERAGE-CLIFF" in cov.verdict(result, 20)
+
+
+def test_no_cliff_when_trajectory_stays_inside_map():
+    # Vehicle stays comfortably inside a large dense map for the whole run.
+    map_xy = grid_map(-200, 200, -200, 200, step=2.0)
+    t = np.arange(0, 30, 1.0)
+    xy = np.column_stack([np.linspace(-50, 50, len(t)), np.zeros(len(t))])
+    result = cov.analyze_coverage(map_xy, xy, t, radius_m=30.0, min_points=50)
+    assert result["cliff_index"] is None
+    v = cov.verdict(result, 50)
+    assert "COVERAGE-OK" in v
+    # The (A)/(C) split: OK means a real crop_too_small is prediction-driven.
+    assert "prediction-driven" in v
+
+
+def test_out_of_bounds_flag_tracks_bbox_plus_radius():
+    map_xy = grid_map(0, 100, 0, 100, step=2.0)
+    t = np.array([0.0, 1.0])
+    # First pose inside; second pose far outside bbox + radius.
+    xy = np.array([[50.0, 50.0], [1000.0, 50.0]])
+    result = cov.analyze_coverage(map_xy, xy, t, radius_m=10.0, min_points=20)
+    assert not result["out_of_bounds"][0]
+    assert result["out_of_bounds"][1]
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/test_reinitialization_supervisor_node_ros.py
+++ b/test/test_reinitialization_supervisor_node_ros.py
@@ -48,13 +48,17 @@ class _Harness(Node):
     walked to the second candidate -- exercising the ranked-candidate walk glue.
     """
 
-    def __init__(self, recover_on_second=False):
+    def __init__(self, recover_on_second=False, pose_z=None):
         super().__init__("g3_test_harness")
         self.create_service(Trigger, "/global_localization_node/query", self._on_query)
         self._reinit = self.create_publisher(Bool, "/reinitialization_requested", _REL)
         self._status = self.create_publisher(DiagnosticArray, "/alignment_status", 10)
         self.create_subscription(
             PoseWithCovarianceStamped, "/initialpose", self._on_pose, _REL)
+        # Optionally fake the localizer pose output so the supervisor can carry z.
+        self._pose_z = pose_z
+        self._pcl_pose = self.create_publisher(
+            PoseWithCovarianceStamped, "/pcl_pose", 10)
         self.query_calls = 0
         self.recover_on_second = recover_on_second
         self.poses = []
@@ -90,6 +94,12 @@ class _Harness(Node):
         array = DiagnosticArray()
         array.status = [status]
         self._status.publish(array)
+        if self._pose_z is not None:
+            pose = PoseWithCovarianceStamped()
+            pose.header.frame_id = "map"
+            pose.pose.pose.position.z = self._pose_z
+            pose.pose.pose.orientation.w = 1.0
+            self._pcl_pose.publish(pose)
 
 
 def test_supervisor_node_closes_the_loop():
@@ -151,6 +161,35 @@ def test_supervisor_node_walks_to_second_candidate_and_recovers():
         # Recovered on the walked candidate, within one query, without giving up.
         assert sup.state.name == rsn.rsp.STATE_STANDDOWN
         assert harness.query_calls == 1
+    finally:
+        executor.shutdown()
+        sup.destroy_node()
+        harness.destroy_node()
+        rclpy.shutdown()
+
+
+def test_reset_carries_z_from_localizer_pose():
+    # A 2D candidate (z=0) on a map whose true z is far from zero seeds the reset
+    # outside the registration z-basin. The supervisor must carry z from the last
+    # /pcl_pose so the published reset uses the real height, not 0.
+    rclpy.init()
+    sup = rsn.ReinitializationSupervisorNode()
+    sup.params = replace(sup.params, request_debounce_sec=0.5)
+    harness = _Harness(pose_z=-11.05)
+    executor = SingleThreadedExecutor()
+    executor.add_node(sup)
+    executor.add_node(harness)
+    spin = threading.Thread(target=executor.spin, daemon=True)
+    spin.start()
+    try:
+        deadline = time.monotonic() + 12.0
+        while time.monotonic() < deadline and harness.initialpose is None:
+            time.sleep(0.1)
+        assert harness.initialpose is not None, "supervisor never published /initialpose"
+        # Candidate carried x/y from the query but z from the localizer pose.
+        pose = harness.initialpose.pose.pose
+        assert abs(pose.position.x - 12.0) < 1e-3
+        assert abs(pose.position.z - (-11.05)) < 1e-2, pose.position.z
     finally:
         executor.shutdown()
         sup.destroy_node()

--- a/test/test_reinitialization_supervisor_node_ros.py
+++ b/test/test_reinitialization_supervisor_node_ros.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""ROS integration smoke for the G3 reinitialization supervisor node.
+
+Validates the ROS glue that the pure-policy unit tests cannot: that the node
+actually receives /reinitialization_requested + /alignment_status, calls the G2
+~/query service, parses the candidate JSON, and publishes /initialpose behind the
+guards. Requires a sourced ROS 2 env; skipped otherwise so the pure-Python test
+runs are unaffected.
+
+Run: source scripts/setup_local_env.sh && python3 -m pytest \
+        test/test_reinitialization_supervisor_node_ros.py -q
+"""
+
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+rclpy = pytest.importorskip("rclpy")
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from rclpy.executors import SingleThreadedExecutor          # noqa: E402
+from rclpy.node import Node                                  # noqa: E402
+from rclpy.qos import QoSProfile, ReliabilityPolicy          # noqa: E402
+from std_msgs.msg import Bool                                # noqa: E402
+from std_srvs.srv import Trigger                             # noqa: E402
+from diagnostic_msgs.msg import (                            # noqa: E402
+    DiagnosticArray, DiagnosticStatus, KeyValue)
+from geometry_msgs.msg import PoseWithCovarianceStamped      # noqa: E402
+
+import reinitialization_supervisor_node as rsn               # noqa: E402
+
+_REL = QoSProfile(depth=1)
+_REL.reliability = ReliabilityPolicy.RELIABLE
+
+
+class _Harness(Node):
+    """Fakes the localizer + G2 service and watches /initialpose."""
+
+    def __init__(self):
+        super().__init__("g3_test_harness")
+        self.create_service(Trigger, "/global_localization_node/query", self._on_query)
+        self._reinit = self.create_publisher(Bool, "/reinitialization_requested", _REL)
+        self._status = self.create_publisher(DiagnosticArray, "/alignment_status", 10)
+        self.create_subscription(
+            PoseWithCovarianceStamped, "/initialpose", self._on_pose, _REL)
+        self.query_calls = 0
+        self.initialpose = None
+        self.create_timer(0.1, self._drive)
+
+    def _on_query(self, request, response):
+        self.query_calls += 1
+        response.success = True
+        response.message = json.dumps(
+            {"candidate_count": 1,
+             "top": {"x": 12.0, "y": 34.0, "yaw_deg": 45.0, "score": 0.99}})
+        return response
+
+    def _on_pose(self, msg):
+        self.initialpose = msg
+
+    def _drive(self):
+        # Sustained reinit request + persistently-bad fitness (no premature recovery).
+        self._reinit.publish(Bool(data=True))
+        status = DiagnosticStatus()
+        kv = KeyValue()
+        kv.key, kv.value = "fitness_score", "9.0"
+        status.values = [kv]
+        array = DiagnosticArray()
+        array.status = [status]
+        self._status.publish(array)
+
+
+def test_supervisor_node_closes_the_loop():
+    rclpy.init()
+    sup = rsn.ReinitializationSupervisorNode()
+    harness = _Harness()
+    executor = SingleThreadedExecutor()
+    executor.add_node(sup)
+    executor.add_node(harness)
+    spin = threading.Thread(target=executor.spin, daemon=True)
+    spin.start()
+    try:
+        deadline = time.monotonic() + 12.0
+        while time.monotonic() < deadline and harness.initialpose is None:
+            time.sleep(0.1)
+
+        assert harness.query_calls >= 1, "supervisor never queried the G2 service"
+        assert harness.initialpose is not None, "supervisor never published /initialpose"
+        pose = harness.initialpose.pose.pose
+        assert abs(pose.position.x - 12.0) < 1e-3
+        assert abs(pose.position.y - 34.0) < 1e-3
+        # position covariance reflects the default reset_position_std (0.5 m)^2.
+        assert abs(harness.initialpose.pose.covariance[0] - 0.25) < 1e-3
+        # Having published a reset, the policy is now awaiting recovery evidence.
+        assert sup.state.name == rsn.rsp.STATE_SETTLING
+    finally:
+        executor.shutdown()
+        sup.destroy_node()
+        harness.destroy_node()
+        rclpy.shutdown()

--- a/test/test_reinitialization_supervisor_node_ros.py
+++ b/test/test_reinitialization_supervisor_node_ros.py
@@ -15,6 +15,7 @@ import json
 import sys
 import threading
 import time
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -40,9 +41,14 @@ _REL.reliability = ReliabilityPolicy.RELIABLE
 
 
 class _Harness(Node):
-    """Fakes the localizer + G2 service and watches /initialpose."""
+    """Fakes the localizer + G2 service and watches /initialpose.
 
-    def __init__(self):
+    The G2 reply carries a ranked ``candidates`` list (top is aliased-wrong). If
+    ``recover_on_second`` is set, fitness drops to recovered only after the node has
+    walked to the second candidate -- exercising the ranked-candidate walk glue.
+    """
+
+    def __init__(self, recover_on_second=False):
         super().__init__("g3_test_harness")
         self.create_service(Trigger, "/global_localization_node/query", self._on_query)
         self._reinit = self.create_publisher(Bool, "/reinitialization_requested", _REL)
@@ -50,26 +56,36 @@ class _Harness(Node):
         self.create_subscription(
             PoseWithCovarianceStamped, "/initialpose", self._on_pose, _REL)
         self.query_calls = 0
-        self.initialpose = None
+        self.recover_on_second = recover_on_second
+        self.poses = []
         self.create_timer(0.1, self._drive)
+
+    @property
+    def initialpose(self):
+        return self.poses[-1] if self.poses else None
 
     def _on_query(self, request, response):
         self.query_calls += 1
         response.success = True
-        response.message = json.dumps(
-            {"candidate_count": 1,
-             "top": {"x": 12.0, "y": 34.0, "yaw_deg": 45.0, "score": 0.99}})
+        response.message = json.dumps({
+            "candidate_count": 2,
+            "candidates": [
+                {"x": 12.0, "y": 34.0, "yaw_deg": 45.0, "score": 0.99},
+                {"x": 99.0, "y": 88.0, "yaw_deg": -90.0, "score": 0.98},
+            ],
+        })
         return response
 
     def _on_pose(self, msg):
-        self.initialpose = msg
+        self.poses.append(msg)
 
     def _drive(self):
-        # Sustained reinit request + persistently-bad fitness (no premature recovery).
         self._reinit.publish(Bool(data=True))
-        status = DiagnosticStatus()
+        # Recover only once the node has walked to the 2nd candidate, else stay bad.
+        recovered = self.recover_on_second and len(self.poses) >= 2
         kv = KeyValue()
-        kv.key, kv.value = "fitness_score", "9.0"
+        kv.key, kv.value = "fitness_score", ("0.2" if recovered else "9.0")
+        status = DiagnosticStatus()
         status.values = [kv]
         array = DiagnosticArray()
         array.status = [status]
@@ -99,6 +115,42 @@ def test_supervisor_node_closes_the_loop():
         assert abs(harness.initialpose.pose.covariance[0] - 0.25) < 1e-3
         # Having published a reset, the policy is now awaiting recovery evidence.
         assert sup.state.name == rsn.rsp.STATE_SETTLING
+    finally:
+        executor.shutdown()
+        sup.destroy_node()
+        harness.destroy_node()
+        rclpy.shutdown()
+
+
+def test_supervisor_node_walks_to_second_candidate_and_recovers():
+    # The top candidate is aliased-wrong (fitness stays bad); the node must walk to
+    # the second candidate from the same query, at which point the localizer locks.
+    rclpy.init()
+    sup = rsn.ReinitializationSupervisorNode()
+    # Walk fast and within a single query (max_attempts=1 proves walking does not
+    # spend attempts -- a fresh query would have given up).
+    sup.params = replace(
+        sup.params, settle_timeout_sec=2.0, request_debounce_sec=0.5,
+        min_seconds_between_attempts=1.0, max_attempts=1)
+    harness = _Harness(recover_on_second=True)
+    executor = SingleThreadedExecutor()
+    executor.add_node(sup)
+    executor.add_node(harness)
+    spin = threading.Thread(target=executor.spin, daemon=True)
+    spin.start()
+    try:
+        deadline = time.monotonic() + 15.0
+        while (time.monotonic() < deadline
+               and sup.state.name != rsn.rsp.STATE_STANDDOWN):
+            time.sleep(0.1)
+
+        assert len(harness.poses) >= 2, "node never walked to the second candidate"
+        first, second = harness.poses[0].pose.pose, harness.poses[1].pose.pose
+        assert abs(first.position.x - 12.0) < 1e-3 and abs(first.position.y - 34.0) < 1e-3
+        assert abs(second.position.x - 99.0) < 1e-3 and abs(second.position.y - 88.0) < 1e-3
+        # Recovered on the walked candidate, within one query, without giving up.
+        assert sup.state.name == rsn.rsp.STATE_STANDDOWN
+        assert harness.query_calls == 1
     finally:
         executor.shutdown()
         sup.destroy_node()

--- a/test/test_reinitialization_supervisor_policy.py
+++ b/test/test_reinitialization_supervisor_policy.py
@@ -308,6 +308,37 @@ def test_walk_stops_at_min_candidate_score_floor():
     assert rsp.ACTION_GIVE_UP in actions(events)
 
 
+def test_walk_is_bounded_by_max_walk_candidates():
+    # A stale query returns a long ranked list none of whose poses lock. The walk
+    # must stop after max_walk_candidates instead of burning settle_timeout_sec on
+    # all 16 -- past the top few occupancy maxima a fresh query is the better spend.
+    # With max_attempts=1 (a single query) exactly max_walk_candidates resets fire.
+    params = rsp.SupervisorParams(
+        request_debounce_sec=1.0, min_candidate_score=0.6, settle_timeout_sec=3.0,
+        max_attempts=1, max_walk_candidates=4)
+    events = run_ranked(
+        params, 120, requested=True,
+        candidate_scores=[0.99] * 16, recover_on_index=None)
+    assert published_indices(events) == [0, 1, 2, 3]
+    assert actions(events).count(rsp.ACTION_QUERY) == 1
+    assert rsp.ACTION_GIVE_UP in actions(events)
+    assert events[-1][3] == rsp.STATE_EXHAUSTED
+
+
+def test_high_max_walk_candidates_restores_full_list_walk():
+    # Raising the cap restores walking the entire ranked list: the true pose at
+    # rank 5 (beyond the default cap of 4) is reached and recovers only because the
+    # cap is lifted -- proving the cap is what gates the deeper walk.
+    params = rsp.SupervisorParams(
+        request_debounce_sec=1.0, min_candidate_score=0.6, settle_timeout_sec=3.0,
+        max_attempts=1, max_walk_candidates=999)
+    events = run_ranked(
+        params, 120, requested=True,
+        candidate_scores=[0.99] * 6, recover_on_index=5)
+    assert published_indices(events) == [0, 1, 2, 3, 4, 5]
+    assert events[-1][3] == rsp.STATE_STANDDOWN
+
+
 if __name__ == "__main__":
     import pytest
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/test_reinitialization_supervisor_policy.py
+++ b/test/test_reinitialization_supervisor_policy.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Regression tests for the G3 reinitialization guard policy.
+
+These encode the Decision Gates from docs/global_localization_roadmap.md as
+adversarial sequences. They are the "regression test that fails on unsafe
+publication or false acceptance" the roadmap requires, and they exist because
+the Phase 3 degraded-acceptance work proved that a closed recovery loop can
+diverge if its bounds can be reset by the very acts they bound.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import reinitialization_supervisor_policy as rsp  # noqa: E402
+
+
+def run(
+    params,
+    ticks,
+    *,
+    requested,
+    candidate_score=None,
+    query_latency=1,
+    fitness=None,
+    dt=1.0,
+):
+    """Drive the policy like the node would and return the event stream.
+
+    ``requested``/``candidate_score`` may be constants or callables of ``now``.
+    A query reply (``candidate_score``) is delivered exactly once, ``query_latency``
+    ticks after each ACTION_QUERY, mimicking a single service response.
+    ``fitness`` is a callable(now, last_reset_sec) or constant (lower is better).
+    """
+    state = rsp.initial_state()
+    events = []
+    deliver_at = None
+    last_reset_sec = None
+
+    def value(spec, *args):
+        return spec(*args) if callable(spec) else spec
+
+    for i in range(ticks):
+        now = i * dt
+        req = bool(value(requested, now))
+        score = None
+        if deliver_at is not None and i == deliver_at:
+            score = value(candidate_score, now)
+            deliver_at = None
+        fit = None
+        if fitness is not None:
+            fit = fitness(now, last_reset_sec) if callable(fitness) else fitness
+        obs = rsp.SupervisorObservation(now, req, best_candidate_score=score, best_fitness=fit)
+        dec = rsp.decide(params, state, obs)
+        state = dec.state
+        events.append((now, dec.action, dec.reason, state.name))
+        if dec.action == rsp.ACTION_QUERY:
+            deliver_at = i + query_latency
+        if dec.action == rsp.ACTION_PUBLISH_RESET:
+            last_reset_sec = now
+    return events
+
+
+def actions(events):
+    return [a for (_, a, _, _) in events]
+
+
+def reset_times(events):
+    return [t for (t, a, _, _) in events if a == rsp.ACTION_PUBLISH_RESET]
+
+
+# --- Gate: nothing happens without a sustained request -----------------------
+
+def test_transient_request_blip_never_queries_or_publishes():
+    params = rsp.SupervisorParams(request_debounce_sec=2.0)
+    # Request asserted for one second only (< debounce), then gone.
+    events = run(params, 30, requested=lambda now: now < 1.0, candidate_score=0.99)
+    assert rsp.ACTION_QUERY not in actions(events)
+    assert rsp.ACTION_PUBLISH_RESET not in actions(events)
+
+
+def test_no_request_is_pure_tracking():
+    events = run(rsp.SupervisorParams(), 20, requested=False, candidate_score=0.99)
+    assert set(actions(events)) == {rsp.ACTION_NONE}
+
+
+# --- Gate: happy path publishes once and stands down on recovery -------------
+
+def test_sustained_request_strong_candidate_publishes_once_then_recovers():
+    params = rsp.SupervisorParams(
+        request_debounce_sec=1.0, min_candidate_score=0.6, recovery_fitness_threshold=1.5)
+
+    # Fitness is bad until a reset lands, then recovers a couple ticks later.
+    def fitness(now, last_reset_sec):
+        if last_reset_sec is None:
+            return 9.0
+        return 0.4 if now - last_reset_sec >= 2.0 else 9.0
+
+    events = run(params, 40, requested=True, candidate_score=0.95, fitness=fitness)
+    assert len(reset_times(events)) == 1
+    reasons = [r for (_, _, r, _) in events]
+    assert "recovery_confirmed" in reasons
+    # Even though the request line stays high after recovery, the supervisor
+    # stands down and does not re-fire (edge-triggered on the next problem).
+    recovery_i = reasons.index("recovery_confirmed")
+    after = actions(events)[recovery_i + 1:]
+    assert rsp.ACTION_QUERY not in after
+    assert rsp.ACTION_PUBLISH_RESET not in after
+    assert events[-1][3] == rsp.STATE_STANDDOWN
+
+
+# --- Gate: never publish an unsafe (low-score) candidate ---------------------
+
+def test_weak_candidates_are_never_published():
+    params = rsp.SupervisorParams(min_candidate_score=0.6, max_attempts=3)
+    events = run(params, 80, requested=True, candidate_score=0.2, fitness=9.0)
+    assert rsp.ACTION_PUBLISH_RESET not in actions(events)
+    # And it must not query forever: it gives up after max_attempts.
+    assert rsp.ACTION_GIVE_UP in actions(events)
+    assert events[-1][3] == rsp.STATE_EXHAUSTED
+
+
+def test_query_count_is_bounded_by_max_attempts_when_candidates_weak():
+    params = rsp.SupervisorParams(min_candidate_score=0.6, max_attempts=3)
+    events = run(params, 200, requested=True, candidate_score=0.2, fitness=9.0)
+    assert actions(events).count(rsp.ACTION_QUERY) <= params.max_attempts
+
+
+# --- Gate: a confidently-wrong candidate cannot loop forever -----------------
+
+def test_false_acceptance_does_not_loop_forever():
+    # Strong score every time, but fitness never recovers: the classic
+    # closed-loop blowup. Must be bounded by max_attempts, then give up.
+    params = rsp.SupervisorParams(min_candidate_score=0.6, max_attempts=3, settle_timeout_sec=4.0)
+    events = run(params, 300, requested=True, candidate_score=0.99, fitness=9.0)
+    assert len(reset_times(events)) <= params.max_attempts
+    assert rsp.ACTION_GIVE_UP in actions(events)
+    assert events[-1][3] == rsp.STATE_EXHAUSTED
+
+
+# --- Gate: reset publications respect the minimum spacing --------------------
+
+def test_resets_respect_minimum_spacing():
+    params = rsp.SupervisorParams(
+        min_seconds_between_attempts=5.0, settle_timeout_sec=3.0, max_attempts=5)
+    events = run(params, 300, requested=True, candidate_score=0.99, fitness=9.0, dt=1.0)
+    times = reset_times(events)
+    gaps = [b - a for a, b in zip(times, times[1:])]
+    assert all(g >= 5.0 for g in gaps), gaps
+
+
+# --- Gate: recovery clears the ceiling so a later problem gets a fresh budget -
+
+def test_recovery_resets_attempt_budget_for_a_later_problem():
+    params = rsp.SupervisorParams(
+        request_debounce_sec=1.0, max_attempts=3, min_seconds_between_attempts=3.0,
+        settle_timeout_sec=3.0, recovery_fitness_threshold=1.5)
+
+    # Two separate problem episodes separated by a healthy stretch.
+    def requested(now):
+        return now < 20.0 or 40.0 <= now < 60.0
+
+    # Recovers ~2 s after each reset.
+    def fitness(now, last_reset_sec):
+        if last_reset_sec is None:
+            return 9.0
+        return 0.4 if now - last_reset_sec >= 2.0 else 9.0
+
+    events = run(params, 80, requested=requested, candidate_score=0.95, fitness=fitness)
+    # One reset per episode, never exhausted (budget reset by the recovery between).
+    assert len(reset_times(events)) == 2
+    assert rsp.ACTION_GIVE_UP not in actions(events)
+
+
+# --- Gate: exhausted latches until the problem clears, then re-arms -----------
+
+def test_exhausted_latches_until_request_clears():
+    params = rsp.SupervisorParams(min_candidate_score=0.6, max_attempts=2)
+
+    # Unsolvable while requested for the first 120 s, then the request clears.
+    def requested(now):
+        return now < 120.0
+
+    events = run(params, 160, requested=requested, candidate_score=0.2, fitness=9.0)
+    states = [s for (_, _, _, s) in events]
+    assert rsp.STATE_EXHAUSTED in states
+    # Once the request clears it must fall back to idle (re-armable), not stay stuck.
+    assert events[-1][3] == rsp.STATE_IDLE
+
+
+def test_decide_is_pure_same_inputs_same_outputs():
+    params = rsp.SupervisorParams()
+    state = rsp.initial_state()
+    obs = rsp.SupervisorObservation(3.0, True, best_candidate_score=0.9, best_fitness=2.0)
+    d1 = rsp.decide(params, state, obs)
+    d2 = rsp.decide(params, state, obs)
+    assert d1 == d2
+    # Input state object is not mutated.
+    assert state == rsp.initial_state()
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/test_reinitialization_supervisor_policy.py
+++ b/test/test_reinitialization_supervisor_policy.py
@@ -64,11 +64,13 @@ def run(
 
 
 def actions(events):
-    return [a for (_, a, _, _) in events]
+    # Tolerates both the 4-tuple events from run() and the 5-tuple events from
+    # run_ranked() (which also carries the published candidate_index).
+    return [e[1] for e in events]
 
 
 def reset_times(events):
-    return [t for (t, a, _, _) in events if a == rsp.ACTION_PUBLISH_RESET]
+    return [e[0] for e in events if e[1] == rsp.ACTION_PUBLISH_RESET]
 
 
 # --- Gate: nothing happens without a sustained request -----------------------
@@ -199,6 +201,111 @@ def test_decide_is_pure_same_inputs_same_outputs():
     assert d1 == d2
     # Input state object is not mutated.
     assert state == rsp.initial_state()
+
+
+# --- Gate: ranked-candidate walk (the 2026-06-15 live-run lesson) -------------
+#
+# A query's top candidate can be confidently wrong (BBS occupancy score does not
+# separate a 190 m error from a 5 m hit). The supervisor must walk the ranked list
+# from one query, using the localizer's fitness as the registration oracle, before
+# spending another attempt -- and the bounds must still hold.
+
+def run_ranked(
+    params,
+    ticks,
+    *,
+    requested,
+    candidate_scores,
+    recover_on_index=None,
+    query_latency=1,
+    dt=1.0,
+):
+    """Drive the policy delivering a ranked candidate list once per query.
+
+    ``recover_on_index`` is the rank index whose published reset the localizer
+    accepts (fitness drops); None means no candidate ever recovers. Fitness is high
+    while any other (or no) candidate is the most recently published one.
+    """
+    state = rsp.initial_state()
+    events = []
+    deliver_at = None
+    published_index = None
+
+    for i in range(ticks):
+        now = i * dt
+        req = bool(requested(now)) if callable(requested) else bool(requested)
+        scores = None
+        if deliver_at is not None and i == deliver_at:
+            scores = tuple(candidate_scores)
+            deliver_at = None
+        fit = None
+        if published_index is not None:
+            fit = 0.2 if published_index == recover_on_index else 9.0
+        obs = rsp.SupervisorObservation(
+            now, req, candidate_scores=scores, best_fitness=fit)
+        dec = rsp.decide(params, state, obs)
+        state = dec.state
+        events.append((now, dec.action, dec.reason, state.name, dec.candidate_index))
+        if dec.action == rsp.ACTION_QUERY:
+            deliver_at = i + query_latency
+            published_index = None
+        if dec.action == rsp.ACTION_PUBLISH_RESET:
+            published_index = dec.candidate_index
+    return events
+
+
+def published_indices(events):
+    return [ci for (_, a, _, _, ci) in events if a == rsp.ACTION_PUBLISH_RESET]
+
+
+def test_walk_recovers_on_lower_ranked_candidate_within_one_query():
+    # Top two candidates are aliased-wrong; rank 2 is the true pose. A single query
+    # (max_attempts=1) must walk 0 -> 1 -> 2 and recover, without giving up: walking
+    # does not spend attempts, so the ceiling is never hit.
+    params = rsp.SupervisorParams(
+        request_debounce_sec=1.0, min_candidate_score=0.6, settle_timeout_sec=3.0,
+        max_attempts=1, recovery_fitness_threshold=1.5)
+    events = run_ranked(
+        params, 60, requested=True,
+        candidate_scores=[0.99, 0.98, 0.97], recover_on_index=2)
+    assert published_indices(events) == [0, 1, 2]
+    assert actions(events).count(rsp.ACTION_QUERY) == 1
+    assert rsp.ACTION_GIVE_UP not in actions(events)
+    reasons = [r for (_, _, r, _, _) in events]
+    assert "next_candidate" in reasons
+    assert "recovery_confirmed" in reasons
+    assert events[-1][3] == rsp.STATE_STANDDOWN
+
+
+def test_walk_exhausts_list_then_respects_max_attempts():
+    # No candidate ever recovers. Each query walks its whole list (2 candidates),
+    # then a fresh query costs one attempt. The reset count must stay bounded by
+    # max_attempts * list_length, and it must give up -- never loop forever.
+    params = rsp.SupervisorParams(
+        request_debounce_sec=1.0, min_candidate_score=0.6, settle_timeout_sec=3.0,
+        min_seconds_between_attempts=2.0, max_attempts=2)
+    events = run_ranked(
+        params, 300, requested=True,
+        candidate_scores=[0.99, 0.98], recover_on_index=None)
+    assert actions(events).count(rsp.ACTION_QUERY) <= params.max_attempts
+    # Two candidates walked per query, at most max_attempts queries.
+    assert len(reset_times(events)) <= params.max_attempts * 2
+    assert rsp.ACTION_GIVE_UP in actions(events)
+    assert events[-1][3] == rsp.STATE_EXHAUSTED
+
+
+def test_walk_stops_at_min_candidate_score_floor():
+    # Rank 0 is strong, rank 1 is below the score floor: the walk must not publish
+    # the sub-floor candidate even though the list has more entries.
+    params = rsp.SupervisorParams(
+        request_debounce_sec=1.0, min_candidate_score=0.6, settle_timeout_sec=3.0,
+        max_attempts=1)
+    events = run_ranked(
+        params, 60, requested=True,
+        candidate_scores=[0.99, 0.4], recover_on_index=None)
+    # Only the top candidate is ever published; index 1 (score 0.4) is never tried.
+    assert published_indices(events) == [0]
+    assert rsp.ACTION_GIVE_UP in actions(events)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Global localization G3 (guarded automatic reinitialization) taken from logic to a **live, end-to-end recovery on the Koide kidnap window**, plus the Boreas crop-cliff root-cause and the #54/#55 triage. The G3 recovery-evidence Decision Gate is now satisfied with a real localizer.

## G3 guarded automatic reinitialization
Closes the global-localization recovery loop: the localization component raises `/reinitialization_requested` from its C++ recovery supervisor; this adds the consumer that queries the G2 service and republishes `/initialpose`, behind explicit safety guards.

- `scripts/reinitialization_supervisor_policy.py` — ROS-free deterministic state machine owning every safety decision: candidate-score floor (no unsafe publication), minimum reset spacing, post-reset recovery evidence, and a non-self-resetting attempt ceiling that gives up rather than looping. Built around the Phase 3 lesson that a closed loop must not reset the bounds that protect it; after a terminal outcome it is edge-triggered on the next problem so a stuck-high request line cannot re-fire it.
- `scripts/reinitialization_supervisor_node.py` — thin opt-in ROS shell wiring `/reinitialization_requested` + `/alignment_status` → G2 `~/query` → `/initialpose`. Not in the default launch.
- `launch/global_localization_recovery.launch.py` — three-node bringup (localizer + G2 + supervisor) on a shared cloud topic / frame, with the guards and G2 search-cost knobs exposed as launch arguments.
- `scripts/global_localization_node.py` returns the full ranked `candidates` list in its `~/query` reply (not just `top`).

## Ranked-candidate walk
A query's BBS occupancy score does not separate a wrong candidate from a correct one (it scored a 190 m error 0.99 and a 5 m hit 0.998). The localizer's NDT fitness can. So the supervisor walks the ranked list from one query — publish the best, and if fitness does not recover, publish the next-best — using the localizer's fitness as the registration oracle. Walking does **not** spend a `max_attempts` slot (only re-querying does), so the ceiling stays a true bound on queries while one query can try every pose it found.

## Live validation → recovery achieved
Five live runs on the real Koide `outdoor_hard_01a` bag + map (kidnap injected at a healthy location) isolated the recovery blocker by elimination, then closed it:

- The supervisor mechanism is validated end-to-end against a real stack: detect → debounce → query → score-guard → guarded publish → recovery-wait → walk → `max_attempts` ceiling → safe give-up with an operator alert. The ceiling contained confidently-wrong candidates without an unbounded reset loop (the Phase 3 lesson, live).
- The decisive blocker was **not** in G3, the walk, candidate quality, ranking, yaw, or query latency. It was that the reset was published with **z = 0**: G2 candidates are 2D and the supervisor left `position.z = 0`, ~11 m above the true Koide ground, outside the NDT z-basin — so even an x/y/yaw-correct candidate never locked. (The flat HDL demo worked only because z = 0 was right there.)
- **Fix:** the supervisor carries z / roll / pitch from `/pcl_pose` onto the candidate, overriding only x / y / yaw.
- **Result:** the loop now recovers live — after the guarded reset the localizer re-locks, fitness falls from ~30 to ~0.1, and the supervisor logs `recovery_confirmed → standdown → idle` (re-armed). Full write-up and the run-by-run diagnosis in `docs/g3_live_closed_loop.md`.

Remaining G3 work is quality, not correctness (faster / first-try recovery via lower BBS query latency and per-candidate registration scoring in G2).

## Phase 2: Boreas `local_map_crop_too_small` root-cause (code-level)
Traced the failure chain without an idle-machine run: the local-map crop is centered on the predicted seed (not the last accepted pose), so a runaway prediction starves its own target cloud; with `local_map_radius=300` / `local_map_min_points=100`, `local_map_crop_too_small` is a lagging symptom, and the crop-failure guard then drops every scan until a new initial pose arrives, freezing the estimate into the flat ~45 m plateau. `scripts/diagnose_local_map_crop_coverage.py` decides estimator-side vs map-side offline (no ROS) by counting map points within `local_map_radius` of every ground-truth pose; core unit-tested. Running it is blocked only on the Boreas data mount. No runtime change made (Phase 3 rule: no unreplayed estimator edits).

## Issues #54 / #55
Both non-bugs under the shipped configuration: `odom_frame_id_` is already wired into the map→odom TF path, and the shared pose pointer is serialized by the `SingleThreadedExecutor`. Documented the executor invariant at the construction site, the member declaration, and the CHANGELOG instead of adding a redundant mutex.

## Docs
`docs/global_localization.md` operations guide; `docs/g3_live_closed_loop.md` live closed-loop result; `docs/global_localization_roadmap.md` updated through the recovery-evidence gate. CHANGELOG and development_plan execution log updated throughout.

## Tests
`python3 -m pytest test/test_reinitialization_supervisor_policy.py test/test_reinitialization_supervisor_node_ros.py test/test_local_map_crop_coverage.py test/test_global_localization_query.py` → all green (13 policy walk/guard sequences + 3 ROS integration incl. the z-carry and ranked-walk glue + coverage + query). The ROS integration tests skip automatically without a sourced ROS env.
