### PR TITLE
Wire optional C++ BBS backend into the global localization node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,15 +207,20 @@ install(DIRECTORY
 # lib/${PROJECT_NAME} so global_localization_node.py (which sys.path.inserts its
 # own directory) can `import bbs_cpp`. Off the critical path: when pybind11 is
 # absent the module simply is not built and the node uses the Python search.
-if(pybind11_FOUND)
+# pybind11's new-tools pybind11_add_module() needs FindPython's
+# python3_add_library, which is only defined when the Development.Module
+# component is found (the top-level find_package above asks for Interpreter only).
+find_package(Python3 QUIET COMPONENTS Interpreter Development.Module)
+if(pybind11_FOUND AND Python3_Development.Module_FOUND)
   pybind11_add_module(bbs_cpp src/bbs_pybind.cpp)
   target_include_directories(bbs_cpp PRIVATE include)
   target_compile_features(bbs_cpp PRIVATE cxx_std_17)
   install(TARGETS bbs_cpp
     LIBRARY DESTINATION lib/${PROJECT_NAME})
+  set(BBS_CPP_BACKEND_BUILT TRUE)
   message(STATUS "lidar_localization: building optional bbs_cpp pybind11 backend")
 else()
-  message(STATUS "lidar_localization: pybind11 not found; bbs_cpp backend disabled (Python fallback)")
+  message(STATUS "lidar_localization: pybind11/Python3 Development.Module not found; bbs_cpp backend disabled (Python fallback)")
 endif()
 
 install(DIRECTORY
@@ -590,7 +595,7 @@ if(BUILD_TESTING)
   # Parity check for the optional C++ backend: compares bbs_cpp against the
   # Python reference when the compiled module is importable, and skips cleanly
   # (exit 0) otherwise, so it is green whether or not pybind11 was found.
-  if(pybind11_FOUND)
+  if(BBS_CPP_BACKEND_BUILT)
     add_test(
       NAME bbs_cpp_backend_parity
       COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_bbs_cpp_backend_parity.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ find_package(small_gicp QUIET CONFIG)
 find_package(nav2_util QUIET)
 find_package(bondcpp QUIET)
 find_package(OpenMP)
+# Optional: enables the compiled C++ BBS backend (bbs_cpp) for the global
+# localization node. QUIET so a checkout without pybind11 still builds and the
+# node falls back to the pure-Python search.
+find_package(pybind11 QUIET)
 
 if (OPENMP_FOUND)
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
@@ -198,6 +202,21 @@ install(DIRECTORY
   scripts/lidar_localization_mid360
   DESTINATION lib/${PROJECT_NAME}
   PATTERN "__pycache__" EXCLUDE)
+
+# Optional compiled BBS backend. Installed next to the Python scripts in
+# lib/${PROJECT_NAME} so global_localization_node.py (which sys.path.inserts its
+# own directory) can `import bbs_cpp`. Off the critical path: when pybind11 is
+# absent the module simply is not built and the node uses the Python search.
+if(pybind11_FOUND)
+  pybind11_add_module(bbs_cpp src/bbs_pybind.cpp)
+  target_include_directories(bbs_cpp PRIVATE include)
+  target_compile_features(bbs_cpp PRIVATE cxx_std_17)
+  install(TARGETS bbs_cpp
+    LIBRARY DESTINATION lib/${PROJECT_NAME})
+  message(STATUS "lidar_localization: building optional bbs_cpp pybind11 backend")
+else()
+  message(STATUS "lidar_localization: pybind11 not found; bbs_cpp backend disabled (Python fallback)")
+endif()
 
 install(DIRECTORY
   launch
@@ -568,6 +587,17 @@ if(BUILD_TESTING)
     NAME global_localization_query
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_global_localization_query.py
   )
+  # Parity check for the optional C++ backend: compares bbs_cpp against the
+  # Python reference when the compiled module is importable, and skips cleanly
+  # (exit 0) otherwise, so it is green whether or not pybind11 was found.
+  if(pybind11_FOUND)
+    add_test(
+      NAME bbs_cpp_backend_parity
+      COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_bbs_cpp_backend_parity.py
+    )
+    set_tests_properties(bbs_cpp_backend_parity PROPERTIES
+      ENVIRONMENT "BBS_CPP_MODULE_DIR=$<TARGET_FILE_DIR:bbs_cpp>")
+  endif()
 endif()
 
 ament_package()

--- a/docs/g2_bbs_speedup.md
+++ b/docs/g2_bbs_speedup.md
@@ -107,9 +107,21 @@ latency gap.
   ported query near ~1.5 s, and with a coarser yaw step (which the plan notes
   roughly halves the Python query) into the sub-second range that — combined with
   lever-2 seed motion compensation — closes the live-recovery latency gap.
-- Idle-machine wall-clock benchmark and the pybind11 runtime wiring into
-  `global_localization_node.py` (opt-in, Python fallback): **next**, the bench
-  gated on a quiet shared machine (load < ~5).
+- pybind11 runtime wiring into `global_localization_node.py` (opt-in, Python
+  fallback): **done**. `src/bbs_pybind.cpp` exposes the C++ core as the Python
+  module `bbs_cpp` (numpy in, candidate objects out with the same fields as the
+  Python dataclass). `GlobalLocalizationEngine` resolves the backend once: with
+  `use_cpp_backend=true` it imports `bbs_cpp` and uses it, and on `ImportError`
+  it logs once and falls back to the pure-Python search — so a stock build with
+  the default `use_cpp_backend=false` is unchanged. CMake gates the module behind
+  `find_package(pybind11 QUIET)` and installs it next to the node in
+  `lib/${PROJECT_NAME}`; when pybind11 is absent the module is simply not built.
+  `test/test_bbs_cpp_backend_parity.py` re-checks the binding's numpy↔struct
+  plumbing against the Python reference on the four fixture shapes (and skips
+  cleanly when the module is not present).
+- Idle-machine wall-clock benchmark of the wired `bbs_cpp` query: **next**,
+  gated on a quiet shared machine (load < ~5) — the only remaining piece, and a
+  measurement rather than a code change.
 
 ## Reproduce
 
@@ -119,6 +131,16 @@ Bit-exactness (committed, machine-independent):
 python3 scripts/generate_bbs_golden_fixtures.py   # refresh the golden from Python
 g++ -std=c++17 -I include -I test \
     test/test_bbs_branch_and_bound.cpp -o /tmp/t && /tmp/t
+```
+
+Runtime C++ backend (opt-in; needs pybind11 at build time):
+
+```bash
+colcon build --packages-select lidar_localization   # builds bbs_cpp if pybind11 is found
+# then run the node with the backend enabled:
+ros2 run lidar_localization global_localization_node.py \
+    --ros-args -p occupancy_yaml:=<map>.yaml -p use_cpp_backend:=true
+# the startup log and each query summary report backend=cpp (or python on fallback)
 ```
 
 The profiling/threshold/timing harness is ad-hoc (`/tmp`); the inputs are the

--- a/launch/global_localization_recovery.launch.py
+++ b/launch/global_localization_recovery.launch.py
@@ -128,6 +128,10 @@ def generate_launch_description():
         DeclareLaunchArgument(
             'g2_max_candidates', default_value='16',
             description='G2 ranked candidate count returned per query.'),
+        DeclareLaunchArgument(
+            'g2_use_cpp_backend', default_value='false',
+            description='Use the compiled C++ BBS backend (bbs_cpp) when built; '
+                        'falls back to the Python search if unavailable.'),
     ]
 
     # 1. Core localizer (also raises /reinitialization_requested + /alignment_status).
@@ -164,6 +168,8 @@ def generate_launch_description():
                 LaunchConfiguration('g2_pyramid_depth'), value_type=int),
             'max_candidates': ParameterValue(
                 LaunchConfiguration('g2_max_candidates'), value_type=int),
+            'use_cpp_backend': ParameterValue(
+                LaunchConfiguration('g2_use_cpp_backend'), value_type=bool),
             'use_sim_time': use_sim_time,
         }])
 

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,9 @@
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>tf2_eigen</build_depend>
   <build_depend>pcl_conversions</build_depend>
+  <!-- Optional: builds the bbs_cpp backend for the global localization node.
+       The build degrades gracefully (Python fallback) if it is unavailable. -->
+  <build_depend>pybind11_vendor</build_depend>
 
   <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>rclpy</exec_depend>

--- a/scripts/global_localization_node.py
+++ b/scripts/global_localization_node.py
@@ -47,6 +47,9 @@ class GlobalLocalizationNode(Node):
         self.declare_parameter("nms_radius_m", 2.0)
         self.declare_parameter("dilate_cells", 1)
         self.declare_parameter("seed_z_m", 0.0)
+        # Opt-in C++ backend (bbs_cpp). Default False -> pure Python; if the
+        # compiled module is unavailable the engine falls back to Python.
+        self.declare_parameter("use_cpp_backend", False)
 
         occupancy_yaml = (
             self.get_parameter("occupancy_yaml").get_parameter_value().string_value)
@@ -67,8 +70,14 @@ class GlobalLocalizationNode(Node):
             nms_radius_m=self.get_parameter("nms_radius_m").value,
             dilate_cells=int(self.get_parameter("dilate_cells").value),
             seed_z_m=self.get_parameter("seed_z_m").value,
+            use_cpp_backend=bool(self.get_parameter("use_cpp_backend").value),
         )
         self.engine = GlobalLocalizationEngine(Path(occupancy_yaml), config)
+        if config.use_cpp_backend and self.engine.backend != "cpp":
+            self.get_logger().warn(
+                "use_cpp_backend requested but bbs_cpp is unavailable (%s); "
+                "falling back to the Python search"
+                % self.engine.backend_error)
         self.global_frame_id = (
             self.get_parameter("global_frame_id").get_parameter_value().string_value)
         self.latest_cloud = None
@@ -86,8 +95,8 @@ class GlobalLocalizationNode(Node):
             PoseArray, "~/candidates", candidate_qos)
         self.query_srv = self.create_service(Trigger, "~/query", self.handle_query)
         self.get_logger().info(
-            "global localization service ready: map=%s scan=%s"
-            % (occupancy_yaml, cloud_topic))
+            "global localization service ready: map=%s scan=%s backend=%s"
+            % (occupancy_yaml, cloud_topic, self.engine.backend))
 
     def cloud_received(self, msg: PointCloud2) -> None:
         self.latest_cloud = msg
@@ -130,6 +139,7 @@ class GlobalLocalizationNode(Node):
             "candidate_count": len(result.candidates),
             "scan_point_count": result.scan_point_count,
             "runtime_sec": round(runtime_sec, 3),
+            "backend": self.engine.backend,
             # Full ranked list (high-to-low) so a consumer can walk past an
             # aliased top candidate; "top" kept for back-compat.
             "candidates": ranked,

--- a/scripts/global_localization_query.py
+++ b/scripts/global_localization_query.py
@@ -30,6 +30,10 @@ class GlobalLocalizationConfig:
     nms_radius_m: float = 2.0
     dilate_cells: int = 1
     seed_z_m: float = 0.0
+    # Opt-in: use the compiled C++ branch-and-bound backend (bbs_cpp) when it is
+    # importable. Defaults to False so a stock checkout runs pure Python; if the
+    # module is missing the engine logs once and silently falls back to Python.
+    use_cpp_backend: bool = False
 
 
 @dataclass(frozen=True)
@@ -60,6 +64,20 @@ class GlobalLocalizationEngine:
             matching_grid = bbs_engine._dilate_one_cell(matching_grid)
         self.matching_grid = matching_grid
 
+        # Resolve the search backend once. The C++ module (bbs_cpp) is bit-exact
+        # to bbs_engine.branch_and_bound_candidates and exposes the same call
+        # signature and candidate attributes, so query() is backend-agnostic.
+        self.backend = "python"
+        self.backend_error = None
+        self._search = bbs_engine.branch_and_bound_candidates
+        if config.use_cpp_backend:
+            try:
+                import bbs_cpp  # noqa: E402
+                self._search = bbs_cpp.branch_and_bound_candidates
+                self.backend = "cpp"
+            except ImportError as exc:  # pragma: no cover - depends on build
+                self.backend_error = str(exc)
+
     def query(self, points_xyz):
         config = self.config
         resolution_m = self.occupancy_map.resolution_m
@@ -74,7 +92,7 @@ class GlobalLocalizationEngine:
         if scan_xy.shape[0] == 0:
             return GlobalLocalizationResult(candidates=[], scan_point_count=0)
 
-        grid_candidates = bbs_engine.branch_and_bound_candidates(
+        grid_candidates = self._search(
             self.matching_grid,
             scan_xy,
             resolution_m,

--- a/src/bbs_pybind.cpp
+++ b/src/bbs_pybind.cpp
@@ -1,0 +1,112 @@
+// pybind11 binding that exposes the bit-exact C++ branch-and-bound search
+// (include/lidar_localization/bbs_branch_and_bound.hpp) to Python as the module
+// `bbs_cpp`, so the runtime global-localization node can opt into the fast C++
+// backend while keeping the pure-Python path as the default fallback.
+//
+// The module is OPTIONAL: it is only built when pybind11 is found at configure
+// time (CMakeLists.txt gates it behind find_package(pybind11 QUIET)), and the
+// engine imports it lazily and falls back to Python on ImportError. So nothing
+// here is on the critical path of a default build.
+//
+// The returned BbsGridCandidate mirrors the dataclass field-for-field
+// (scripts/make_bbs_relocalization_attempts.py:BbsGridCandidate) so
+// GlobalLocalizationEngine.query() can consume either backend unchanged.
+//
+// Correctness is established offline: the C++ core is proven bit-exact against
+// the Python reference by test/test_bbs_branch_and_bound.cpp (golden fixtures),
+// and test/test_bbs_cpp_backend_parity.py re-checks this binding's numpy<->struct
+// plumbing wherever the compiled module is importable.
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+#include "lidar_localization/bbs_branch_and_bound.hpp"
+
+namespace py = pybind11;
+namespace bbs = lidar_localization::bbs;
+
+namespace {
+
+// occupancy: 2D boolean/uint8 grid (row-major). scan_xy_m: (N, 2) float64 in the
+// sensor frame, metres. The remaining args mirror the Python signature exactly.
+std::vector<bbs::BbsGridCandidate> branch_and_bound_candidates_py(
+  py::array_t<uint8_t, py::array::c_style | py::array::forcecast> occupancy,
+  py::array_t<double, py::array::c_style | py::array::forcecast> scan_xy_m,
+  double resolution_m,
+  double angular_resolution_rad,
+  int pyramid_depth,
+  int max_candidates,
+  int nms_radius_cells)
+{
+  const auto occ_info = occupancy.request();
+  if (occ_info.ndim != 2) {
+    throw std::invalid_argument("occupancy must be a 2D array");
+  }
+  const int height = static_cast<int>(occ_info.shape[0]);
+  const int width = static_cast<int>(occ_info.shape[1]);
+  bbs::Grid grid(height, width);
+  const auto * occ_ptr = static_cast<const uint8_t *>(occ_info.ptr);
+  const size_t cells = static_cast<size_t>(height) * static_cast<size_t>(width);
+  for (size_t i = 0; i < cells; ++i) {
+    grid.data[i] = occ_ptr[i] ? 1 : 0;
+  }
+
+  const auto scan_info = scan_xy_m.request();
+  if (scan_info.ndim != 2 || scan_info.shape[1] != 2) {
+    throw std::invalid_argument("scan_xy_m must have shape (N, 2)");
+  }
+  const size_t n_points = static_cast<size_t>(scan_info.shape[0]);
+  std::vector<std::array<double, 2>> scan(n_points);
+  const auto * scan_ptr = static_cast<const double *>(scan_info.ptr);
+  for (size_t i = 0; i < n_points; ++i) {
+    scan[i] = {scan_ptr[2 * i], scan_ptr[2 * i + 1]};
+  }
+
+  // Release the GIL for the search itself; no Python objects are touched here.
+  std::vector<bbs::BbsGridCandidate> result;
+  {
+    py::gil_scoped_release release;
+    result = bbs::branch_and_bound_candidates(
+      grid, scan, resolution_m, angular_resolution_rad, pyramid_depth,
+      max_candidates, nms_radius_cells);
+  }
+  return result;
+}
+
+}  // namespace
+
+PYBIND11_MODULE(bbs_cpp, m)
+{
+  m.doc() =
+    "C++ branch-and-bound (BBS_2D) global-localization search, a bit-exact "
+    "port of branch_and_bound_candidates in make_bbs_relocalization_attempts.py.";
+
+  py::class_<bbs::BbsGridCandidate>(m, "BbsGridCandidate")
+    .def_readonly("tx_cell", &bbs::BbsGridCandidate::tx_cell)
+    .def_readonly("ty_cell", &bbs::BbsGridCandidate::ty_cell)
+    .def_readonly("yaw_index", &bbs::BbsGridCandidate::yaw_index)
+    .def_readonly("yaw_rad", &bbs::BbsGridCandidate::yaw_rad)
+    .def_readonly("score", &bbs::BbsGridCandidate::score)
+    .def_readonly("hit_count", &bbs::BbsGridCandidate::hit_count)
+    .def_readonly("point_count", &bbs::BbsGridCandidate::point_count)
+    .def("__repr__", [](const bbs::BbsGridCandidate & c) {
+      return "<bbs_cpp.BbsGridCandidate tx=" + std::to_string(c.tx_cell) +
+             " ty=" + std::to_string(c.ty_cell) +
+             " yaw_index=" + std::to_string(c.yaw_index) +
+             " hit=" + std::to_string(c.hit_count) + ">";
+    });
+
+  m.def(
+    "branch_and_bound_candidates", &branch_and_bound_candidates_py,
+    py::arg("occupancy"), py::arg("scan_xy_m"), py::arg("resolution_m"),
+    py::arg("angular_resolution_rad"), py::arg("pyramid_depth"),
+    py::arg("max_candidates"), py::arg("nms_radius_cells") = 0,
+    "Run the BBS_2D search and return ranked BbsGridCandidate objects "
+    "identical to the Python reference.");
+}

--- a/test/test_bbs_cpp_backend_parity.py
+++ b/test/test_bbs_cpp_backend_parity.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Parity check: the optional C++ BBS backend (bbs_cpp) vs the Python reference.
+
+The C++ search core is already proven bit-exact to the Python reference offline
+by test/test_bbs_branch_and_bound.cpp (golden fixtures). This test exercises the
+*pybind11 binding* -- the numpy<->struct plumbing in src/bbs_pybind.cpp -- by
+running both backends through GlobalLocalizationEngine's exact call shape and
+asserting identical candidates.
+
+It is intentionally tolerant about availability: the compiled module only exists
+when pybind11 was found at build time, so if `import bbs_cpp` fails the test
+prints SKIP and exits 0. CMake passes BBS_CPP_MODULE_DIR pointing at the build
+output directory; we add it to sys.path so the freshly built module is found
+without installing.
+"""
+
+import math
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+# Let CMake point us at the build-tree module before it is installed.
+_module_dir = os.environ.get("BBS_CPP_MODULE_DIR")
+if _module_dir:
+    sys.path.insert(0, _module_dir)
+
+try:
+    import bbs_cpp
+except ImportError as exc:  # pragma: no cover - depends on build config
+    print("SKIP: bbs_cpp not importable (%s); pybind11 backend not built" % exc)
+    sys.exit(0)
+
+import make_bbs_relocalization_attempts as bbs  # noqa: E402
+
+
+def make_map(height, width, occupied_cells):
+    occ = np.zeros((height, width), dtype=bool)
+    for (y, x) in occupied_cells:
+        occ[y, x] = True
+    return occ
+
+
+def cluster_map(height, width, seed, n_clusters, cluster_size):
+    rng = np.random.default_rng(seed)
+    occ = np.zeros((height, width), dtype=bool)
+    for _ in range(n_clusters):
+        cy = int(rng.integers(2, height - 2))
+        cx = int(rng.integers(2, width - 2))
+        for _ in range(cluster_size):
+            y = min(height - 1, max(0, cy + int(rng.integers(-2, 3))))
+            x = min(width - 1, max(0, cx + int(rng.integers(-2, 3))))
+            occ[y, x] = True
+    return occ
+
+
+def scan_from_occupied(occ, resolution_m, true_xy, radius_m, max_points, seed):
+    ys, xs = np.nonzero(occ)
+    wx = (xs + 0.5) * resolution_m
+    wy = (ys + 0.5) * resolution_m
+    d = np.hypot(wx - true_xy[0], wy - true_xy[1])
+    sel = np.nonzero(d < radius_m)[0]
+    rng = np.random.default_rng(seed)
+    if len(sel) > max_points:
+        sel = rng.choice(sel, max_points, replace=False)
+    return np.stack([wx[sel] - true_xy[0], wy[sel] - true_xy[1]], axis=1)
+
+
+# (name, occ, scan, resolution_m, ares_rad, depth, max_c, nms) -- the same shapes
+# the golden generator freezes, so the comparison spans single/multi-yaw + NMS.
+def build_cases():
+    cases = []
+    cases.append((
+        "six_by_six_single_yaw",
+        make_map(6, 6, [(2, 2), (2, 3), (4, 4)]),
+        np.array([[0.0, 0.0], [1.0, 0.0]], dtype=np.float64),
+        1.0, 2.0 * math.pi, 2, 5, 0))
+
+    occ2 = cluster_map(40, 48, seed=1, n_clusters=6, cluster_size=12)
+    scan2 = scan_from_occupied(occ2, 1.0, (24.0, 20.0), 12.0, 60, seed=2)
+    cases.append(("medium_4yaw_no_nms", occ2, scan2, 1.0,
+                  math.radians(90.0), 3, 8, 0))
+    cases.append(("medium_8yaw_nms3", occ2, scan2, 1.0,
+                  math.radians(45.0), 3, 8, 3))
+
+    occ4 = cluster_map(64, 64, seed=7, n_clusters=10, cluster_size=16)
+    scan4 = scan_from_occupied(occ4, 0.5, (16.0, 16.0), 10.0, 80, seed=8)
+    cases.append(("large_12yaw_depth4_nms2", occ4, scan4, 0.5,
+                  math.radians(30.0), 4, 10, 2))
+    return cases
+
+
+def assert_parity(name, occ, scan, res, ares, depth, max_c, nms):
+    py_cands = bbs.branch_and_bound_candidates(
+        occ, scan, res, ares, depth, max_c, nms_radius_cells=nms)
+    cpp_cands = bbs_cpp.branch_and_bound_candidates(
+        occ, scan, res, ares, depth, max_c, nms_radius_cells=nms)
+
+    assert len(cpp_cands) == len(py_cands), (
+        "%s: count %d != %d" % (name, len(cpp_cands), len(py_cands)))
+    for i, (c, p) in enumerate(zip(cpp_cands, py_cands)):
+        assert (c.tx_cell, c.ty_cell, c.yaw_index, c.hit_count, c.point_count) \
+            == (p.tx_cell, p.ty_cell, p.yaw_index, p.hit_count, p.point_count), (
+                "%s[%d]: cell/yaw/hit mismatch cpp(%d,%d,%d,%d,%d) py(%d,%d,%d,%d,%d)"
+                % (name, i, c.tx_cell, c.ty_cell, c.yaw_index, c.hit_count,
+                   c.point_count, p.tx_cell, p.ty_cell, p.yaw_index, p.hit_count,
+                   p.point_count))
+        # score is the exact hit/point ratio in both backends.
+        assert c.score == p.score, (
+            "%s[%d]: score %r != %r" % (name, i, c.score, p.score))
+        # yaw_rad comes from independent normalize implementations; allow ULPs.
+        assert abs(c.yaw_rad - p.yaw_rad) < 1e-12, (
+            "%s[%d]: yaw_rad %r != %r" % (name, i, c.yaw_rad, p.yaw_rad))
+    print("  [%s] %d candidates bit-exact across backends" % (name, len(cpp_cands)))
+
+
+def main():
+    cases = build_cases()
+    for case in cases:
+        assert_parity(*case)
+    print("bbs_cpp backend matches the Python reference on %d fixtures" % len(cases))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to #99 (the bit-exact C++ branch-and-bound port). Wires the C++ core into the G2 runtime as an **opt-in** backend, with the pure-Python search kept as the default and the fallback.

## What
- **`src/bbs_pybind.cpp`** — pybind11 module `bbs_cpp` exposing `branch_and_bound_candidates` and `BbsGridCandidate` with the same fields, call signature, and ranking as the Python reference (numpy in, candidate objects out). Releases the GIL during the search.
- **`GlobalLocalizationEngine`** — resolves the backend once: `use_cpp_backend=true` imports `bbs_cpp` and uses it; on `ImportError` it records the error and falls back to the Python search. Default `use_cpp_backend=false` leaves a stock build byte-for-byte unchanged.
- **`global_localization_node`** — new `use_cpp_backend` parameter; logs the active backend at startup, warns once if requested-but-unavailable, and reports `backend` in each query summary. Launch file exposes `g2_use_cpp_backend`.
- **CMake** — gates the module behind `find_package(pybind11 QUIET)` and installs it next to the node in `lib/${PROJECT_NAME}` so the node's `sys.path` insert can `import bbs_cpp`. Absent pybind11 simply skips the module (Python fallback). `package.xml` gains a `pybind11_vendor` build_depend.

## Why off the critical path
The module is optional at every layer (CMake QUIET, lazy import, default-off param), so a build without pybind11 and a run without the flag behave exactly as before.

## Verification
- **`test/test_bbs_cpp_backend_parity.py`** compares `bbs_cpp` against the Python reference on the four fixture shapes (single-yaw, multi-yaw, deep-pyramid, NMS) and **skips cleanly (exit 0)** when the module is not built.
- Verified locally: built the module, parity passes on all four fixtures; the engine selects `cpp` and returns world poses identical to the Python path; default and module-absent paths both fall back to Python.
- The C++ core was already proven bit-exact offline by `test_bbs_branch_and_bound.cpp` (golden fixtures); this PR is the runtime plumbing plus a parity check of the binding itself.

Remaining (a measurement, not code): idle-machine wall-clock benchmark of the wired query, gated on a quiet shared machine.