### PR TITLE
Add IMU preintegration regression test + estimator docs (#36, #77)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,15 @@ if(BUILD_TESTING)
     COMMAND test_imu_preintegration_guard_policy
   )
 
+  add_executable(test_imu_preintegration
+    test/test_imu_preintegration.cpp)
+  target_include_directories(test_imu_preintegration PRIVATE
+    include)
+  add_test(
+    NAME imu_preintegration
+    COMMAND test_imu_preintegration
+  )
+
   add_executable(test_prediction_state_policy
     test/test_prediction_state_policy.cpp)
   target_include_directories(test_prediction_state_policy PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,8 +376,12 @@ if(BUILD_TESTING)
 
   add_executable(test_imu_preintegration
     test/test_imu_preintegration.cpp)
+  # Unlike the guard-policy header, imu_preintegration.hpp pulls in Eigen (via
+  # so3_utils.hpp), so the Eigen include path must be explicit here -- it reaches
+  # the global include path only indirectly via PCL on some distros (Jazzy) and
+  # not others (Humble).
   target_include_directories(test_imu_preintegration PRIVATE
-    include)
+    include ${EIGEN3_INCLUDE_DIRS})
   add_test(
     NAME imu_preintegration
     COMMAND test_imu_preintegration

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ git branch -D <branch>
 | Bringup troubleshooting | [docs/troubleshooting.md](docs/troubleshooting.md) |
 | Map alignment / pose offset | [docs/map_alignment.md](docs/map_alignment.md) |
 | Pose covariance semantics | [docs/pose_covariance.md](docs/pose_covariance.md) |
+| IMU estimation (preintegration) | [docs/imu_estimation.md](docs/imu_estimation.md) |
 | Frame / TF contract | [docs/frame_contract.md](docs/frame_contract.md) |
 
 ## ROS 2 Support

--- a/docs/imu_estimation.md
+++ b/docs/imu_estimation.md
@@ -1,0 +1,144 @@
+# IMU Estimation
+
+This page documents the IMU-aided estimation already implemented in the package,
+in response to the recurring requests in
+[#36 (imu preintegration)](https://github.com/rsasaki0109/lidar_localization_ros2/issues/36)
+and
+[#77 (utilization of IMU angular velocity and the introduction of an
+estimator)](https://github.com/rsasaki0109/lidar_localization_ros2/issues/77).
+Both are implemented; this page is the map of what exists, how to turn it on, and
+what is and is not validated.
+
+## What is implemented
+
+The node offers a **layered** set of prediction/estimation options, cheapest
+first. Each is opt-in; the default bringup uses none of them (pure NDT/GICP
+tracking) so the IMU path never affects users who do not enable it.
+
+| Layer | Parameter | What it does | Addresses |
+| --- | --- | --- | --- |
+| Twist prediction | `use_twist_prediction` (+ `twist_prediction_use_angular_velocity`) | Constant-twist motion prediction between scans, using the IMU/odom angular velocity to rotate the seed | #77 (angular velocity) |
+| Twist EKF | `use_twist_ekf` | A small constant-velocity EKF on the twist, feeding both the prediction seed and the published covariance | #77 (estimator) |
+| **IMU preintegration + smoother** | `use_imu` + `use_imu_preintegration` | On-manifold IMU preintegration (Forster et al. 2017) inside a sliding-window Gauss-Newton optimizer with 6-DOF NDT priors and online gyro/accel bias estimation | #36, #77 |
+| Twist GTSAM smoother | `use_gtsam_smoother` | Sliding-window odometry+NDT smoother (no raw IMU) | #77 (estimator) |
+
+The headline item is the **IMU preintegration estimator**:
+
+- `include/lidar_localization/imu_preintegration.hpp` — on-manifold
+  preintegration of gyro+accel into a relative `(delta_p, delta_v, delta_R)`
+  with covariance propagation and first-order bias Jacobians, pure Eigen.
+- `include/lidar_localization/imu_gtsam_smoother.hpp` — a sliding-window
+  Gauss-Newton optimizer over per-pose state `[p, v, rpy]` (9 DOF) plus a shared
+  `[bias_gyro, bias_accel]` (6 DOF), with preintegration factors between poses
+  and Huber-robust NDT priors weighted by alignment fitness.
+- `include/lidar_localization/imu_preintegration_guard_policy.hpp` — the safety
+  layer (below).
+
+## Correctness evidence
+
+The preintegration math is the subtle, easy-to-get-wrong core, so it has a
+numerical regression test, `test/test_imu_preintegration.cpp`, that pins it
+against closed-form answers and a finite-difference check:
+
+- `reset()` is identity; out-of-range `dt` (≤0 or >0.5 s sensor dropouts) is
+  ignored;
+- **pure rotation** (constant gyro, zero specific force) reproduces
+  `delta_R = Exp(omega·t)` exactly, with zero `delta_p`/`delta_v`;
+- **pure translation** (constant specific force) reproduces `delta_v = a·t`,
+  `delta_p = ½·a·t²` exactly (the discrete scheme is exact for constant accel);
+- the **residual is zero** for a world trajectory built to be consistent with
+  the integrated specific force and gravity;
+- the **bias Jacobians match finite differences**: the first-order
+  `correctByBias()` update reproduces a full re-integration at a perturbed bias
+  to within the O(δ²) truncation error — this validates all five
+  `d_*/d_bias` accumulators together;
+- the propagated covariance is symmetric, positive-semidefinite, and grows with
+  integration time.
+
+The test is pure Eigen (no ROS), so it also builds and runs standalone:
+
+```bash
+g++ -std=c++17 -I include -I /usr/include/eigen3 \
+    test/test_imu_preintegration.cpp -o /tmp/t && /tmp/t
+```
+
+It is registered in `CMakeLists.txt` and runs under `colcon test` as
+`imu_preintegration`.
+
+## Safety: prediction/correction guard and fallback
+
+A LiDAR localizer must not let a bad IMU integration drag the pose. The guard
+policy (`imu_preintegration_guard_policy.hpp`) enforces that:
+
+- if the IMU prediction and the NDT correction disagree by more than
+  `imu_prediction_correction_guard_translation_m` (2.0 m) or
+  `imu_prediction_correction_guard_yaw_deg` (4.0°), or the smoother update is
+  non-finite / implausibly large, the node enters **fallback mode** and reverts
+  to non-IMU prediction until the disagreement clears;
+- the guard is itself unit-tested (`test_imu_preintegration_guard_policy.cpp`).
+
+This is the same design principle as the rest of the stack (see
+[pose_covariance.md](pose_covariance.md), the G3 reinitialization guard): a
+component that feeds itself must not be able to diverge unbounded.
+
+## Parameters
+
+| Parameter | Default | Meaning |
+| --- | --- | --- |
+| `use_imu` | `false` | Master enable for the IMU input |
+| `use_imu_preintegration` | `true` | Use the preintegration smoother (only active when `use_imu`) |
+| `imu_preintegration_use_base_frame_transform` | `false` | Transform IMU samples into the base frame before integrating |
+| `imu_gyro_noise_density` | `0.01` | rad/s/√Hz |
+| `imu_accel_noise_density` | `0.1` | m/s²/√Hz |
+| `imu_gyro_random_walk` | `0.0001` | rad/s²/√Hz |
+| `imu_accel_random_walk` | `0.001` | m/s³/√Hz |
+| `imu_bias_prior_sigma_gyro` | `0.01` | gyro bias prior σ |
+| `imu_bias_prior_sigma_accel` | `0.1` | accel bias prior σ |
+| `imu_ndt_sigma_z` / `_roll` / `_pitch` | `0.1` / `0.05` / `0.05` | NDT prior σ on the axes IMU constrains most |
+| `imu_prediction_correction_guard_translation_m` | `2.0` | fallback if IMU-vs-NDT disagree beyond this |
+| `imu_prediction_correction_guard_yaw_deg` | `4.0` | fallback if IMU-vs-NDT yaw disagree beyond this |
+
+Set the noise densities from your IMU datasheet (or an Allan-variance run) for
+best results; the defaults are MEMS-grade ballpark values.
+
+## How to enable
+
+```bash
+ros2 launch lidar_localization_ros2 lidar_localization.launch.py \
+    localization_param_dir:=/path/to/params.yaml \
+    imu_topic:=/your/imu
+```
+
+`lidar_localization.launch.py` exposes an `imu_topic` argument (default `/imu`)
+that is remapped onto the node's `/imu` subscription, so no manual remapping is
+needed. In the params file:
+
+```yaml
+/**:
+  ros__parameters:
+    use_imu: true
+    use_imu_preintegration: true
+```
+
+The MID-360 launch (`mid360_legged_localization.launch.py`) already wires
+`imu_topic:=/livox/imu` as a worked example.
+
+## Validation state (honest limits)
+
+- The preintegration **math** is verified (the regression test above) and the
+  guard prevents divergence.
+- The estimator is exercised by the **HDL IMU smoke / throughput check** in the
+  release suite, which is a *pipeline safety* gate, **not** an accuracy ranking
+  (see [competitive_roadmap.md](competitive_roadmap.md)).
+- A controlled public **LiDAR + IMU + GT** accuracy benchmark is still open
+  (the Boreas / Koide tracks). Until that lands, the IMU estimator is offered as
+  a working, math-verified, guarded option — **not** as a validated accuracy
+  improvement over pure NDT on a specific dataset. Do not cite it as an accuracy
+  claim without a controlled run.
+
+## Related docs
+
+- [pose_covariance.md](pose_covariance.md) — the twist-EKF hybrid covariance path
+- [interfaces.md](interfaces.md) — topics, including the optional `/imu` input
+- [mid360_legged_jetson.md](mid360_legged_jetson.md) — a real IMU bringup
+- [competitive_roadmap.md](competitive_roadmap.md) — dataset/validation strategy

--- a/docs/reliability_roadmap.md
+++ b/docs/reliability_roadmap.md
@@ -41,8 +41,8 @@ Last triaged: 2026-06-10
 | [#54](https://github.com/rsasaki0109/lidar_localization_ros2/issues/54) | `corrent_pose_with_cov_stamped_ptr_` locking | enhancement | P3 | open | code audit if reproduced under concurrency |
 | [#25](https://github.com/rsasaki0109/lidar_localization_ros2/issues/25) | specifying lidar frame id | docs | P3 | open | already configurable; improve launch examples |
 | [#50](https://github.com/rsasaki0109/lidar_localization_ros2/issues/50) | enhance stability | enhancement | P4 | open | track through public regression, not ad-hoc tuning |
-| [#77](https://github.com/rsasaki0109/lidar_localization_ros2/issues/77) | IMU angular velocity estimator | enhancement | P4 | open | keep in experiments; not a v1.1 reliability target |
-| [#36](https://github.com/rsasaki0109/lidar_localization_ros2/issues/36) | imu preintegration | enhancement | P4 | open | covered by guarded IMU path + public regression |
+| [#77](https://github.com/rsasaki0109/lidar_localization_ros2/issues/77) | IMU angular velocity estimator | enhancement | P4 | open | **implemented** (twist prediction / twist EKF / IMU preintegration smoother); documented in [imu_estimation.md](imu_estimation.md). Open only on a controlled LiDAR+IMU+GT accuracy ranking |
+| [#36](https://github.com/rsasaki0109/lidar_localization_ros2/issues/36) | imu preintegration | enhancement | P4 | open | **implemented** (Forster on-manifold preintegration + sliding-window smoother + guard); math verified by `test_imu_preintegration`; documented in [imu_estimation.md](imu_estimation.md). Open only on a controlled accuracy ranking |
 
 ## Sprint 1 Targets
 

--- a/test/test_imu_preintegration.cpp
+++ b/test/test_imu_preintegration.cpp
@@ -1,0 +1,219 @@
+// Numerical regression tests for the on-manifold IMU preintegration core
+// (include/lidar_localization/imu_preintegration.hpp, Forster et al. 2017).
+//
+// The preintegration math is the heart of the IMU estimator that issues #36
+// (imu preintegration) and #77 (IMU angular-velocity utilization + estimator)
+// ask for, yet only its *guard* policy had a test -- the integration, bias
+// Jacobians, residual and covariance propagation were unverified. These tests
+// pin them against closed-form answers and a finite-difference check, in the
+// repository's plain-assert style. They are pure Eigen (no ROS), so they build
+// and run standalone:
+//
+//   g++ -std=c++17 -I include -I /usr/include/eigen3 \
+//       test/test_imu_preintegration.cpp -o /tmp/t && /tmp/t
+
+#include "lidar_localization/imu_preintegration.hpp"
+
+#include <Eigen/Eigenvalues>
+
+#include <cassert>
+#include <cmath>
+#include <vector>
+
+namespace {
+
+bool close(double a, double b, double tol) { return std::abs(a - b) < tol; }
+
+bool vclose(const Eigen::Vector3d & a, const Eigen::Vector3d & b, double tol)
+{
+  return (a - b).norm() < tol;
+}
+
+// Geodesic distance between two rotations, in radians.
+double rot_diff(const Eigen::Matrix3d & A, const Eigen::Matrix3d & B)
+{
+  return so3::Log(A.transpose() * B).norm();
+}
+
+struct ImuTick
+{
+  Eigen::Vector3d gyro;
+  Eigen::Vector3d accel;
+  double dt;
+};
+
+// Integrate a fixed measurement stream under a given bias, returning the
+// (jacobian-bearing) preintegration object.
+ImuPreintegration integrate_stream(
+  const std::vector<ImuTick> & ticks,
+  const Eigen::Vector3d & bg, const Eigen::Vector3d & ba)
+{
+  ImuPreintegration pre;
+  pre.reset();
+  for (const auto & t : ticks) {
+    pre.integrate(t.gyro, t.accel, bg, ba, t.dt);
+  }
+  return pre;
+}
+
+// ---------------------------------------------------------------------------
+
+void test_reset_is_identity()
+{
+  ImuPreintegration pre;
+  pre.integrate({0.3, -0.1, 0.2}, {1.0, 0.0, 9.0}, {0, 0, 0}, {0, 0, 0}, 0.01);
+  pre.reset();
+  assert(vclose(pre.delta_p, Eigen::Vector3d::Zero(), 1e-12));
+  assert(vclose(pre.delta_v, Eigen::Vector3d::Zero(), 1e-12));
+  assert(rot_diff(pre.delta_R, Eigen::Matrix3d::Identity()) < 1e-12);
+  assert(close(pre.dt_sum, 0.0, 1e-12));
+  assert(pre.covariance.norm() < 1e-12);
+}
+
+void test_dt_outside_range_is_ignored()
+{
+  // The integrator rejects non-positive and >0.5 s steps (sensor dropouts).
+  ImuPreintegration pre;
+  pre.reset();
+  pre.integrate({0.3, 0.0, 0.0}, {1.0, 0.0, 0.0}, {0, 0, 0}, {0, 0, 0}, 0.0);
+  pre.integrate({0.3, 0.0, 0.0}, {1.0, 0.0, 0.0}, {0, 0, 0}, {0, 0, 0}, -0.01);
+  pre.integrate({0.3, 0.0, 0.0}, {1.0, 0.0, 0.0}, {0, 0, 0}, {0, 0, 0}, 0.6);
+  assert(close(pre.dt_sum, 0.0, 1e-12));
+  assert(rot_diff(pre.delta_R, Eigen::Matrix3d::Identity()) < 1e-12);
+}
+
+void test_pure_rotation_matches_analytic()
+{
+  // Constant angular velocity, zero specific force -> delta_R = Exp(omega * t),
+  // and position/velocity stay zero (no acceleration).
+  const Eigen::Vector3d omega(0.2, -0.3, 0.15);
+  const double dt = 0.005;
+  const int n = 200;  // 1.0 s
+  ImuPreintegration pre;
+  pre.reset();
+  for (int i = 0; i < n; ++i) {
+    pre.integrate(omega, Eigen::Vector3d::Zero(), {0, 0, 0}, {0, 0, 0}, dt);
+  }
+  const Eigen::Matrix3d expected_R = so3::Exp(omega * (dt * n));
+  assert(rot_diff(pre.delta_R, expected_R) < 1e-9);
+  assert(vclose(pre.delta_v, Eigen::Vector3d::Zero(), 1e-12));
+  assert(vclose(pre.delta_p, Eigen::Vector3d::Zero(), 1e-12));
+  assert(close(pre.dt_sum, dt * n, 1e-9));
+}
+
+void test_pure_translation_matches_analytic()
+{
+  // Zero rotation, constant specific force a -> the discrete scheme is exact for
+  // constant acceleration: delta_v = a*t, delta_p = 0.5*a*t^2.
+  const Eigen::Vector3d a(0.5, -1.0, 2.0);
+  const double dt = 0.01;
+  const int n = 100;  // 1.0 s
+  ImuPreintegration pre;
+  pre.reset();
+  for (int i = 0; i < n; ++i) {
+    pre.integrate(Eigen::Vector3d::Zero(), a, {0, 0, 0}, {0, 0, 0}, dt);
+  }
+  const double t = dt * n;
+  assert(rot_diff(pre.delta_R, Eigen::Matrix3d::Identity()) < 1e-12);
+  assert(vclose(pre.delta_v, a * t, 1e-9));
+  assert(vclose(pre.delta_p, 0.5 * a * t * t, 1e-9));
+}
+
+void test_residual_zero_for_consistent_trajectory()
+{
+  // Build a world trajectory consistent with constant world acceleration
+  // a_world and identity attitude. The IMU measures specific force
+  // accel_raw = a_world - g, so a preintegration of accel_raw plus the gravity
+  // terms in computeResidual must reproduce the trajectory exactly (residual 0).
+  const Eigen::Vector3d g(0, 0, -9.81);
+  const Eigen::Vector3d a_world(0.3, -0.2, 0.1);
+  const Eigen::Vector3d accel_raw = a_world - g;
+  const double dt = 0.01;
+  const int n = 100;
+  ImuPreintegration pre;
+  pre.params.gravity = g;
+  pre.reset();
+  for (int i = 0; i < n; ++i) {
+    pre.integrate(Eigen::Vector3d::Zero(), accel_raw, {0, 0, 0}, {0, 0, 0}, dt);
+  }
+  const double t = dt * n;
+  const Eigen::Matrix3d R = Eigen::Matrix3d::Identity();
+  const Eigen::Vector3d p_i(2.0, -3.0, 1.0);
+  const Eigen::Vector3d v_i(1.0, 0.5, -0.2);
+  const Eigen::Vector3d v_j = v_i + a_world * t;
+  const Eigen::Vector3d p_j = p_i + v_i * t + 0.5 * a_world * t * t;
+  const Eigen::Matrix<double, 9, 1> r =
+    pre.computeResidual(p_i, v_i, R, p_j, v_j, R);
+  assert(r.norm() < 1e-6);
+}
+
+void test_bias_jacobian_matches_finite_difference()
+{
+  // The decisive test: the first-order bias correction (correctByBias, using the
+  // accumulated d_*/d_b Jacobians) must match a full re-integration at the
+  // perturbed bias, to within the O(delta^2) truncation error. This validates
+  // d_dp_d_bg, d_dp_d_ba, d_dv_d_bg, d_dv_d_ba and d_dR_d_bg together.
+  std::vector<ImuTick> ticks;
+  for (int i = 0; i < 50; ++i) {
+    const double s = 0.02 * i;
+    ticks.push_back({
+      Eigen::Vector3d(0.1 + 0.05 * std::sin(s), -0.2, 0.3 * std::cos(s)),
+      Eigen::Vector3d(0.5, -1.0 + 0.2 * s, 9.0),
+      0.01});
+  }
+  const Eigen::Vector3d bg0(0.01, -0.02, 0.015);
+  const Eigen::Vector3d ba0(0.05, 0.03, -0.04);
+  const Eigen::Vector3d dbg(1e-4, -2e-4, 1.5e-4);
+  const Eigen::Vector3d dba(2e-4, 1e-4, -1e-4);
+
+  const ImuPreintegration nominal = integrate_stream(ticks, bg0, ba0);
+  const ImuPreintegration truth = integrate_stream(ticks, bg0 + dbg, ba0 + dba);
+
+  ImuPreintegration corrected = nominal;
+  corrected.correctByBias(dbg, dba);
+
+  // First-order match: residual error must be far below the perturbation size
+  // (which moved delta_p/delta_v by ~1e-3) -- i.e. the Jacobians explain it.
+  assert(vclose(corrected.delta_p, truth.delta_p, 1e-6));
+  assert(vclose(corrected.delta_v, truth.delta_v, 1e-6));
+  assert(rot_diff(corrected.delta_R, truth.delta_R) < 1e-6);
+
+  // Sanity: the perturbation actually moved the state well above the tolerance,
+  // so the test is not trivially passing on a no-op.
+  assert((nominal.delta_p - truth.delta_p).norm() > 1e-5);
+}
+
+void test_covariance_symmetric_and_grows()
+{
+  ImuPreintegration pre;
+  pre.reset();
+  auto step = [&]() {
+    pre.integrate({0.1, -0.2, 0.05}, {0.4, -0.3, 9.2}, {0, 0, 0}, {0, 0, 0}, 0.01);
+  };
+  step();
+  const double cov_after_1 = pre.covariance.trace();
+  for (int i = 0; i < 49; ++i) step();
+  const double cov_after_50 = pre.covariance.trace();
+
+  // Symmetric.
+  assert((pre.covariance - pre.covariance.transpose()).norm() < 1e-12);
+  // Monotone growth of total uncertainty as more noisy steps accumulate.
+  assert(cov_after_50 > cov_after_1);
+  // Positive semidefinite: smallest eigenvalue is non-negative.
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double, 9, 9>> es(pre.covariance);
+  assert(es.eigenvalues().minCoeff() > -1e-12);
+}
+
+}  // namespace
+
+int main()
+{
+  test_reset_is_identity();
+  test_dt_outside_range_is_ignored();
+  test_pure_rotation_matches_analytic();
+  test_pure_translation_matches_analytic();
+  test_residual_zero_for_consistent_trajectory();
+  test_bias_jacobian_matches_finite_difference();
+  test_covariance_symmetric_and_grows();
+  return 0;
+}


### PR DESCRIPTION
## Summary

The IMU estimator that #36 (imu preintegration) and #77 (IMU angular velocity + estimator) ask for is **already implemented** — on-manifold preintegration (Forster et al. 2017) inside a sliding-window Gauss-Newton smoother with online gyro/accel bias estimation, plus twist-prediction and twist-EKF layers and a prediction/correction guard. But the preintegration **core math had no test**, and there was **no user-facing doc** to point the issues at. This closes both gaps (the #54/#55-style "it's already done, prove and document it" disposition).

## Correctness evidence — `test/test_imu_preintegration.cpp`

Numerical regression tests for the preintegration core, in the repo's plain-assert style:

- `reset()` → identity; out-of-range `dt` (≤0 / >0.5 s dropouts) ignored
- **pure rotation** reproduces `delta_R = Exp(omega·t)` exactly; **pure translation** reproduces `delta_v = a·t`, `delta_p = ½a·t²` exactly
- **zero residual** on a trajectory built consistent with the integrated specific force + gravity
- **bias Jacobians match finite differences** — the first-order `correctByBias()` reproduces a full re-integration at a perturbed bias to O(δ²), validating all five `d_*/d_bias` accumulators together (the decisive, easy-to-get-wrong check)
- covariance symmetric, PSD, monotone growth

Pure Eigen (no ROS), so it builds standalone and under `colcon test` as `imu_preintegration`:

```bash
g++ -std=c++17 -I include -I /usr/include/eigen3 test/test_imu_preintegration.cpp -o /tmp/t && /tmp/t
```

Verified passing locally.

## Documentation — `docs/imu_estimation.md`

Maps the layered options (twist prediction / twist EKF / IMU preintegration smoother / twist GTSAM smoother) to the issues; documents the parameters, the guard/fallback safety layer, how to enable it (the existing `imu_topic` launch arg), and the **honest validation state**: math verified + HDL IMU smoke, but a controlled LiDAR+IMU+GT accuracy ranking is still open — so it is *not* presented as an accuracy claim. Linked from README; the reliability_roadmap triage now records #36/#77 as **implemented**.

## Scope

No runtime/behavior change — adds a test, docs, and triage notes only. Fully machine-independent.