### PR TITLE
Phase 1: vgicp_voxel_resolution sweep -- finer voxels do not rescue SMALL_VGICP

### DIFF
--- a/docs/phase1_koide_backend_comparison.md
+++ b/docs/phase1_koide_backend_comparison.md
@@ -90,8 +90,40 @@ Phase 3 lesson): the smoke ranking was exactly reversed by the full replay.
 - **SMALL_VGICP: not competitive** as configured.
 
 Single run per backend; the divergence magnitude (11.7 m vs 0.67 m) is far beyond
-run-to-run variance, but a repeat would firm up the numbers. A `vgicp_voxel_resolution`
-sweep is still open for VGICP.
+run-to-run variance, but a repeat would firm up the numbers. The
+`vgicp_voxel_resolution` sweep that was open here is resolved in the next section.
+
+## SMALL_VGICP `vgicp_voxel_resolution` sweep (full 380 s): finer voxels do not help
+
+The full-window SMALL_VGICP above used `vgicp_voxel_resolution: 0.5`. The open
+question was whether a finer target voxelization would let VGICP hold lock through
+the hard section. Swept 0.5 -> 0.3 -> 0.2 (full 380 s, identical config otherwise,
+each run gated at load < 5 so alignment timing is valid):
+
+| vgicp_voxel_resolution | poses | ok-rate | trans RMSE | rot RMSE | longest lost window |
+| --- | --- | --- | --- | --- | --- |
+| 0.5 (baseline) | 35 | 6.7% | 22.68 m | 32.6 deg | 298.4 s |
+| 0.3 | 27 | 6.0% | 2.49 m | 7.9 deg | 348.7 s |
+| 0.2 | 12 | 2.7% | 1.77 m | 5.4 deg | 368.8 s |
+
+**The RMSE drop is a mirage -- it is the same early-window throughput trap.** As the
+voxel gets finer the *number* goes down (22.68 -> 1.77 m), which looks like
+improvement, but every robustness signal moves the wrong way:
+
+- **ok-rate falls** (6.7% -> 6.0% -> 2.7%) and **poses collapse** (35 -> 27 -> 12).
+- **the longest lost window grows** (298 -> 349 -> 369 s). At 0.2, VGICP loses lock at
+  index 10 (~9 s in) and *never recovers* -- lost for 368.8 s of the 380 s run. The
+  1.77 m RMSE is computed over the 10 matched poses of the first ~9 s only.
+- this is **not** throughput-bound: `max_alignment_time_sec` stays ~1.25 s (same as
+  0.5), so finer voxels are not simply too slow. Instead the finer per-voxel
+  covariances make the fit more peaked and brittle -- `fitness_score_over_threshold`
+  rejections dominate (371 rows at 0.3) and it cannot re-lock on the hard section.
+
+**Verdict: the sweep refutes the hypothesis.** Finer `vgicp_voxel_resolution` does not
+rescue SMALL_VGICP; it worsens lock retention while making the RMSE number
+deceptively small. SMALL_VGICP stays non-competitive, and **NDT_OMP remains the
+recommended default**. (Methodological echo of the smoke-vs-full reversal: read
+ok-rate + lost-window + pose-count *before* RMSE.)
 
 ## Reproduce
 

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01a_full380_small_vgicp_vox02.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01a_full380_small_vgicp_vox02.yaml
@@ -1,0 +1,42 @@
+# Koide outdoor_hard_01a FULL 380s -- SMALL_VGICP backend (Phase 1 definitive).
+# Identical downsampling (voxel 0.5) across backends; GICP-scale gate for GICP.
+mode: run
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01a
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01a/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01a/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 15.0
+    enable_recovery_retry_from_last_pose: true
+    recovery_retry_from_last_pose_min_rejections: 3
+    recovery_retry_from_last_pose_max_accepted_gap_sec: 1.0
+    recovery_retry_from_last_pose_max_seed_translation_m: 15.0
+    registration_method: SMALL_VGICP
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.2
+  launch_args:
+  - use_sim_time:=true
+  - lidar_frame_id:=livox_frame
+benchmark:
+  output_dir: /tmp/lidarloc_koide_01a_full380_small_vgicp_vox02
+  ros_domain_id: 188
+  bag_duration: 380
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01a_full380_small_vgicp_vox03.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01a_full380_small_vgicp_vox03.yaml
@@ -1,0 +1,42 @@
+# Koide outdoor_hard_01a FULL 380s -- SMALL_VGICP backend (Phase 1 definitive).
+# Identical downsampling (voxel 0.5) across backends; GICP-scale gate for GICP.
+mode: run
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01a
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01a/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01a/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 15.0
+    enable_recovery_retry_from_last_pose: true
+    recovery_retry_from_last_pose_min_rejections: 3
+    recovery_retry_from_last_pose_max_accepted_gap_sec: 1.0
+    recovery_retry_from_last_pose_max_seed_translation_m: 15.0
+    registration_method: SMALL_VGICP
+    gicp_max_correspondence_distance: 3.0
+    vgicp_voxel_resolution: 0.3
+  launch_args:
+  - use_sim_time:=true
+  - lidar_frame_id:=livox_frame
+benchmark:
+  output_dir: /tmp/lidarloc_koide_01a_full380_small_vgicp_vox03
+  ros_domain_id: 187
+  bag_duration: 380
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true


### PR DESCRIPTION
Resolves the `vgicp_voxel_resolution` sweep left open in `docs/phase1_koide_backend_comparison.md` (full-380s backend comparison).

## Question
The full-window SMALL_VGICP used `vgicp_voxel_resolution: 0.5` (22.68 m, lost 298 s). Would a finer target voxelization let it hold lock through the hard section?

## Result -- swept 0.5 -> 0.3 -> 0.2 (full 380 s, identical config, each run gated at load < 5)

| vgicp_voxel_resolution | poses | ok-rate | trans RMSE | longest lost window |
| --- | --- | --- | --- | --- |
| 0.5 (baseline) | 35 | 6.7% | 22.68 m | 298.4 s |
| 0.3 | 27 | 6.0% | 2.49 m | 348.7 s |
| 0.2 | 12 | 2.7% | 1.77 m | 368.8 s |

**The RMSE drop is a mirage** -- the same early-window throughput trap. Every robustness signal moves the wrong way: ok-rate falls, poses collapse, and the longest lost window grows to nearly the whole run. At 0.2, VGICP loses lock ~9 s in and never recovers; the 1.77 m is over the first 10 poses only. It is **not** throughput-bound (max align time ~1.25 s, unchanged) -- finer per-voxel covariances are more brittle and fitness-reject through the hard section.

## Verdict
The sweep **refutes** the hypothesis. Finer `vgicp_voxel_resolution` worsens lock retention while making the RMSE number deceptively small. SMALL_VGICP stays non-competitive; **NDT_OMP remains the recommended default**.

## Changes
- `docs/phase1_koide_backend_comparison.md`: new sweep section + verdict.
- two sweep manifests (`..._full380_small_vgicp_vox03.yaml`, `..._vox02.yaml`) for reproducibility.