### PR TITLE
Prepare turnkey Koide IMU preintegration A/B accuracy benchmark

### DIFF
--- a/docs/imu_estimation.md
+++ b/docs/imu_estimation.md
@@ -136,6 +136,34 @@ The MID-360 launch (`mid360_legged_localization.launch.py`) already wires
   improvement over pure NDT on a specific dataset. Do not cite it as an accuracy
   claim without a controlled run.
 
+### Turnkey A/B benchmark (idle-ready)
+
+A controlled Koide A/B is committed and ready to run the moment the machine is
+quiet (timing/accuracy on this shared box is only trustworthy at load < ~5):
+
+- `param/benchmark/koide_hard_localization_outdoor_hard_01a_full380_ndt_omp_imu_off.yaml`
+- `param/benchmark/koide_hard_localization_outdoor_hard_01a_full380_ndt_omp_imu_on.yaml`
+
+Both are the Phase 1 NDT_OMP winner config on the real `outdoor_hard_01a` bag
+(which carries `/livox/imu`, 75947 samples over 380 s, plus GT); they differ
+**only** in `use_imu_preintegration` (and `output_dir` / `ros_domain_id`), so any
+metric delta is attributable to the Forster preintegration smoother. Run both
+back-to-back and compare:
+
+```bash
+ros2 run lidar_localization_ros2 benchmark_from_manifest --manifest \
+  param/benchmark/koide_hard_localization_outdoor_hard_01a_full380_ndt_omp_imu_off.yaml
+ros2 run lidar_localization_ros2 benchmark_from_manifest --manifest \
+  param/benchmark/koide_hard_localization_outdoor_hard_01a_full380_ndt_omp_imu_on.yaml
+```
+
+**Read the metrics the Phase 1 way** (docs/phase1_koide_backend_comparison.md): a
+lower translation RMSE alone is a trap on this hard sequence — an estimator can
+look better while tracking far fewer poses. Judge on **ok-rate, longest lost
+window, and pose count first**, then RMSE among the survivors. Only after this
+run lands may the preintegration path be described as an accuracy win (or not)
+on Koide; until then the limits above stand.
+
 ## Related docs
 
 - [pose_covariance.md](pose_covariance.md) — the twist-EKF hybrid covariance path

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01a_full380_ndt_omp_imu_off.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01a_full380_ndt_omp_imu_off.yaml
@@ -1,0 +1,44 @@
+# Koide outdoor_hard_01a FULL 380s -- NDT_OMP, IMU preintegration OFF (A/B baseline).
+# Controlled A/B for the IMU preintegration accuracy question (docs/imu_estimation.md
+# "Validation state"). This arm is the Phase 1 NDT_OMP winner config with the
+# preintegration smoother disabled; the _imu_on sibling differs ONLY in
+# use_imu_preintegration (and output_dir/ros_domain_id). Run both back-to-back on
+# a quiet machine (load < ~5) and compare translation RMSE *and* ok-rate / longest
+# lost window / pose count -- RMSE alone is a trap on this hard sequence (Phase 1).
+mode: run
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01a
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01a/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01a/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: false
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+    enable_recovery_retry_from_last_pose: true
+    recovery_retry_from_last_pose_min_rejections: 3
+    recovery_retry_from_last_pose_max_accepted_gap_sec: 1.0
+    recovery_retry_from_last_pose_max_seed_translation_m: 15.0
+  launch_args:
+  - use_sim_time:=true
+  - lidar_frame_id:=livox_frame
+benchmark:
+  output_dir: /tmp/lidarloc_koide_01a_full380_ndt_omp_imu_off
+  ros_domain_id: 136
+  bag_duration: 380
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true

