### PR TITLE
G3 lever 2: forward-compensate the recovery seed for query latency

### DIFF
--- a/docs/g3_live_closed_loop.md
+++ b/docs/g3_live_closed_loop.md
@@ -249,3 +249,40 @@ Note this does *not* help when the true candidate is genuinely in the list but r
 on registration quality -- that is what per-candidate registration scoring in G2 (lever 2,
 not yet built) would fix. The cap addresses the more common stale-query case observed here,
 where no rank would have recovered and the time is better spent on a new scan.
+
+## Speedup lever 2 -- forward-compensate the seed for query latency
+
+The fourth (clean) run isolated the residual blocker after the re-lock fix: even a *correct
+rank-1 fix goes stale*. A G2 BBS query takes ~5-23 s, and the candidate it returns is a fix
+of the scan taken when the query was *issued*; by the time the supervisor publishes the
+reset the vehicle has driven several metres on, so the seed lands behind the vehicle, outside
+the registration basin, and the lock does not take. The true lever here is not candidate
+*quality* but *latency*: close the gap between where the fix says the vehicle was and where it
+is when the seed is applied.
+
+Two ways to close it: make the query instant (the G2 C++ port -- the root fix, separate work),
+or *forward-compensate* the seed by the measured latency. This lever does the latter, and it
+has to work on the Koide bag, which carries no twist/odom topic (only `/livox` lidar+imu). So
+the velocity is inferred from the data the loop already has: **successive query fixes**. Each
+query returns an absolute map-frame position at its issue time, so the displacement between
+two consecutively published fixes, divided by the wall time between their issues, is a direct
+map-frame velocity; the next seed is pushed ahead by `velocity * (now - query_issue_time)`.
+Monotonic wall time is used consistently for both the velocity `dt` and the latency, so the
+result is correct under `use_sim_time` and any constant bag-replay rate (the rate cancels).
+
+Safety is the same shape as the rest of the guard: a perceptual-aliasing wrong candidate (the
+first run saw a 190 m-off candidate scored 0.99) would imply an absurd speed, so any estimate
+above `max_seed_speed_mps` (default 30) is rejected and the raw candidate is published
+unchanged; the latency is clamped to `max_seed_latency_sec` (default 30) so a pathologically
+slow query cannot extrapolate a first-order model arbitrarily far. Compensation therefore only
+ever fires when two consecutive fixes are mutually consistent -- exactly when the velocity is
+trustworthy -- and a bad estimate is always a no-op, so this can never *worsen* a publish. It
+is off by default (`enable_seed_motion_compensation` / `supervisor_enable_seed_motion_compensation`
+launch arg), since it only helps a moving vehicle with slow queries.
+
+The compensation math is pure and unit-tested in `reinitialization_supervisor_policy.py`
+(`estimate_seed_velocity`, `forward_compensate_xy`) with `test_reinitialization_supervisor_policy.py`
+pinning the velocity estimate, the within-query-walk rejection, the implausible-speed
+rejection, the latency clamp, and the invalid-estimate no-op. Live verification on Koide
+(does the compensated seed lock where the raw one went stale) is the remaining idle-machine
+step.

--- a/launch/global_localization_recovery.launch.py
+++ b/launch/global_localization_recovery.launch.py
@@ -67,6 +67,7 @@ def generate_launch_description():
     supervisor_query_timeout_sec = LaunchConfiguration('supervisor_query_timeout_sec')
     supervisor_settle_timeout_sec = LaunchConfiguration('supervisor_settle_timeout_sec')
     supervisor_max_walk_candidates = LaunchConfiguration('supervisor_max_walk_candidates')
+    supervisor_enable_seed_motion = LaunchConfiguration('supervisor_enable_seed_motion_compensation')
 
     declared = [
         DeclareLaunchArgument(
@@ -107,6 +108,13 @@ def generate_launch_description():
                         'query before re-querying on a fresher scan; a stale query '
                         'can return a full list none of whose poses lock '
                         '(g3_live_closed_loop.md). Set high to walk the whole list.'),
+        DeclareLaunchArgument(
+            'supervisor_enable_seed_motion_compensation', default_value='false',
+            description='Forward-extrapolate a candidate by the measured query->publish '
+                        'latency so it lands where the moving vehicle is now, not where '
+                        'it was when the (slow) BBS query was issued. Velocity is inferred '
+                        'from successive query fixes (g3_live_closed_loop.md). Off by '
+                        'default; helps only on a moving vehicle with slow queries.'),
         DeclareLaunchArgument(
             'g2_angular_resolution_deg', default_value='5.0',
             description='G2 BBS yaw sampling step; coarser = faster query, fresher '
@@ -179,6 +187,8 @@ def generate_launch_description():
                 supervisor_settle_timeout_sec, value_type=float),
             'max_walk_candidates': ParameterValue(
                 supervisor_max_walk_candidates, value_type=int),
+            'enable_seed_motion_compensation': ParameterValue(
+                supervisor_enable_seed_motion, value_type=bool),
             'use_sim_time': use_sim_time,
         }])
 

