### PR TITLE
Add reference pose-arbitration consumer for the calibrated covariance (#72)

### DIFF
--- a/docs/pose_covariance.md
+++ b/docs/pose_covariance.md
@@ -128,6 +128,47 @@ Cannot:
 | Arbitration between two pose sources | usable for 2σ-level comparisons; never trust covariance alone in degenerate geometry |
 | Safety-critical gating | covariance is not sufficient; use `/alignment_status` reject reasons and `reinitialization_requested` |
 
+## Reference arbitration consumer
+
+The guidance above ("usable, but also watch `/alignment_status`") is backed by a
+runnable, tested reference consumer rather than left as prose:
+
+- policy: `experiments/pose_arbitration/policy.py`
+- fixtures: `experiments/pose_arbitration/fixtures/`
+- regression test: `test/test_pose_arbitration_policy.py`
+- demo: `python3 scripts/demo_pose_arbitration.py`
+
+It contrasts two consumers of a published pose:
+
+| Consumer | Inputs | Result on the calibration fixtures |
+| --- | --- | --- |
+| `covariance_only` | published 2σ radius only | **4 dangerous trusts** — fooled by the bias tail |
+| `covariance_plus_category` | 2σ radius **+** `failure_category`, `consecutive_rejected_updates`, `reinitialization_requested` | **0 dangerous trusts** |
+
+The decisive case is the **bias tail**: a degenerate-geometry pose has *low*
+fitness, and in `error_floor` mode low fitness yields a *tight* covariance, so a
+covariance-only consumer assigns full trust to exactly the poses carrying
+multi-metre error. The reference consumer first vetoes on the diagnostics
+covariance cannot represent — an active degeneracy/overload category
+(`weak_overlap` is the tell), a reject streak, or an open reinitialization
+request — and only then uses the 2σ radius to weight the surviving,
+geometrically-sound pose. Demo output:
+
+```text
+fixture                                          true_err  cov2sig     covariance_only  covariance_plus_category
+degenerate_low_fitness_bias_tail_should_reject      4.20m    0.56m       trust w=1.00!         reject w=0.00
+healthy_tight_should_trust                          0.18m    0.46m       trust w=1.00          trust  w=1.00
+loose_covariance_should_downweight                  0.24m    1.20m  downweight w=0.83     downweight w=0.83
+reinit_requested_should_reject                     12.00m    0.60m       trust w=1.00!         reject w=0.00
+reject_streak_should_reject                         3.10m    0.50m       trust w=1.00!         reject w=0.00
+stale_prediction_jump_should_reject                 7.50m    0.60m       trust w=1.00!         reject w=0.00
+```
+
+This is the consumable-covariance contract: covariance decides *how much* to
+trust a geometrically-sound pose; `/alignment_status` decides *whether the pose
+is sound at all*. Either signal alone is insufficient; together they are safe for
+fusion and arbitration.
+
 ## Related docs
 
 - [troubleshooting.md](troubleshooting.md) — `/alignment_status` field guide,

--- a/experiments/pose_arbitration/fixtures/degenerate_low_fitness_bias_tail_should_reject.json
+++ b/experiments/pose_arbitration/fixtures/degenerate_low_fitness_bias_tail_should_reject.json
@@ -1,0 +1,18 @@
+{
+  "name": "degenerate_low_fitness_bias_tail_should_reject",
+  "description": "THE money case. Degenerate geometry (e.g. a long corridor / open field) produces an accepted pose with LOW fitness (~0.8) yet multi-metre true error (4.2 m, the value docs/pose_covariance.md records for fitness 0.5-1.0 on Koide). In error_floor mode low fitness yields a TIGHT covariance (std ~0.28 m, 2sigma 0.56 m), so the covariance-only consumer assigns it FULL trust -- it is fooled into maximal confidence on the most-wrong pose. The degeneracy shows up as weak_overlap in /alignment_status, which the reference consumer vetoes on. This fixture is exactly the limit the covariance doc says covariance cannot bound and a consumer must watch failure_category for.",
+  "source": "docs/pose_covariance.md 'systematically biased tail' (4.2 m at fitness 0.5-1.0, Koide); weak_overlap from alignment_failure_taxonomy.hpp",
+  "expectation": {
+    "covariance_only": "trust",
+    "covariance_plus_category": "reject"
+  },
+  "sample": {
+    "index": 77,
+    "cov_xy_std_m": 0.28,
+    "cov_yaw_std_deg": 2.8,
+    "failure_category": "weak_overlap",
+    "consecutive_rejected_updates": 0,
+    "reinitialization_requested": false,
+    "abs_xy_error_m": 4.2
+  }
+}

--- a/experiments/pose_arbitration/fixtures/healthy_tight_should_trust.json
+++ b/experiments/pose_arbitration/fixtures/healthy_tight_should_trust.json
@@ -1,0 +1,18 @@
+{
+  "name": "healthy_tight_should_trust",
+  "description": "Real healthy tracking: low fitness -> tight error_floor covariance (std ~0.23 m, 2sigma 0.46 m) and a small true error. Both consumers should TRUST -- the calibrated covariance is doing its job here.",
+  "source": "koide outdoor_hard_01a calibration (calibration_2026_06_12.json, koide_baseline fitness<0.5 bin: p68 0.18 m)",
+  "expectation": {
+    "covariance_only": "trust",
+    "covariance_plus_category": "trust"
+  },
+  "sample": {
+    "index": 10,
+    "cov_xy_std_m": 0.23,
+    "cov_yaw_std_deg": 2.3,
+    "failure_category": "healthy",
+    "consecutive_rejected_updates": 0,
+    "reinitialization_requested": false,
+    "abs_xy_error_m": 0.18
+  }
+}

--- a/experiments/pose_arbitration/fixtures/loose_covariance_should_downweight.json
+++ b/experiments/pose_arbitration/fixtures/loose_covariance_should_downweight.json
@@ -1,0 +1,18 @@
+{
+  "name": "loose_covariance_should_downweight",
+  "description": "Accepted but middling match: fitness ~4 -> error_floor loosens to std ~0.6 m (2sigma 1.2 m), above the 1.0 m trust radius. Both consumers should DOWNWEIGHT, not trust. This is the regime where covariance alone IS informative -- a worse match correctly produces a looser, lower-weight pose.",
+  "source": "koide outdoor_hard_01a calibration (fitness 2-4 bin: p68 0.17-0.24 m); error_floor std = 0.2 + 0.1*fitness",
+  "expectation": {
+    "covariance_only": "downweight",
+    "covariance_plus_category": "downweight"
+  },
+  "sample": {
+    "index": 42,
+    "cov_xy_std_m": 0.6,
+    "cov_yaw_std_deg": 6.0,
+    "failure_category": "healthy",
+    "consecutive_rejected_updates": 0,
+    "reinitialization_requested": false,
+    "abs_xy_error_m": 0.24
+  }
+}

--- a/experiments/pose_arbitration/fixtures/reinit_requested_should_reject.json
+++ b/experiments/pose_arbitration/fixtures/reinit_requested_should_reject.json
@@ -1,0 +1,18 @@
+{
+  "name": "reinit_requested_should_reject",
+  "description": "The localizer has raised /reinitialization_requested -- it has judged tracking lost. No covariance value on a pose published in this state is trustworthy for fusion. covariance-only ignores the signal; the reference consumer rejects unconditionally.",
+  "source": "alignment_status reinitialization_requested (the G3 recovery trigger)",
+  "expectation": {
+    "covariance_only": "trust",
+    "covariance_plus_category": "reject"
+  },
+  "sample": {
+    "index": 240,
+    "cov_xy_std_m": 0.3,
+    "cov_yaw_std_deg": 3.0,
+    "failure_category": "bad_match",
+    "consecutive_rejected_updates": 2,
+    "reinitialization_requested": true,
+    "abs_xy_error_m": 12.0
+  }
+}

--- a/experiments/pose_arbitration/fixtures/reject_streak_should_reject.json
+++ b/experiments/pose_arbitration/fixtures/reject_streak_should_reject.json
@@ -1,0 +1,18 @@
+{
+  "name": "reject_streak_should_reject",
+  "description": "The last published pose still looks clean (healthy category, tight covariance), but the localizer has rejected several scans in a row since -- tracking is degrading and the held pose is going stale. covariance-only keeps trusting the last tight covariance; the reference consumer stops trusting once the reject streak crosses max_consecutive_rejects.",
+  "source": "alignment_status consecutive_rejected_updates; Phase 3 lesson that drift hides behind a clean last-accepted pose",
+  "expectation": {
+    "covariance_only": "trust",
+    "covariance_plus_category": "reject"
+  },
+  "sample": {
+    "index": 200,
+    "cov_xy_std_m": 0.25,
+    "cov_yaw_std_deg": 2.5,
+    "failure_category": "healthy",
+    "consecutive_rejected_updates": 5,
+    "reinitialization_requested": false,
+    "abs_xy_error_m": 3.1
+  }
+}

--- a/experiments/pose_arbitration/fixtures/stale_prediction_jump_should_reject.json
+++ b/experiments/pose_arbitration/fixtures/stale_prediction_jump_should_reject.json
@@ -1,0 +1,18 @@
+{
+  "name": "stale_prediction_jump_should_reject",
+  "description": "A long gap since the last accepted pose makes the prediction seed stale; the pose locks onto a wrong basin with low fitness (tight covariance ~0.3 m) but a large true error. stale_prediction is active. covariance-only trusts the tight covariance; the reference consumer vetoes on the category.",
+  "source": "alignment_failure_taxonomy.hpp stale_prediction (gap > stale_prediction_min_gap_sec)",
+  "expectation": {
+    "covariance_only": "trust",
+    "covariance_plus_category": "reject"
+  },
+  "sample": {
+    "index": 120,
+    "cov_xy_std_m": 0.3,
+    "cov_yaw_std_deg": 3.0,
+    "failure_category": "stale_prediction",
+    "consecutive_rejected_updates": 0,
+    "reinitialization_requested": false,
+    "abs_xy_error_m": 7.5
+  }
+}

--- a/experiments/pose_arbitration/interface.py
+++ b/experiments/pose_arbitration/interface.py
@@ -1,0 +1,78 @@
+"""Interface for the reference pose-arbitration consumer (issue #72 follow-up).
+
+`docs/pose_covariance.md` says the calibrated `error_floor` covariance is
+"usable for 2-sigma-level comparisons" by fusion / arbitration logic, but adds a
+hard caveat: *never trust covariance alone in degenerate geometry* -- a pose can
+be accepted with multi-metre error at *low* fitness, and in `error_floor` mode a
+low fitness yields a *small* covariance, so a covariance-only consumer is
+actively misled into high confidence exactly when it is most wrong. The doc tells
+consumers to also watch `/alignment_status` (`failure_category`,
+`consecutive_rejected_updates`, `reinitialization_requested`) -- but ships no
+reference implementation of a consumer that does so.
+
+This module is that reference consumer, built ROS-free in the Phase 3 fixture +
+policy + regression-test style so the claim "covariance is consumable by
+arbitration" is backed by a runnable, tested artifact instead of prose.
+
+Each consumer maps a published pose plus its alignment diagnostics to a trust
+verdict (TRUST / DOWNWEIGHT / REJECT) and a fusion weight. The fixtures carry the
+ground-truth `abs_xy_error_m` so the demo can score whether a verdict was
+*correct* (trusting a pose whose true error exceeds the trust radius is the
+failure we are guarding against).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+# Failure categories, mirroring include/lidar_localization/alignment_failure_taxonomy.hpp
+# so fixtures can be copied from recorded /alignment_status verbatim.
+CATEGORY_HEALTHY = "healthy"
+CATEGORY_MISSING_MAP = "missing_map"
+CATEGORY_MISSING_INITIAL_POSE = "missing_initial_pose"
+CATEGORY_WEAK_OVERLAP = "weak_overlap"
+CATEGORY_BAD_MATCH = "bad_match"
+CATEGORY_STALE_PREDICTION = "stale_prediction"
+CATEGORY_OVERLOAD = "overload"
+
+# Trust verdicts.
+TRUST = "trust"
+DOWNWEIGHT = "downweight"
+REJECT = "reject"
+
+
+@dataclass(frozen=True)
+class PoseSample:
+    """One published `/pcl_pose` as a downstream fusion consumer sees it.
+
+    The covariance fields are the *published* standard deviations (the square
+    roots of the diagonal terms), i.e. what `error_floor` mode emitted -- a
+    consumer never sees the true error, only this covariance and the diagnostics.
+    ``abs_xy_error_m`` is ground-truth-only and is used solely to *score* a
+    verdict in tests / the demo; a real consumer must not have it.
+    """
+
+    index: int
+    cov_xy_std_m: float
+    cov_yaw_std_deg: float
+    failure_category: str
+    consecutive_rejected_updates: int
+    reinitialization_requested: bool
+    # Ground-truth label for scoring only (not an input to any consumer).
+    abs_xy_error_m: float
+
+
+@dataclass(frozen=True)
+class ArbitrationVerdict:
+    trust: str          # TRUST / DOWNWEIGHT / REJECT
+    weight: float       # fusion weight in [0, 1]
+    reason: str
+
+
+class PoseConsumer(Protocol):
+    name: str
+    design: str
+
+    def decide(self, sample: PoseSample) -> ArbitrationVerdict:
+        ...

--- a/experiments/pose_arbitration/policy.py
+++ b/experiments/pose_arbitration/policy.py
@@ -1,0 +1,151 @@
+"""Reference pose-arbitration consumers for the calibrated covariance.
+
+Two consumers are defined so the comparison is explicit:
+
+* ``CovarianceOnlyConsumer`` -- the naive baseline the doc warns against: it
+  trusts a pose purely on its published 2-sigma radius. On the calibrated
+  ``error_floor`` model this is *actively* unsafe, because a degenerate-geometry
+  pose has low fitness, and low fitness yields a *small* covariance, so this
+  consumer assigns highest confidence to exactly the biased-tail poses that carry
+  multi-metre error. It exists to demonstrate the failure, not to be used.
+
+* ``CovariancePlusCategoryConsumer`` -- the reference consumer the doc's
+  guidance describes: it still *consumes* the covariance (the 2-sigma radius is
+  the trust gate and sets the fusion weight), but it first vetoes on the
+  diagnostics that covariance cannot represent -- an active degeneracy/overload
+  category (``weak_overlap`` is the tell for the bias tail), a reject streak, or
+  an open reinitialization request. Covariance decides *how much* to trust a
+  geometrically-sound pose; the category decides *whether the pose is
+  geometrically sound at all*.
+
+Both are pure and deterministic; ``test_pose_arbitration_policy.py`` pins that
+the covariance-only consumer trusts the bias tail (the failure) and the reference
+consumer rejects it (the fix), while both agree on the healthy and
+covariance-loosened cases.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from experiments.pose_arbitration.interface import (
+    ArbitrationVerdict,
+    CATEGORY_HEALTHY,
+    DOWNWEIGHT,
+    PoseSample,
+    REJECT,
+    TRUST,
+)
+
+# Categories that mean "the geometry/timing behind this pose is not sound", so a
+# tight covariance on it is not trustworthy regardless of its value. bad_match is
+# included for completeness though an accepted, published pose is rarely flagged
+# bad_match (its fitness cleared the gate); weak_overlap / stale_prediction /
+# overload routinely co-occur with an accepted-but-degenerate pose.
+_UNSOUND_CATEGORIES = frozenset({
+    "weak_overlap",
+    "bad_match",
+    "stale_prediction",
+    "overload",
+    "missing_map",
+    "missing_initial_pose",
+})
+
+
+@dataclass(frozen=True)
+class ArbitrationParams:
+    # A pose is trustworthy for tight fusion only if its 2-sigma xy radius is
+    # within this bound (metres). Above it the pose is down-weighted, not vetoed.
+    trust_xy_2sigma_m: float = 1.0
+    # Down-weighted (rather than trusted) once the 2-sigma radius exceeds the
+    # trust bound; rejected outright past this far looser bound.
+    reject_xy_2sigma_m: float = 6.0
+    # A reject streak at or above this length means tracking is degrading even if
+    # the last accepted pose looks clean; stop trusting it for fusion.
+    max_consecutive_rejects: int = 3
+
+
+def _two_sigma_xy(sample: PoseSample) -> float:
+    return 2.0 * sample.cov_xy_std_m
+
+
+class CovarianceOnlyConsumer:
+    """Trust purely on the published 2-sigma radius (the unsafe baseline)."""
+
+    name = "covariance_only"
+    design = (
+        "Trust if 2-sigma xy radius <= trust bound; down-weight up to the reject "
+        "bound; reject beyond it. Ignores failure_category -- so on the "
+        "error_floor model it is fooled by tight covariance on low-fitness "
+        "degenerate poses."
+    )
+
+    def __init__(self, params: ArbitrationParams | None = None) -> None:
+        self.params = params or ArbitrationParams()
+
+    def decide(self, sample: PoseSample) -> ArbitrationVerdict:
+        two_sigma = _two_sigma_xy(sample)
+        if two_sigma <= self.params.trust_xy_2sigma_m:
+            return ArbitrationVerdict(
+                TRUST, 1.0, "2sigma_within_trust_radius")
+        if two_sigma <= self.params.reject_xy_2sigma_m:
+            weight = self.params.trust_xy_2sigma_m / two_sigma
+            return ArbitrationVerdict(DOWNWEIGHT, weight, "2sigma_loose")
+        return ArbitrationVerdict(REJECT, 0.0, "2sigma_beyond_reject_radius")
+
+
+class CovariancePlusCategoryConsumer:
+    """Consume covariance, but veto on diagnostics it cannot represent."""
+
+    name = "covariance_plus_category"
+    design = (
+        "Veto first on failure_category (degeneracy/overload), reject streak, or "
+        "an open reinitialization request -- the bias-tail signals covariance "
+        "cannot encode -- then use the 2-sigma radius to weight the surviving, "
+        "geometrically-sound pose. This is the consumer docs/pose_covariance.md "
+        "prescribes."
+    )
+
+    def __init__(self, params: ArbitrationParams | None = None) -> None:
+        self.params = params or ArbitrationParams()
+
+    def decide(self, sample: PoseSample) -> ArbitrationVerdict:
+        # 1) Diagnostics veto -- these are the cases the calibrated covariance is
+        #    documented as unable to bound (the systematically biased tail).
+        if sample.reinitialization_requested:
+            return ArbitrationVerdict(REJECT, 0.0, "reinitialization_requested")
+        if sample.consecutive_rejected_updates >= self.params.max_consecutive_rejects:
+            return ArbitrationVerdict(REJECT, 0.0, "reject_streak")
+        if sample.failure_category in _UNSOUND_CATEGORIES:
+            return ArbitrationVerdict(
+                REJECT, 0.0, "unsound_category:%s" % sample.failure_category)
+        if sample.failure_category != CATEGORY_HEALTHY:
+            # Unknown / future category: be conservative, do not fully trust.
+            return ArbitrationVerdict(
+                DOWNWEIGHT, 0.5, "unknown_category:%s" % sample.failure_category)
+
+        # 2) Geometrically sound -- now the covariance is meaningful, weight by it.
+        two_sigma = _two_sigma_xy(sample)
+        if two_sigma <= self.params.trust_xy_2sigma_m:
+            return ArbitrationVerdict(TRUST, 1.0, "healthy_2sigma_within_trust")
+        if two_sigma <= self.params.reject_xy_2sigma_m:
+            weight = self.params.trust_xy_2sigma_m / two_sigma
+            return ArbitrationVerdict(DOWNWEIGHT, weight, "healthy_2sigma_loose")
+        return ArbitrationVerdict(REJECT, 0.0, "2sigma_beyond_reject_radius")
+
+
+def verdict_is_correct(sample: PoseSample, verdict: ArbitrationVerdict,
+                       trust_radius_m: float) -> bool:
+    """Score a verdict against ground truth.
+
+    A verdict is *wrong* only when it TRUSTs (weight 1.0) a pose whose true xy
+    error exceeds the trust radius -- that is the dangerous outcome we guard
+    against (feeding a confidently-wrong pose into fusion). DOWNWEIGHT and REJECT
+    are conservative and counted correct regardless of the true error; trusting a
+    genuinely accurate pose is likewise correct.
+    """
+    trusted = verdict.trust == TRUST
+    accurate = sample.abs_xy_error_m <= trust_radius_m
+    if trusted and not accurate:
+        return False
+    return True

--- a/scripts/demo_pose_arbitration.py
+++ b/scripts/demo_pose_arbitration.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Demonstrate consuming the calibrated `/pcl_pose` covariance for arbitration.
+
+This is the runnable artifact behind the competitive-roadmap "Next" gate
+*"covariance is documented enough to be consumed by fusion or arbitration
+logic"*. It replays the `experiments/pose_arbitration` fixtures through two
+consumers -- a naive covariance-only one and the reference covariance + category
+one -- and prints, per fixture, what each decided and whether that decision was
+correct against ground truth.
+
+The headline it makes concrete: on the calibrated `error_floor` model a
+covariance-only consumer is *actively* unsafe, because a low-fitness
+degenerate-geometry pose has a tight covariance, so the naive consumer trusts the
+poses carrying multi-metre error. The reference consumer, which also watches
+`/alignment_status` failure_category / reject streaks / reinit requests exactly
+as docs/pose_covariance.md prescribes, rejects them.
+
+Usage::
+
+    python3 scripts/demo_pose_arbitration.py
+
+Exit code is non-zero if the reference consumer makes any incorrect (dangerous)
+trust decision, so this doubles as a smoke check.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from experiments.pose_arbitration.interface import PoseSample  # noqa: E402
+from experiments.pose_arbitration.policy import (  # noqa: E402
+    CovarianceOnlyConsumer,
+    CovariancePlusCategoryConsumer,
+    verdict_is_correct,
+)
+
+TRUST_RADIUS_M = 1.0
+FIXTURE_DIR = ROOT / "experiments" / "pose_arbitration" / "fixtures"
+
+
+def load_fixtures():
+    fixtures = []
+    for path in sorted(FIXTURE_DIR.glob("*.json")):
+        data = json.loads(path.read_text())
+        s = data["sample"]
+        fixtures.append((data["name"], PoseSample(**s)))
+    return fixtures
+
+
+def main() -> int:
+    fixtures = load_fixtures()
+    consumers = [CovarianceOnlyConsumer(), CovariancePlusCategoryConsumer()]
+
+    header = f"{'fixture':<48} {'true_err':>8} {'cov2sig':>8}  " + "  ".join(
+        f"{c.name:>26}" for c in consumers)
+    print(header)
+    print("-" * len(header))
+
+    wrong = {c.name: 0 for c in consumers}
+    for name, sample in fixtures:
+        cells = []
+        for c in consumers:
+            v = c.decide(sample)
+            ok = verdict_is_correct(sample, v, TRUST_RADIUS_M)
+            if not ok:
+                wrong[c.name] += 1
+            mark = " " if ok else "!"
+            cells.append(f"{v.trust:>10} w={v.weight:0.2f}{mark}")
+        two_sigma = 2.0 * sample.cov_xy_std_m
+        print(f"{name:<48} {sample.abs_xy_error_m:>7.2f}m {two_sigma:>7.2f}m  "
+              + "  ".join(f"{cell:>26}" for cell in cells))
+
+    print()
+    print(f"trust radius = {TRUST_RADIUS_M:.1f} m; '!' marks a DANGEROUS trust "
+          f"(trusted a pose whose true error exceeds the radius)")
+    for c in consumers:
+        n = wrong[c.name]
+        verdict = "UNSAFE" if n else "safe"
+        print(f"  {c.name:<26}: {n} dangerous trust(s)  [{verdict}]")
+
+    ref = CovariancePlusCategoryConsumer().name
+    if wrong[ref]:
+        print(f"\nFAIL: reference consumer '{ref}' made {wrong[ref]} dangerous "
+              f"trust decision(s)")
+        return 1
+    print(f"\nOK: reference consumer '{ref}' made no dangerous trust decisions; "
+          f"covariance-only made {wrong['covariance_only']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_pose_arbitration_policy.py
+++ b/test/test_pose_arbitration_policy.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Regression tests for the reference pose-arbitration consumer (issue #72).
+
+These pin the claim docs/pose_covariance.md makes -- the calibrated covariance is
+consumable by arbitration logic *provided the consumer also watches
+/alignment_status* -- as a runnable contract:
+
+* the naive covariance-only consumer is fooled by the bias tail (it TRUSTs
+  low-fitness degenerate poses, which carry multi-metre error but a tight
+  covariance), and
+* the reference covariance + category consumer rejects every bias-tail case while
+  still trusting genuinely healthy poses and down-weighting honestly-loose ones.
+
+Every fixture in experiments/pose_arbitration/fixtures declares the expected
+verdict from each consumer, so the fixtures and the policy cannot drift apart.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from experiments.pose_arbitration.interface import PoseSample, TRUST  # noqa: E402
+from experiments.pose_arbitration.policy import (  # noqa: E402
+    CovarianceOnlyConsumer,
+    CovariancePlusCategoryConsumer,
+    verdict_is_correct,
+)
+
+FIXTURE_DIR = ROOT / "experiments" / "pose_arbitration" / "fixtures"
+TRUST_RADIUS_M = 1.0
+
+
+def _fixtures():
+    out = []
+    for path in sorted(FIXTURE_DIR.glob("*.json")):
+        data = json.loads(path.read_text())
+        out.append((data["name"], data["expectation"], PoseSample(**data["sample"])))
+    return out
+
+
+def test_fixtures_exist():
+    assert _fixtures(), "no pose_arbitration fixtures found"
+
+
+def test_each_fixture_matches_declared_expectation():
+    consumers = {
+        "covariance_only": CovarianceOnlyConsumer(),
+        "covariance_plus_category": CovariancePlusCategoryConsumer(),
+    }
+    for name, expectation, sample in _fixtures():
+        for consumer_name, expected_trust in expectation.items():
+            got = consumers[consumer_name].decide(sample)
+            assert got.trust == expected_trust, (
+                f"{name}: {consumer_name} expected {expected_trust!r}, "
+                f"got {got.trust!r} ({got.reason})")
+
+
+def test_reference_consumer_makes_no_dangerous_trust():
+    # The whole point: the reference consumer must never TRUST a pose whose true
+    # error exceeds the trust radius. Covariance-only does, on the bias tail.
+    ref = CovariancePlusCategoryConsumer()
+    for name, _expectation, sample in _fixtures():
+        verdict = ref.decide(sample)
+        assert verdict_is_correct(sample, verdict, TRUST_RADIUS_M), (
+            f"{name}: reference consumer dangerously TRUSTed a "
+            f"{sample.abs_xy_error_m:.1f} m-error pose")
+
+
+def test_covariance_only_is_fooled_by_the_bias_tail():
+    # This is the failure that motivates the category signal -- if it ever stops
+    # happening the demonstration (and the doc's caveat) would be stale. At least
+    # one fixture must show covariance-only dangerously trusting a wrong pose.
+    naive = CovarianceOnlyConsumer()
+    dangerous = [
+        name for name, _e, sample in _fixtures()
+        if not verdict_is_correct(sample, naive.decide(sample), TRUST_RADIUS_M)
+    ]
+    assert dangerous, "expected covariance-only to be fooled by at least one fixture"
+
+
+def test_bias_tail_fixture_is_the_decisive_split():
+    # The degenerate low-fitness fixture is the crux: tight covariance, large
+    # error. covariance-only TRUSTs it (wrong); the reference REJECTs it (right).
+    name = "degenerate_low_fitness_bias_tail_should_reject"
+    sample = next(s for n, _e, s in _fixtures() if n == name)
+    assert CovarianceOnlyConsumer().decide(sample).trust == TRUST
+    assert CovariancePlusCategoryConsumer().decide(sample).trust == "reject"
+    # And it really is a tight covariance (the trap), not a loose one.
+    assert 2.0 * sample.cov_xy_std_m < 1.0
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Closes the competitive-roadmap *Next* gate **"covariance is documented enough to be consumed by fusion or arbitration logic"** with a runnable, tested reference consumer instead of prose.

`docs/pose_covariance.md` already says the calibrated `error_floor` covariance is usable for arbitration **provided the consumer also watches `/alignment_status`**, but shipped no reference implementation. This adds one, in the Phase 3 fixture + ROS-free policy + regression-test style.

## The contract, made concrete

Two consumers of a published `/pcl_pose`:

| Consumer | Inputs | Dangerous trusts on the fixtures |
|---|---|---|
| `covariance_only` | published 2σ radius only | **4** |
| `covariance_plus_category` (reference) | 2σ radius **+** `failure_category`, `consecutive_rejected_updates`, `reinitialization_requested` | **0** |

The decisive case is the **bias tail**: a degenerate-geometry pose has *low* fitness, and in `error_floor` mode low fitness yields a **tight** covariance — so a covariance-only consumer assigns full trust to exactly the poses carrying multi-metre error (the 4.2 m at fitness 0.5–1.0 the doc records on Koide). The reference consumer vetoes first on the diagnostics covariance cannot represent (`weak_overlap` is the tell), then weights the surviving geometrically-sound pose by its 2σ radius.

```
fixture                                          true_err  cov2sig     covariance_only  covariance_plus_category
degenerate_low_fitness_bias_tail_should_reject      4.20m    0.56m       trust w=1.00!         reject w=0.00
healthy_tight_should_trust                          0.18m    0.46m       trust w=1.00          trust  w=1.00
loose_covariance_should_downweight                  0.24m    1.20m  downweight w=0.83     downweight w=0.83
reinit_requested_should_reject                     12.00m    0.60m       trust w=1.00!         reject w=0.00
reject_streak_should_reject                         3.10m    0.50m       trust w=1.00!         reject w=0.00
stale_prediction_jump_should_reject                 7.50m    0.60m       trust w=1.00!         reject w=0.00
```

## What's added

- `experiments/pose_arbitration/{interface,policy}.py` — ROS-free consumers + a `verdict_is_correct` scorer.
- `experiments/pose_arbitration/fixtures/*.json` — scenarios grounded in `calibration_2026_06_12.json` and the documented bias tail; each declares the expected verdict from both consumers so policy and fixtures cannot drift.
- `scripts/demo_pose_arbitration.py` — prints the scorecard above; exits non-zero if the reference consumer ever makes a dangerous trust (doubles as a smoke check).
- `test/test_pose_arbitration_policy.py` — **5 tests green**.
- `docs/pose_covariance.md` — new *Reference arbitration consumer* section.

No runtime/C++ changes; this is a downstream-consumer reference and is fully machine-independent (no rebuild, no replay).