### PR TITLE
Make registration cloud keep-alive window configurable

### DIFF
--- a/include/lidar_localization/lidar_localization_component.hpp
+++ b/include/lidar_localization/lidar_localization_component.hpp
@@ -66,6 +66,7 @@
 #include "lidar_localization/pose_backend_result_policy.hpp"
 #include "lidar_localization/pose_covariance_policy.hpp"
 #include "lidar_localization/pose_backend_selection_policy.hpp"
+#include "lidar_localization/registration_cloud_keep_alive_policy.hpp"
 #include "lidar_localization/registration_observation_policy.hpp"
 #include "lidar_localization/registration_seed_policy.hpp"
 #include "lidar_localization/recovery_supervisor.hpp"
@@ -160,6 +161,10 @@ public:
   bool map_bounds_valid_{false};
   std::deque<pcl::PointCloud<pcl::PointXYZI>::Ptr> recent_source_clouds_;
   std::deque<pcl::PointCloud<pcl::PointXYZI>::Ptr> recent_target_clouds_;
+  std::size_t registration_source_cloud_keep_alive_count_{
+    lidar_localization::kDefaultRegistrationSourceCloudKeepAliveCount};
+  std::size_t registration_target_cloud_keep_alive_count_{
+    lidar_localization::kDefaultRegistrationTargetCloudKeepAliveCount};
   bool use_local_map_crop_{false};
   bool enable_local_map_crop_{false};
   double local_map_radius_{150.0};

--- a/include/lidar_localization/registration_cloud_keep_alive_policy.hpp
+++ b/include/lidar_localization/registration_cloud_keep_alive_policy.hpp
@@ -10,6 +10,24 @@ namespace lidar_localization
 inline constexpr std::size_t kDefaultRegistrationSourceCloudKeepAliveCount = 8;
 inline constexpr std::size_t kDefaultRegistrationTargetCloudKeepAliveCount = 8;
 
+struct RegistrationCloudKeepAliveCount
+{
+  std::size_t value;
+  bool was_adjusted;
+};
+
+// A value of 0 disables keep-alive and is only safe when the registration backend
+// holds no reference to prior clouds.
+inline RegistrationCloudKeepAliveCount normalizeRegistrationCloudKeepAliveCount(
+  int requested,
+  std::size_t fallback)
+{
+  if (requested < 0) {
+    return {fallback, true};
+  }
+  return {static_cast<std::size_t>(requested), false};
+}
+
 template<typename CloudPtr>
 inline void keepRegistrationCloudAlive(
   std::deque<CloudPtr> & recent_clouds,

--- a/src/lidar_localization_component.cpp
+++ b/src/lidar_localization_component.cpp
@@ -43,11 +43,6 @@ double stamp_to_sec(const builtin_interfaces::msg::Time & stamp)
   return static_cast<double>(stamp.sec) + static_cast<double>(stamp.nanosec) * 1e-9;
 }
 
-constexpr std::size_t kRegistrationSourceCloudKeepAliveCount =
-  lidar_localization::kDefaultRegistrationSourceCloudKeepAliveCount;
-constexpr std::size_t kRegistrationTargetCloudKeepAliveCount =
-  lidar_localization::kDefaultRegistrationTargetCloudKeepAliveCount;
-
 lidar_localization::PredictionStateSnapshot make_prediction_state_snapshot(
   bool have_last_accepted_pose,
   const Eigen::Matrix4f & last_accepted_pose_matrix,
@@ -156,6 +151,12 @@ PCLLocalization::PCLLocalization(const rclcpp::NodeOptions & options)
   declare_parameter("enable_local_map_crop", false);
   declare_parameter("local_map_radius", 150.0);
   declare_parameter("local_map_min_points", 100);
+  declare_parameter(
+    "registration_source_cloud_keep_alive_count",
+    static_cast<int>(lidar_localization::kDefaultRegistrationSourceCloudKeepAliveCount));
+  declare_parameter(
+    "registration_target_cloud_keep_alive_count",
+    static_cast<int>(lidar_localization::kDefaultRegistrationTargetCloudKeepAliveCount));
   declare_parameter("reject_above_score_threshold", true);
   declare_parameter("enable_consistency_recovery_gate", false);
   declare_parameter("consistency_recovery_min_rejections", 10);
@@ -637,6 +638,40 @@ void PCLLocalization::initializeParameters()
     RCLCPP_WARN(
       get_logger(), "local_map_min_points must be positive; using %zu",
       local_map_min_points_);
+  }
+  int requested_registration_source_cloud_keep_alive_count =
+    static_cast<int>(registration_source_cloud_keep_alive_count_);
+  get_parameter(
+    "registration_source_cloud_keep_alive_count",
+    requested_registration_source_cloud_keep_alive_count);
+  const auto registration_source_cloud_keep_alive_count =
+    lidar_localization::normalizeRegistrationCloudKeepAliveCount(
+    requested_registration_source_cloud_keep_alive_count,
+    lidar_localization::kDefaultRegistrationSourceCloudKeepAliveCount);
+  registration_source_cloud_keep_alive_count_ =
+    registration_source_cloud_keep_alive_count.value;
+  if (registration_source_cloud_keep_alive_count.was_adjusted) {
+    RCLCPP_WARN(
+      get_logger(),
+      "registration_source_cloud_keep_alive_count must be >= 0; using %zu",
+      registration_source_cloud_keep_alive_count_);
+  }
+  int requested_registration_target_cloud_keep_alive_count =
+    static_cast<int>(registration_target_cloud_keep_alive_count_);
+  get_parameter(
+    "registration_target_cloud_keep_alive_count",
+    requested_registration_target_cloud_keep_alive_count);
+  const auto registration_target_cloud_keep_alive_count =
+    lidar_localization::normalizeRegistrationCloudKeepAliveCount(
+    requested_registration_target_cloud_keep_alive_count,
+    lidar_localization::kDefaultRegistrationTargetCloudKeepAliveCount);
+  registration_target_cloud_keep_alive_count_ =
+    registration_target_cloud_keep_alive_count.value;
+  if (registration_target_cloud_keep_alive_count.was_adjusted) {
+    RCLCPP_WARN(
+      get_logger(),
+      "registration_target_cloud_keep_alive_count must be >= 0; using %zu",
+      registration_target_cloud_keep_alive_count_);
   }
   get_parameter("reject_above_score_threshold", measurement_gate_config_.reject_above_score_threshold);
   get_parameter("enable_consistency_recovery_gate", measurement_gate_config_.enable_consistency_recovery_gate);
