### PR TITLE
[codex] Bound registration cloud keepalive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,15 @@ if(BUILD_TESTING)
     COMMAND test_registration_seed_policy
   )
 
+  add_executable(test_registration_cloud_keep_alive_policy
+    test/test_registration_cloud_keep_alive_policy.cpp)
+  target_include_directories(test_registration_cloud_keep_alive_policy PRIVATE
+    include)
+  add_test(
+    NAME registration_cloud_keep_alive_policy
+    COMMAND test_registration_cloud_keep_alive_policy
+  )
+
   add_executable(test_scan_admission_policy
     test/test_scan_admission_policy.cpp)
   target_include_directories(test_scan_admission_policy PRIVATE

--- a/include/lidar_localization/registration_cloud_keep_alive_policy.hpp
+++ b/include/lidar_localization/registration_cloud_keep_alive_policy.hpp
@@ -1,0 +1,31 @@
+#ifndef LIDAR_LOCALIZATION_REGISTRATION_CLOUD_KEEP_ALIVE_POLICY_HPP_
+#define LIDAR_LOCALIZATION_REGISTRATION_CLOUD_KEEP_ALIVE_POLICY_HPP_
+
+#include <cstddef>
+#include <deque>
+
+namespace lidar_localization
+{
+
+inline constexpr std::size_t kDefaultRegistrationSourceCloudKeepAliveCount = 8;
+inline constexpr std::size_t kDefaultRegistrationTargetCloudKeepAliveCount = 8;
+
+template<typename CloudPtr>
+inline void keepRegistrationCloudAlive(
+  std::deque<CloudPtr> & recent_clouds,
+  const CloudPtr & cloud,
+  std::size_t max_count)
+{
+  if (!cloud || max_count == 0) {
+    return;
+  }
+
+  recent_clouds.push_back(cloud);
+  while (recent_clouds.size() > max_count) {
+    recent_clouds.pop_front();
+  }
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_REGISTRATION_CLOUD_KEEP_ALIVE_POLICY_HPP_

--- a/src/lidar_localization_component.cpp
+++ b/src/lidar_localization_component.cpp
@@ -24,6 +24,7 @@
 #include "lidar_localization/recovery_supervisor_state_policy.hpp"
 #include "lidar_localization/reinitialization_latch_policy.hpp"
 #include "lidar_localization/reinitialization_request_output_policy.hpp"
+#include "lidar_localization/registration_cloud_keep_alive_policy.hpp"
 #include "lidar_localization/registration_backend_policy.hpp"
 #include "lidar_localization/registration_observation_policy.hpp"
 #include "lidar_localization/prediction_state_policy.hpp"
@@ -42,22 +43,10 @@ double stamp_to_sec(const builtin_interfaces::msg::Time & stamp)
   return static_cast<double>(stamp.sec) + static_cast<double>(stamp.nanosec) * 1e-9;
 }
 
-constexpr std::size_t kRegistrationSourceCloudKeepAliveCount = 4096;
-constexpr std::size_t kRegistrationTargetCloudKeepAliveCount = 4096;
-
-void keep_cloud_alive(
-  std::deque<pcl::PointCloud<pcl::PointXYZI>::Ptr> * recent_clouds,
-  const pcl::PointCloud<pcl::PointXYZI>::Ptr & cloud,
-  std::size_t max_count)
-{
-  if (!recent_clouds || !cloud || max_count == 0) {
-    return;
-  }
-  recent_clouds->push_back(cloud);
-  while (recent_clouds->size() > max_count) {
-    recent_clouds->pop_front();
-  }
-}
+constexpr std::size_t kRegistrationSourceCloudKeepAliveCount =
+  lidar_localization::kDefaultRegistrationSourceCloudKeepAliveCount;
+constexpr std::size_t kRegistrationTargetCloudKeepAliveCount =
+  lidar_localization::kDefaultRegistrationTargetCloudKeepAliveCount;
 
 lidar_localization::PredictionStateSnapshot make_prediction_state_snapshot(
   bool have_last_accepted_pose,
@@ -1246,13 +1235,13 @@ void PCLLocalization::mapReceived(const sensor_msgs::msg::PointCloud2::SharedPtr
     voxel_grid_filter_.setInputCloud(map_cloud_ptr);
     voxel_grid_filter_.filter(*filtered_cloud_ptr);
     registration_->setInputTarget(filtered_cloud_ptr);
-    keep_cloud_alive(
-      &recent_target_clouds_, filtered_cloud_ptr, kRegistrationTargetCloudKeepAliveCount);
+    lidar_localization::keepRegistrationCloudAlive(
+      recent_target_clouds_, filtered_cloud_ptr, kRegistrationTargetCloudKeepAliveCount);
 
   } else {
     registration_->setInputTarget(map_cloud_ptr);
-    keep_cloud_alive(
-      &recent_target_clouds_, map_cloud_ptr, kRegistrationTargetCloudKeepAliveCount);
+    lidar_localization::keepRegistrationCloudAlive(
+      recent_target_clouds_, map_cloud_ptr, kRegistrationTargetCloudKeepAliveCount);
   }
 
   map_recieved_ = true;
@@ -2250,12 +2239,12 @@ bool PCLLocalization::setInputTargetForPose(const Eigen::Matrix4f & center_pose_
     lidar_localization::LocalMapTargetCloud::kFilteredLocalMap)
   {
     registration_->setInputTarget(filtered_local_map);
-    keep_cloud_alive(
-      &recent_target_clouds_, filtered_local_map, kRegistrationTargetCloudKeepAliveCount);
+    lidar_localization::keepRegistrationCloudAlive(
+      recent_target_clouds_, filtered_local_map, kRegistrationTargetCloudKeepAliveCount);
   } else {
     registration_->setInputTarget(local_map);
-    keep_cloud_alive(
-      &recent_target_clouds_, local_map, kRegistrationTargetCloudKeepAliveCount);
+    lidar_localization::keepRegistrationCloudAlive(
+      recent_target_clouds_, local_map, kRegistrationTargetCloudKeepAliveCount);
   }
 
   const auto success_decision = lidar_localization::handleLocalMapTargetSuccess();
@@ -2448,7 +2437,8 @@ void PCLLocalization::setRegistrationSourceCloud(
   const pcl::PointCloud<pcl::PointXYZI>::Ptr & source_cloud)
 {
   registration_->setInputSource(source_cloud);
-  keep_cloud_alive(&recent_source_clouds_, source_cloud, kRegistrationSourceCloudKeepAliveCount);
+  lidar_localization::keepRegistrationCloudAlive(
+    recent_source_clouds_, source_cloud, kRegistrationSourceCloudKeepAliveCount);
 }
 
 void PCLLocalization::printAlignmentDebugInfo(

--- a/test/test_registration_cloud_keep_alive_policy.cpp
+++ b/test/test_registration_cloud_keep_alive_policy.cpp
@@ -1,0 +1,46 @@
+#include "lidar_localization/registration_cloud_keep_alive_policy.hpp"
+
+#include <cassert>
+#include <deque>
+#include <memory>
+
+namespace ll = lidar_localization;
+
+void test_keep_alive_retains_only_recent_entries()
+{
+  std::deque<std::shared_ptr<int>> recent;
+
+  for (int i = 0; i < 10; ++i) {
+    ll::keepRegistrationCloudAlive(recent, std::make_shared<int>(i), 3);
+  }
+
+  assert(recent.size() == 3);
+  assert(*recent[0] == 7);
+  assert(*recent[1] == 8);
+  assert(*recent[2] == 9);
+}
+
+void test_keep_alive_ignores_empty_inputs()
+{
+  std::deque<std::shared_ptr<int>> recent;
+
+  ll::keepRegistrationCloudAlive(recent, std::shared_ptr<int>{}, 3);
+  assert(recent.empty());
+
+  ll::keepRegistrationCloudAlive(recent, std::make_shared<int>(1), 0);
+  assert(recent.empty());
+}
+
+void test_default_limits_are_small_bounded_windows()
+{
+  assert(ll::kDefaultRegistrationSourceCloudKeepAliveCount == 8);
+  assert(ll::kDefaultRegistrationTargetCloudKeepAliveCount == 8);
+}
+
+int main()
+{
+  test_keep_alive_retains_only_recent_entries();
+  test_keep_alive_ignores_empty_inputs();
+  test_default_limits_are_small_bounded_windows();
+  return 0;
+}


### PR DESCRIPTION
## Summary

This bounds the point cloud keep-alive window used for registration source and target clouds.

The previous implementation retained up to 4096 source clouds and 4096 target clouds. With dense sensors such as MID-360, that can retain several GB of point cloud data during normal operation and matches the memory growth reported in #103.

## Changes

- Move the registration cloud keep-alive helper into a small policy header.
- Reduce the default source/target keep-alive window from 4096 clouds to 8 clouds.
- Add a regression test for the bounded keep-alive behavior.

## Validation

- `g++ -std=c++17 -Iinclude test/test_registration_cloud_keep_alive_policy.cpp -o /tmp/test_registration_cloud_keep_alive_policy && /tmp/test_registration_cloud_keep_alive_policy`
- `git diff --check HEAD~1..HEAD`

Full `colcon build --packages-select lidar_localization_ros2 --cmake-args -DBUILD_TESTING=ON` was not able to run in this environment because `/usr/bin/python3` cannot import `ament_package` from the ROS Jazzy ament CMake setup.