--- a/param/benchmark/koide_hard_localization_outdoor_hard_01a_full380_ndt_omp_imu_on.yaml
+++ b/param/benchmark/koide_hard_localization_outdoor_hard_01a_full380_ndt_omp_imu_on.yaml
@@ -1,0 +1,45 @@
+# Koide outdoor_hard_01a FULL 380s -- NDT_OMP, IMU preintegration ON (A/B treatment).
+# Identical to the _imu_off sibling EXCEPT use_imu_preintegration=true (and
+# output_dir/ros_domain_id), so any metric delta is attributable to the Forster
+# on-manifold preintegration smoother (imu_preintegration.hpp / ImuGtsamSmoother),
+# the estimator whose math is unit-tested but whose *accuracy* is still unvalidated
+# (docs/imu_estimation.md "Validation state"). use_imu stays false to isolate the
+# preintegration path from the legacy twist-EKF. The /livox/imu stream (75947 msgs
+# over 380 s) feeds the smoother; the guard falls back to NDT-only on divergence.
+mode: run
+dataset:
+  bag_path: repo://data/public/koide_hard_localization/sequences/outdoor_hard_01a
+  map_path: repo://data/public/koide_hard_localization/map_outdoor_hard.ply
+  reference_csv: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01a/reference.csv
+  initial_pose_yaml: repo://data/public/koide_hard_localization/benchmark/outdoor_hard_01a/initial_pose.yaml
+  cloud_topic: /livox/points
+  imu_topic: /livox/imu
+localizer:
+  base_param_yaml: repo://param/nav2_ndt_urban.yaml
+  param_overrides:
+    use_imu: false
+    use_imu_preintegration: true
+    enable_scan_voxel_filter: true
+    voxel_leaf_size: 0.5
+    base_frame_id: livox_frame
+    scan_min_range: 1.0
+    scan_max_range: 100.0
+    score_threshold: 6.0
+    enable_recovery_retry_from_last_pose: true
+    recovery_retry_from_last_pose_min_rejections: 3
+    recovery_retry_from_last_pose_max_accepted_gap_sec: 1.0
+    recovery_retry_from_last_pose_max_seed_translation_m: 15.0
+  launch_args:
+  - use_sim_time:=true
+  - lidar_frame_id:=livox_frame
+benchmark:
+  output_dir: /tmp/lidarloc_koide_01a_full380_ndt_omp_imu_on
+  ros_domain_id: 137
+  bag_duration: 380
+  bag_start_offset: 0
+  settle_seconds: 5
+  post_roll_seconds: 1
+  max_time_diff: 0.05
+  record_qos_reliability: reliable
+  record_qos_durability: volatile
+  record_use_sim_time: true


### PR DESCRIPTION
Follow-up to the IMU estimator audit (#97). That PR documented an honest gap: the preintegration smoother's **math is unit-tested and guarded, but its accuracy is unvalidated** on a controlled LiDAR+IMU+GT run. This makes that run **idle-ready** — no code change, just a turnkey A/B.

## What
A controlled A/B manifest pair on the real `outdoor_hard_01a` bag (which carries `/livox/imu`, 75947 samples over 380 s, plus GT), both the Phase 1 NDT_OMP winner config:
- `..._full380_ndt_omp_imu_off.yaml` — `use_imu_preintegration: false`
- `..._full380_ndt_omp_imu_on.yaml` — `use_imu_preintegration: true`

They differ **only** in `use_imu_preintegration` (and `output_dir`/`ros_domain_id`), so any metric delta is attributable to the Forster preintegration smoother. `use_imu` stays `false` in both to isolate the preintegration path from the legacy twist-EKF.

## Why now
Benchmarking is machine-gated (timing/accuracy only valid at load < ~5, and the shared box is busy). Preparing the turnkey pair is the machine-independent half — the run is one command per arm the moment the machine is quiet, mirroring how Phase 1 was made turnkey before its idle run.

## Honest framing (docs/imu_estimation.md)
Documents how to run the pair and — per the Phase 1 lesson — to judge on **ok-rate / longest lost window / pose count before translation RMSE** (RMSE alone is a trap on this hard sequence). Only after this run lands may the preintegration path be called an accuracy win (or not) on Koide; until then the existing "Validation state" limits stand.

## Verification
Both manifests parse; their non-comment diff is exactly the three intended lines; all referenced data (bag, map, reference CSV, initial pose, base param) exists in-repo.