@@ -1236,12 +1271,12 @@ void PCLLocalization::mapReceived(const sensor_msgs::msg::PointCloud2::SharedPtr
     voxel_grid_filter_.filter(*filtered_cloud_ptr);
     registration_->setInputTarget(filtered_cloud_ptr);
     lidar_localization::keepRegistrationCloudAlive(
-      recent_target_clouds_, filtered_cloud_ptr, kRegistrationTargetCloudKeepAliveCount);
+      recent_target_clouds_, filtered_cloud_ptr, registration_target_cloud_keep_alive_count_);
 
   } else {
     registration_->setInputTarget(map_cloud_ptr);
     lidar_localization::keepRegistrationCloudAlive(
-      recent_target_clouds_, map_cloud_ptr, kRegistrationTargetCloudKeepAliveCount);
+      recent_target_clouds_, map_cloud_ptr, registration_target_cloud_keep_alive_count_);
   }
 
   map_recieved_ = true;
@@ -2240,11 +2275,11 @@ bool PCLLocalization::setInputTargetForPose(const Eigen::Matrix4f & center_pose_
   {
     registration_->setInputTarget(filtered_local_map);
     lidar_localization::keepRegistrationCloudAlive(
-      recent_target_clouds_, filtered_local_map, kRegistrationTargetCloudKeepAliveCount);
+      recent_target_clouds_, filtered_local_map, registration_target_cloud_keep_alive_count_);
   } else {
     registration_->setInputTarget(local_map);
     lidar_localization::keepRegistrationCloudAlive(
-      recent_target_clouds_, local_map, kRegistrationTargetCloudKeepAliveCount);
+      recent_target_clouds_, local_map, registration_target_cloud_keep_alive_count_);
   }
 
   const auto success_decision = lidar_localization::handleLocalMapTargetSuccess();
@@ -2438,7 +2473,7 @@ void PCLLocalization::setRegistrationSourceCloud(
 {
   registration_->setInputSource(source_cloud);
   lidar_localization::keepRegistrationCloudAlive(
-    recent_source_clouds_, source_cloud, kRegistrationSourceCloudKeepAliveCount);
+    recent_source_clouds_, source_cloud, registration_source_cloud_keep_alive_count_);
 }
 
 void PCLLocalization::printAlignmentDebugInfo(

--- a/test/test_registration_cloud_keep_alive_policy.cpp
+++ b/test/test_registration_cloud_keep_alive_policy.cpp
@@ -37,10 +37,26 @@ void test_default_limits_are_small_bounded_windows()
   assert(ll::kDefaultRegistrationTargetCloudKeepAliveCount == 8);
 }
 
+void test_normalize_registration_cloud_keep_alive_count()
+{
+  const auto negative = ll::normalizeRegistrationCloudKeepAliveCount(-1, 8);
+  assert(negative.value == 8);
+  assert(negative.was_adjusted);
+
+  const auto zero = ll::normalizeRegistrationCloudKeepAliveCount(0, 8);
+  assert(zero.value == 0);
+  assert(!zero.was_adjusted);
+
+  const auto positive = ll::normalizeRegistrationCloudKeepAliveCount(4, 8);
+  assert(positive.value == 4);
+  assert(!positive.was_adjusted);
+}
+
 int main()
 {
   test_keep_alive_retains_only_recent_entries();
   test_keep_alive_ignores_empty_inputs();
   test_default_limits_are_small_bounded_windows();
+  test_normalize_registration_cloud_keep_alive_count();
   return 0;
 }


### PR DESCRIPTION
## Summary

Follow-up to #105 / #103. #105 bounded the registration source/target cloud keep-alive window from 4096 to a fixed 8. In #103, @kalhansb asked whether 8 is required and reported that 4 worked well. This makes the window a ROS 2 parameter so it can be tuned without patching the source.

The keep-alive exists only to keep the clouds the registration backend (NDT_OMP) still references alive long enough to avoid a use-after-free — so the exact bound is a safety margin, not a functional requirement, and lighter sensors can safely lower it.

## Changes

- Add `registration_source_cloud_keep_alive_count` and `registration_target_cloud_keep_alive_count` parameters (both default `8`, preserving current behavior).
- Negative values fall back to the default with a warning. `0` disables retention and is only safe when the backend holds no reference to prior clouds.
- Add a `normalizeRegistrationCloudKeepAliveCount` helper in the keep-alive policy header with unit tests.

## Validation

- `colcon build --packages-select lidar_localization_ros2` — Finished (clean).
- `g++ -std=c++17 -Iinclude test/test_registration_cloud_keep_alive_policy.cpp -o /tmp/t && /tmp/t` — passes (default-bound and normalization cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)