--- a/scripts/reinitialization_supervisor_node.py
+++ b/scripts/reinitialization_supervisor_node.py
@@ -88,6 +88,16 @@ class ReinitializationSupervisorNode(Node):
         self.declare_parameter("settle_timeout_sec", 8.0)
         self.declare_parameter("recovery_fitness_threshold", 1.5)
         self.declare_parameter("max_walk_candidates", 4)
+        # Seed motion compensation: forward-extrapolate a candidate by the measured
+        # query->publish latency so it lands where the moving vehicle is *now*, not
+        # where it was when the (slow) BBS query was issued. Off by default; the
+        # velocity is inferred from successive query fixes (see the policy module's
+        # seed-motion section). max_seed_speed_mps rejects an implausible estimate
+        # (a wrong perceptual-aliasing candidate); max_seed_latency_sec clamps how
+        # far the first-order extrapolation is trusted.
+        self.declare_parameter("enable_seed_motion_compensation", False)
+        self.declare_parameter("max_seed_speed_mps", 30.0)
+        self.declare_parameter("max_seed_latency_sec", 30.0)
 
         self.params = rsp.SupervisorParams(
             request_debounce_sec=float(self.get_parameter("request_debounce_sec").value),
@@ -107,6 +117,10 @@ class ReinitializationSupervisorNode(Node):
         self.position_std = float(self.get_parameter("reset_position_std_m").value)
         self.yaw_std = float(self.get_parameter("reset_yaw_std_rad").value)
         self.reset_default_z = float(self.get_parameter("reset_default_z_m").value)
+        self.enable_seed_motion = bool(
+            self.get_parameter("enable_seed_motion_compensation").value)
+        self.max_seed_speed = float(self.get_parameter("max_seed_speed_mps").value)
+        self.max_seed_latency = float(self.get_parameter("max_seed_latency_sec").value)
 
         # Latest observed signals.
         self._requested = False
@@ -129,6 +143,11 @@ class ReinitializationSupervisorNode(Node):
         # policy's candidate_index when it asks for a publish (the ranked-candidate
         # walk -- see reinitialization_supervisor_policy).
         self._candidates = []
+        # Seed motion compensation bookkeeping: the monotonic time the in-flight
+        # query was issued (a proxy for its fix's scan time), and the previously
+        # published candidate fix (x, y, issue_time) used to infer map velocity.
+        self._query_issue_time = None
+        self._prev_fix = None
 
         reliable = QoSProfile(depth=1)
         reliable.reliability = ReliabilityPolicy.RELIABLE
@@ -156,7 +175,12 @@ class ReinitializationSupervisorNode(Node):
     # --- subscriptions -------------------------------------------------------
 
     def _on_reinit(self, msg: Bool) -> None:
-        self._requested = bool(msg.data)
+        requested = bool(msg.data)
+        if self._requested and not requested:
+            # Problem cleared: the next recovery episode is a fresh trajectory, so
+            # drop the previous fix rather than differencing across the gap.
+            self._prev_fix = None
+        self._requested = requested
 
     def _on_alignment_status(self, msg: DiagnosticArray) -> None:
         for status in msg.status:
@@ -214,6 +238,9 @@ class ReinitializationSupervisorNode(Node):
         future = self.query_client.call_async(Trigger.Request())
         future.add_done_callback(self._on_query_response)
         self._query_in_flight = True
+        # The candidate this query returns is a fix of the scan available now, so
+        # stamp the issue time for the query->publish latency used in compensation.
+        self._query_issue_time = time.monotonic()
 
     def _on_query_response(self, future) -> None:
         self._query_in_flight = False
@@ -249,6 +276,8 @@ class ReinitializationSupervisorNode(Node):
             return
         top = self._candidates[candidate_index]
         yaw = math.radians(top["yaw_deg"])
+        raw_x, raw_y = float(top["x"]), float(top["y"])
+        seed_x, seed_y = self._compensate_seed(raw_x, raw_y)
         # The candidate is 2D (x, y, yaw); carry z / roll / pitch from the last
         # localizer pose so the seed lands in the registration z-basin on a non-flat
         # map. Fall back to the configured default z if no pose seen yet.
@@ -258,8 +287,8 @@ class ReinitializationSupervisorNode(Node):
         msg = PoseWithCovarianceStamped()
         msg.header.stamp = self.get_clock().now().to_msg()
         msg.header.frame_id = self.global_frame_id
-        msg.pose.pose.position.x = float(top["x"])
-        msg.pose.pose.position.y = float(top["y"])
+        msg.pose.pose.position.x = seed_x
+        msg.pose.pose.position.y = seed_y
         msg.pose.pose.position.z = float(z)
         msg.pose.pose.orientation.x = qx
         msg.pose.pose.orientation.y = qy
@@ -271,11 +300,40 @@ class ReinitializationSupervisorNode(Node):
         cov[35] = self.yaw_std ** 2              # yaw
         msg.pose.covariance = cov
         self.initialpose_pub.publish(msg)
+        comp_note = ""
+        if (seed_x, seed_y) != (raw_x, raw_y):
+            comp_note = " (motion-compensated from %.2f, %.2f)" % (raw_x, raw_y)
         self.get_logger().warn(
             "published /initialpose reset to (%.2f, %.2f, z=%.2f, %.1f deg) score=%s "
-            "[candidate %d/%d]"
-            % (top["x"], top["y"], z, top["yaw_deg"], top["score"],
-               candidate_index + 1, len(self._candidates)))
+            "[candidate %d/%d]%s"
+            % (seed_x, seed_y, z, top["yaw_deg"], top["score"],
+               candidate_index + 1, len(self._candidates), comp_note))
+
+    def _compensate_seed(self, raw_x: float, raw_y: float):
+        """Forward-extrapolate (raw_x, raw_y) by the query->publish latency.
+
+        Records the raw fix (the true measured position) for the next call's
+        velocity estimate, then -- if enabled and a prior fix from an earlier query
+        exists -- returns the candidate pushed ahead along the inferred map-frame
+        velocity. Disabled, first-query, within-query-walk, or implausible-velocity
+        cases all return the raw position unchanged (see the policy module).
+        """
+        issue = self._query_issue_time
+        if not self.enable_seed_motion or issue is None:
+            return raw_x, raw_y
+        seed_x, seed_y = raw_x, raw_y
+        if self._prev_fix is not None:
+            prev_x, prev_y, prev_issue = self._prev_fix
+            velocity = rsp.estimate_seed_velocity(
+                (prev_x, prev_y), prev_issue, (raw_x, raw_y), issue,
+                max_speed_mps=self.max_seed_speed)
+            latency = time.monotonic() - issue
+            seed_x, seed_y = rsp.forward_compensate_xy(
+                (raw_x, raw_y), velocity, latency, max_latency_sec=self.max_seed_latency)
+        # Store the raw (un-compensated) fix: it is the actual measurement the next
+        # query's velocity estimate must difference against.
+        self._prev_fix = (raw_x, raw_y, issue)
+        return seed_x, seed_y
 
 
 def main() -> None:

--- a/scripts/reinitialization_supervisor_policy.py
+++ b/scripts/reinitialization_supervisor_policy.py
@@ -74,6 +74,7 @@ Conventions
   a clock, so replays are exact.
 """
 
+import math
 from dataclasses import dataclass, field, replace
 from typing import Optional, Tuple
 
@@ -342,3 +343,88 @@ def decide(
         return SupervisorDecision(ACTION_NONE, "exhausted", state)
 
     raise ValueError(f"unknown supervisor state: {name!r}")
+
+
+# --- seed motion compensation --------------------------------------------------
+#
+# The decisive G3 live-run blocker (docs/g3_live_closed_loop.md, 5th clean run)
+# was *not* the supervisor, the walk, candidate quality, or yaw: it was latency.
+# A G2 BBS query takes ~5-23 s, and the candidate it returns is a fix of the scan
+# taken when the query was *issued*. By the time the reset is published the vehicle
+# has driven on, so the seed lands metres behind the vehicle -- outside the
+# registration basin -- and the lock never takes, even when the candidate was a
+# correct rank-1 fix at query time.
+#
+# We cannot make the query instant here (that is the G2 C++ port), but we can
+# forward-compensate: estimate the vehicle's map-frame velocity and push the seed
+# ahead by the measured query->publish latency. The velocity source must work on
+# the Koide bag, which carries no twist/odom topic (only /livox lidar+imu) -- so we
+# estimate it from the data we already have: *successive query fixes*. Each query
+# returns an absolute map-frame position at its issue time, so the displacement
+# between two consecutive published fixes, divided by the wall time between their
+# issues, is a direct map-frame velocity. Using monotonic wall time consistently
+# for both the velocity dt and the latency keeps this correct under use_sim_time
+# and any constant bag-replay rate (the rate cancels).
+#
+# Safety: a perceptual-aliasing wrong candidate (the live run saw a 190 m-off
+# candidate scored 0.99) would yield an absurd inferred speed. We reject any
+# estimate above ``max_speed_mps`` and fall back to publishing the raw candidate --
+# so compensation only ever fires when two consecutive fixes are mutually
+# consistent, which is exactly when the velocity is trustworthy. This is opt-in
+# (off by default) and never weakens the publish: a bad estimate is a no-op.
+
+
+@dataclass(frozen=True)
+class SeedVelocity:
+    """Map-frame velocity (m/s) inferred from two successive query fixes."""
+    vx: float = 0.0
+    vy: float = 0.0
+    valid: bool = False
+
+
+def estimate_seed_velocity(
+    prev_xy: Tuple[float, float],
+    prev_issue_sec: float,
+    curr_xy: Tuple[float, float],
+    curr_issue_sec: float,
+    max_speed_mps: float,
+    min_dt_sec: float = 0.5,
+) -> SeedVelocity:
+    """Map-frame velocity from two consecutive query fixes, or invalid.
+
+    ``prev_xy`` / ``curr_xy`` are the published candidate positions of two
+    *different* queries; ``*_issue_sec`` are the monotonic times those queries
+    were issued (a good proxy for each fix's scan time). Returns ``valid=False``
+    when the two fixes are too close in time to differentiate (same query / a
+    within-query walk, where ``dt`` is ~0) or when the implied speed exceeds
+    ``max_speed_mps`` -- the latter rejects an inconsistent pair (e.g. one fix was
+    a perceptual-aliasing wrong candidate), so a bad pair never compensates.
+    """
+    dt = curr_issue_sec - prev_issue_sec
+    if dt < min_dt_sec:
+        return SeedVelocity()
+    vx = (curr_xy[0] - prev_xy[0]) / dt
+    vy = (curr_xy[1] - prev_xy[1]) / dt
+    if math.hypot(vx, vy) > max_speed_mps:
+        return SeedVelocity()
+    return SeedVelocity(vx=vx, vy=vy, valid=True)
+
+
+def forward_compensate_xy(
+    xy: Tuple[float, float],
+    velocity: SeedVelocity,
+    latency_sec: float,
+    max_latency_sec: float,
+) -> Tuple[float, float]:
+    """Push ``xy`` ahead by ``velocity * latency`` (clamped), or return it unchanged.
+
+    ``latency_sec`` is the query->publish delay; it is clamped to
+    ``max_latency_sec`` so a pathologically slow query cannot extrapolate the seed
+    arbitrarily far on a first-order model. A non-positive latency or an invalid
+    velocity is a no-op, so this can never move a seed backwards or sideways from a
+    bad estimate.
+    """
+    if not velocity.valid or latency_sec <= 0.0:
+        return xy
+    dt = min(latency_sec, max_latency_sec)
+    return (xy[0] + velocity.vx * dt, xy[1] + velocity.vy * dt)

--- a/test/test_reinitialization_supervisor_policy.py
+++ b/test/test_reinitialization_supervisor_policy.py
@@ -339,6 +339,64 @@ def test_high_max_walk_candidates_restores_full_list_walk():
     assert events[-1][3] == rsp.STATE_STANDDOWN
 
 
+# --- seed motion compensation --------------------------------------------------
+#
+# The query->publish latency is the decisive G3 live blocker: a correct rank-1 fix
+# goes stale because the vehicle drives on while the BBS query runs. These tests
+# pin the forward-compensation helpers that push a seed ahead by the measured
+# latency, and -- crucially -- that a bad/implausible estimate is always a no-op so
+# compensation can never *worsen* a publish.
+
+
+def test_seed_velocity_from_consecutive_fixes():
+    # Two fixes 10 m apart in x over 5 s -> 2 m/s east.
+    v = rsp.estimate_seed_velocity((0.0, 0.0), 100.0, (10.0, 0.0), 105.0,
+                                   max_speed_mps=30.0)
+    assert v.valid
+    assert abs(v.vx - 2.0) < 1e-9
+    assert abs(v.vy - 0.0) < 1e-9
+
+
+def test_seed_velocity_rejects_within_query_walk():
+    # Same query (issue times within min_dt) -> not a motion sample, invalid.
+    v = rsp.estimate_seed_velocity((0.0, 0.0), 100.0, (50.0, 0.0), 100.1,
+                                   max_speed_mps=30.0)
+    assert not v.valid
+
+
+def test_seed_velocity_rejects_implausible_speed():
+    # A perceptual-aliasing wrong candidate jumps 200 m in 2 s = 100 m/s -> rejected,
+    # so a wrong/right fix pair never drives compensation.
+    v = rsp.estimate_seed_velocity((0.0, 0.0), 100.0, (200.0, 0.0), 102.0,
+                                   max_speed_mps=30.0)
+    assert not v.valid
+
+
+def test_forward_compensate_pushes_seed_ahead_by_latency():
+    v = rsp.SeedVelocity(vx=2.0, vy=1.0, valid=True)
+    # 8 s of query latency at (2, 1) m/s -> +16 m east, +8 m north.
+    x, y = rsp.forward_compensate_xy((100.0, 50.0), v, latency_sec=8.0,
+                                     max_latency_sec=30.0)
+    assert abs(x - 116.0) < 1e-9
+    assert abs(y - 58.0) < 1e-9
+
+
+def test_forward_compensate_clamps_latency():
+    v = rsp.SeedVelocity(vx=2.0, vy=0.0, valid=True)
+    # A 100 s query is clamped to max_latency_sec (30 s) -> +60 m, not +200 m.
+    x, _ = rsp.forward_compensate_xy((0.0, 0.0), v, latency_sec=100.0,
+                                     max_latency_sec=30.0)
+    assert abs(x - 60.0) < 1e-9
+
+
+def test_forward_compensate_invalid_velocity_is_noop():
+    # An invalid estimate must never move the seed -- compensation cannot worsen a
+    # publish, it can only help when the estimate is trustworthy.
+    x, y = rsp.forward_compensate_xy((7.0, 3.0), rsp.SeedVelocity(),
+                                     latency_sec=10.0, max_latency_sec=30.0)
+    assert (x, y) == (7.0, 3.0)
+
+
 if __name__ == "__main__":
     import pytest
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

The decisive G3 live-recovery blocker isolated in `docs/g3_live_closed_loop.md` (clean fourth run) is **latency, not candidate quality**. A G2 BBS query takes ~5-23 s and returns a fix of the scan at *query-issue* time; by the time the supervisor publishes the reset, the moving vehicle has driven out of the registration basin, so even a correct rank-1 fix goes stale and the lock never takes.

This adds **lever 2**: forward-compensate the seed by the measured query→publish latency.

## How it works

- The Koide bag carries no twist/odom (only `/livox` lidar+imu), so velocity is inferred from **successive query fixes**: each query returns an absolute map-frame position at its issue time, so the displacement between two consecutive published fixes over the wall time between issues is a direct map-frame velocity. The next seed is pushed ahead by `velocity * (now - query_issue_time)`.
- Monotonic wall time is used for **both** the velocity `dt` and the latency, so the result is correct under `use_sim_time` and any constant bag-replay rate (the rate cancels).

## Safety (cannot worsen a publish)

- An implausible inferred speed (e.g. a perceptual-aliasing wrong candidate — the first live run saw a 190 m-off candidate scored 0.99) above `max_seed_speed_mps` (default 30) is **rejected**; the raw candidate is published unchanged.
- Latency is clamped to `max_seed_latency_sec` (default 30) so a pathologically slow query cannot extrapolate a first-order model arbitrarily far.
- A bad/invalid estimate is always a **no-op**. Compensation only ever fires when two consecutive fixes are mutually consistent.
- **Off by default** (`enable_seed_motion_compensation` / `supervisor_enable_seed_motion_compensation` launch arg).

## Tests

Pure compensation math (`estimate_seed_velocity`, `forward_compensate_xy`) lives in the ROS-free policy module and is unit-tested with 6 new cases: velocity estimate, within-query-walk rejection, implausible-speed rejection, latency clamp, invalid-estimate no-op. **21 policy tests green.** Launch arg wired with bool type coercion (verified `'false'`→`False`).

## Follow-up

Live verification on Koide (does the compensated seed lock where the raw one went stale) is the remaining idle-machine step. The root fix for the latency itself is the G2 BBS C++ port (separate work).