### PR TITLE
Harden localization state and validate research candidates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,8 @@ if(BUILD_TESTING)
     test/test_alignment_diagnostic_ros_adapter.cpp)
   target_include_directories(test_alignment_diagnostic_ros_adapter PRIVATE
     include)
+  target_link_libraries(test_alignment_diagnostic_ros_adapter
+    Eigen3::Eigen)
   ament_target_dependencies(test_alignment_diagnostic_ros_adapter
     diagnostic_msgs)
   add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,7 @@ install(DIRECTORY
 
 if(BUILD_TESTING)
   find_package(Threads REQUIRED)
+  link_libraries(Eigen3::Eigen)
   add_executable(test_registration_seed_policy
     test/test_registration_seed_policy.cpp)
   target_include_directories(test_registration_seed_policy PRIVATE
@@ -346,8 +347,6 @@ if(BUILD_TESTING)
     test/test_registration_localizability_policy.cpp)
   target_include_directories(test_registration_localizability_policy PRIVATE
     include)
-  target_link_libraries(test_registration_localizability_policy
-    Eigen3::Eigen)
   add_test(
     NAME registration_localizability_policy
     COMMAND test_registration_localizability_policy
@@ -357,8 +356,6 @@ if(BUILD_TESTING)
     test/test_alignment_diagnostics_policy.cpp)
   target_include_directories(test_alignment_diagnostics_policy PRIVATE
     include)
-  target_link_libraries(test_alignment_diagnostics_policy
-    Eigen3::Eigen)
   add_test(
     NAME alignment_diagnostics_policy
     COMMAND test_alignment_diagnostics_policy
@@ -377,8 +374,6 @@ if(BUILD_TESTING)
     test/test_alignment_diagnostic_ros_adapter.cpp)
   target_include_directories(test_alignment_diagnostic_ros_adapter PRIVATE
     include)
-  target_link_libraries(test_alignment_diagnostic_ros_adapter
-    Eigen3::Eigen)
   ament_target_dependencies(test_alignment_diagnostic_ros_adapter
     diagnostic_msgs)
   add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ endif()
 add_library(lidar_localization_component SHARED
 src/lidar_localization_component.cpp
 )
+target_link_libraries(lidar_localization_component Eigen3::Eigen)
 
 ament_target_dependencies(lidar_localization_component
   rclcpp
@@ -273,6 +274,7 @@ install(DIRECTORY
 )
 
 if(BUILD_TESTING)
+  find_package(Threads REQUIRED)
   add_executable(test_registration_seed_policy
     test/test_registration_seed_policy.cpp)
   target_include_directories(test_registration_seed_policy PRIVATE
@@ -343,8 +345,9 @@ if(BUILD_TESTING)
   add_executable(test_registration_localizability_policy
     test/test_registration_localizability_policy.cpp)
   target_include_directories(test_registration_localizability_policy PRIVATE
-    include
-    ${EIGEN3_INCLUDE_DIRS})
+    include)
+  target_link_libraries(test_registration_localizability_policy
+    Eigen3::Eigen)
   add_test(
     NAME registration_localizability_policy
     COMMAND test_registration_localizability_policy
@@ -354,6 +357,8 @@ if(BUILD_TESTING)
     test/test_alignment_diagnostics_policy.cpp)
   target_include_directories(test_alignment_diagnostics_policy PRIVATE
     include)
+  target_link_libraries(test_alignment_diagnostics_policy
+    Eigen3::Eigen)
   add_test(
     NAME alignment_diagnostics_policy
     COMMAND test_alignment_diagnostics_policy
@@ -523,6 +528,30 @@ if(BUILD_TESTING)
     COMMAND test_imu_preintegration
   )
 
+  add_test(
+    NAME imu_bias_correction_experiment
+    COMMAND ${Python3_EXECUTABLE}
+      ${CMAKE_CURRENT_SOURCE_DIR}/test/test_imu_bias_correction_experiment.py
+  )
+  set_tests_properties(imu_bias_correction_experiment PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}")
+
+  add_test(
+    NAME kiss_matcher_verifier_experiment
+    COMMAND ${Python3_EXECUTABLE}
+      ${CMAKE_CURRENT_SOURCE_DIR}/test/test_kiss_matcher_verifier_experiment.py
+  )
+  set_tests_properties(kiss_matcher_verifier_experiment PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}")
+
+  add_test(
+    NAME correspondence_localizability_experiment
+    COMMAND ${Python3_EXECUTABLE}
+      ${CMAKE_CURRENT_SOURCE_DIR}/test/test_correspondence_localizability_experiment.py
+  )
+  set_tests_properties(correspondence_localizability_experiment PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}")
+
   add_executable(test_bbs_branch_and_bound
     test/test_bbs_branch_and_bound.cpp)
   # The test includes bbs_golden_fixtures.inc from the test/ directory.
@@ -542,6 +571,17 @@ if(BUILD_TESTING)
   add_test(
     NAME prediction_state_policy
     COMMAND test_prediction_state_policy
+  )
+
+  add_executable(test_callback_state_coordinator
+    test/test_callback_state_coordinator.cpp)
+  target_include_directories(test_callback_state_coordinator PRIVATE
+    include)
+  target_link_libraries(test_callback_state_coordinator
+    Threads::Threads)
+  add_test(
+    NAME callback_state_coordinator
+    COMMAND test_callback_state_coordinator
   )
 
   add_executable(test_pose_publish_policy

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -30,13 +30,13 @@
 
 ## Multi-Criteria Measurement Acceptance
 
-- adopted variant for this problem: `correction_conditioned`
-- design family: fitness threshold + correction/staleness cross-check
-- rationale: highest combined score (`75.27`) under the shared fixture/evaluation contract
-- benchmark score: `85.7`
-- readability score: `25.2`
-- extensibility score: `94.0`
-- nearest alternative: `bounded_degraded` at `75.03`
+- adopted variant for this problem: `fixed_threshold`
+- design family: scalar fitness threshold (runtime baseline)
+- rationale: highest combined score (`85.3`) under the shared fixture/evaluation contract
+- benchmark score: `87.5`
+- readability score: `79.0`
+- extensibility score: `85.0`
+- nearest alternative: `bounded_degraded` at `73.82`
 - generated_from: `scripts/run_measurement_acceptance_experiments.py`
 
 ## Recovery Action Selection

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -73,44 +73,44 @@ Accept degraded-but-consistent registration results that the scalar fitness gate
 
 | Variant | Design | Benchmark | Readability | Extensibility | Overall |
 |---|---|---:|---:|---:|---:|
-| `correction_conditioned` | fitness threshold + correction/staleness cross-check | 85.7 | 25.2 | 94.0 | 75.27 |
-| `bounded_degraded` | correction cross-check with non-resetting degraded-accept budget | 85.7 | 34.0 | 84.0 | 75.03 |
-| `score_ratio_budget` | relative score cap with gap/streak budget | 71.4 | 49.6 | 94.0 | 71.58 |
-| `fixed_threshold` | scalar fitness threshold (runtime baseline) | 42.9 | 79.0 | 85.0 | 58.51 |
+| `fixed_threshold` | scalar fitness threshold (runtime baseline) | 87.5 | 79.0 | 85.0 | 85.30 |
+| `bounded_degraded` | correction cross-check with non-resetting degraded-accept budget | 87.5 | 22.6 | 84.0 | 73.82 |
+| `correction_conditioned` | fitness threshold + correction/staleness cross-check | 50.0 | 25.2 | 94.0 | 53.84 |
+| `score_ratio_budget` | relative score cap with gap/streak budget | 37.5 | 49.6 | 94.0 | 51.22 |
 
 ### Fixture Outcomes
 
-#### `correction_conditioned`
-- `degraded_onset_small_correction_should_accept`: pass=`True` decision=`accept` reason=`degraded_score_consistent_pose`
-- `degraded_streak_small_correction_should_accept`: pass=`True` decision=`accept` reason=`degraded_score_consistent_pose`
-- `fresh_jump_good_score_should_reject`: pass=`True` decision=`reject` reason=`fresh_prediction_contradicted`
+#### `fixed_threshold`
+- `degraded_onset_small_correction_should_reject`: pass=`True` decision=`reject` reason=`score_over_threshold`
+- `degraded_streak_small_correction_should_reject`: pass=`True` decision=`reject` reason=`score_over_threshold`
+- `fresh_jump_good_score_should_reject`: pass=`False` decision=`accept` reason=`score_within_threshold`
 - `healthy_tracking_should_accept`: pass=`True` decision=`accept` reason=`score_within_threshold`
-- `lost_huge_score_should_reject`: pass=`True` decision=`reject` reason=`score_over_threshold_unsupported`
-- `stale_prediction_should_reject`: pass=`True` decision=`reject` reason=`score_over_threshold_unsupported`
+- `lost_huge_score_should_reject`: pass=`True` decision=`reject` reason=`score_over_threshold`
+- `stale_prediction_should_reject`: pass=`True` decision=`reject` reason=`score_over_threshold`
 
 #### `bounded_degraded`
-- `degraded_onset_small_correction_should_accept`: pass=`True` decision=`accept` reason=`degraded_accept_within_budget`
-- `degraded_streak_small_correction_should_accept`: pass=`True` decision=`accept` reason=`degraded_accept_within_budget`
+- `degraded_onset_small_correction_should_reject`: pass=`True` decision=`reject` reason=`degraded_budget_exhausted_or_unsupported`
+- `degraded_streak_small_correction_should_reject`: pass=`True` decision=`reject` reason=`degraded_budget_exhausted_or_unsupported`
 - `fresh_jump_good_score_should_reject`: pass=`False` decision=`accept` reason=`score_within_threshold`
 - `healthy_tracking_should_accept`: pass=`True` decision=`accept` reason=`score_within_threshold`
 - `lost_huge_score_should_reject`: pass=`True` decision=`reject` reason=`degraded_budget_exhausted_or_unsupported`
 - `stale_prediction_should_reject`: pass=`True` decision=`reject` reason=`degraded_budget_exhausted_or_unsupported`
 
+#### `correction_conditioned`
+- `degraded_onset_small_correction_should_reject`: pass=`False` decision=`accept` reason=`degraded_score_consistent_pose`
+- `degraded_streak_small_correction_should_reject`: pass=`False` decision=`accept` reason=`degraded_score_consistent_pose`
+- `fresh_jump_good_score_should_reject`: pass=`True` decision=`reject` reason=`fresh_prediction_contradicted`
+- `healthy_tracking_should_accept`: pass=`True` decision=`accept` reason=`score_within_threshold`
+- `lost_huge_score_should_reject`: pass=`True` decision=`reject` reason=`score_over_threshold_unsupported`
+- `stale_prediction_should_reject`: pass=`True` decision=`reject` reason=`score_over_threshold_unsupported`
+
 #### `score_ratio_budget`
-- `degraded_onset_small_correction_should_accept`: pass=`True` decision=`accept` reason=`score_within_ratio_budget`
-- `degraded_streak_small_correction_should_accept`: pass=`True` decision=`accept` reason=`score_within_ratio_budget`
+- `degraded_onset_small_correction_should_reject`: pass=`False` decision=`accept` reason=`score_within_ratio_budget`
+- `degraded_streak_small_correction_should_reject`: pass=`False` decision=`accept` reason=`score_within_ratio_budget`
 - `fresh_jump_good_score_should_reject`: pass=`False` decision=`accept` reason=`score_within_threshold`
 - `healthy_tracking_should_accept`: pass=`True` decision=`accept` reason=`score_within_threshold`
 - `lost_huge_score_should_reject`: pass=`True` decision=`reject` reason=`score_over_ratio_budget`
 - `stale_prediction_should_reject`: pass=`True` decision=`reject` reason=`score_over_ratio_budget`
-
-#### `fixed_threshold`
-- `degraded_onset_small_correction_should_accept`: pass=`False` decision=`reject` reason=`score_over_threshold`
-- `degraded_streak_small_correction_should_accept`: pass=`False` decision=`reject` reason=`score_over_threshold`
-- `fresh_jump_good_score_should_reject`: pass=`False` decision=`accept` reason=`score_within_threshold`
-- `healthy_tracking_should_accept`: pass=`True` decision=`accept` reason=`score_within_threshold`
-- `lost_huge_score_should_reject`: pass=`True` decision=`reject` reason=`score_over_threshold`
-- `stale_prediction_should_reject`: pass=`True` decision=`reject` reason=`score_over_threshold`
 
 ## Recovery Action Selection
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -113,8 +113,8 @@ Accept degraded-but-consistent registration results that the scalar fitness gate
 
 ### Shared Fixtures
 
-- `degraded_onset_small_correction_should_accept`: Failure-window onset: score 13.6 is over the 6.0 gate, but the correction is 1.0 m / 1.8 deg against a 0.5 s old prediction. Ground-truth analysis of this window shows even the true pose scores ~9.6 here; rejecting this row starts a 300-row reject streak.
-- `degraded_streak_small_correction_should_accept`: Three rejects into the window: score 26.6 but correction 0.75 m / 2.4 deg, gap 1.8 s. Pose still agrees with prediction.
+- `degraded_onset_small_correction_should_reject`: Failure-window onset: score 13.6 over the 6.0 gate with a small correction. The 2026-06-11 hypothesis was to accept this; the 2026-06-12 bounded replay falsified it: degraded accepts above fitness ~12 dragged the anchor (rotation RMSE 1.8->6.1 deg, ok rows 329->193). GT scores ~9.6 in this window, so anything above ~12 is a false maximum even when the correction is small.
+- `degraded_streak_small_correction_should_reject`: Three rejects into the window: score 26.6 with correction 0.75 m. Falsified accept-hypothesis: the 2026-06-12 bounded replay showed fit 18.7/31.9 rows with small corrections are self-confirming false maxima once a degraded accept re-anchors the prediction.
 - `fresh_jump_good_score_should_reject`: Synthetic, derived from the healthy row: a good score (1.5) whose pose jumps 25 m against a 0.4 s old prediction. An aliased match should not be accepted on score alone.
 - `healthy_tracking_should_accept`: Real healthy tracking row; every strategy must accept.
 - `lost_huge_score_should_reject`: Deep in the failure window: score 4354 with a 128 s gap. Unambiguous loss.
@@ -122,10 +122,10 @@ Accept degraded-but-consistent registration results that the scalar fitness gate
 
 ### Candidate Families
 
-- `correction_conditioned`: fitness threshold + correction/staleness cross-check
-- `bounded_degraded`: correction cross-check with non-resetting degraded-accept budget
-- `score_ratio_budget`: relative score cap with gap/streak budget
 - `fixed_threshold`: scalar fitness threshold (runtime baseline)
+- `bounded_degraded`: correction cross-check with non-resetting degraded-accept budget
+- `correction_conditioned`: fitness threshold + correction/staleness cross-check
+- `score_ratio_budget`: relative score cap with gap/streak budget
 
 
 ## Recovery Action Selection

--- a/docs/research_validation_2026_07_13.md
+++ b/docs/research_validation_2026_07_13.md
@@ -1,0 +1,53 @@
+# Localization research validation — 2026-07-13
+
+This note records the adoption decisions behind the July 2026 correctness and
+research pass. Raw replay output remains under `/tmp`; compact reproducible
+results live beside each experiment as `validation_2026_07_13.json`.
+
+## Adopted correctness changes
+
+- Link the component and Eigen-using tests through `Eigen3::Eigen`; this directly
+  addresses the missing transitive include/link contract seen in Humble CI.
+- Serialize state shared between the default callback group and `/initialpose`,
+  let only the expensive registration backend run outside that lock, and discard
+  its result if the initial-pose generation changed meanwhile.
+- Save the bias used to integrate every IMU factor and apply the standard
+  first-order a-posteriori bias correction before evaluating old factors. The
+  rotation-only deskew history now subtracts the current gyro bias as well.
+
+The IMU correction follows the bias-Jacobian approach described by
+[Forster et al.](https://dellaert.github.io/files/Forster16tro.pdf). It fixes an
+internal inconsistency, but it does not justify enabling IMU or deskew by default:
+all candidates failed the three-repeat Koide safety gate.
+
+## BBS top-K verifier decision
+
+[KISS-Matcher](https://arxiv.org/abs/2409.15615) combines Faster-PFH features,
+graph-based outlier pruning, and a robust pose solver. We compared its global
+estimate against the same BBS top-5 set used by the existing bounded NDT scorer.
+Across three Koide queries, top-5 oracle coverage was 2/3. BBS-first produced two
+false accepts; bounded NDT recovered both covered cases with no false accepts;
+KISS safely abstained on all three but took a median 9.06 s at 1 m and 2.58 s at
+2 m. The 0.5 m run exceeded three minutes and about 2.5 GiB RSS. Bounded NDT
+therefore remains the verifier; KISS stays an optional offline experiment.
+
+## Correspondence-direction decision
+
+[X-ICP](https://arxiv.org/abs/2211.16335) motivates measuring how individual
+point-to-plane correspondences contribute along Hessian eigendirections.
+[LP-ICP](https://arxiv.org/abs/2501.02580) extends this idea to point-to-line and
+point-to-plane features. Our controlled approximation correctly exposed three
+null directions for one plane and recovered full rank from three-axis line
+features. On the three Koide scans, however, adding line contributions did not
+change numerical nullity. More importantly, the existing NDT-Hessian signal
+preceded real replay failure in 0/3 repeats. These diagnostics remain offline and
+must not gate runtime pose updates yet.
+
+## Validation boundary
+
+Jazzy builds and tests are available locally; Humble is not installed, so the
+Humble CI fix is verified by its explicit imported-target dependency and must be
+confirmed by GitHub CI. The real-bag study used the available public Koide
+sequence. Synthetic geometry and KISS's deterministic-transform smoke fixture
+provide cross-domain regression, but a second independent public rosbag was not
+available locally.

--- a/experiments/correspondence_localizability/__init__.py
+++ b/experiments/correspondence_localizability/__init__.py
@@ -1,0 +1,1 @@
+"""Correspondence-direction localizability research variants."""

--- a/experiments/correspondence_localizability/interface.py
+++ b/experiments/correspondence_localizability/interface.py
@@ -1,0 +1,35 @@
+"""Shared geometry and output contracts for localizability variants."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class CorrespondenceGeometry:
+    points: np.ndarray
+    plane_normals: np.ndarray
+    plane_mask: np.ndarray
+    line_directions: np.ndarray
+    line_mask: np.ndarray
+
+
+@dataclass(frozen=True)
+class LocalizabilityResult:
+    name: str
+    correspondence_count: int
+    eigenvalues: np.ndarray
+    eigenvectors: np.ndarray
+    weak_ratio: float
+    numerical_nullity: int
+    direction_effective_support: np.ndarray
+
+
+class LocalizabilityVariant(Protocol):
+    name: str
+
+    def analyze(self, geometry: CorrespondenceGeometry) -> LocalizabilityResult:
+        ...

--- a/experiments/correspondence_localizability/run_comparison.py
+++ b/experiments/correspondence_localizability/run_comparison.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Run synthetic and Koide correspondence-localizability comparisons."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+import time
+
+import numpy as np
+from scipy.spatial import cKDTree
+
+from experiments.correspondence_localizability.interface import CorrespondenceGeometry
+from experiments.correspondence_localizability.variants import HessianSpectrum
+from experiments.correspondence_localizability.variants import LpicpPlaneLineContribution
+from experiments.correspondence_localizability.variants import XicpDirectionContribution
+from experiments.point_cloud_io import read_xyz_pcd
+from experiments.point_cloud_io import read_xyz_ply
+
+
+VARIANTS = [HessianSpectrum(), XicpDirectionContribution(), LpicpPlaneLineContribution()]
+
+
+def _reference_yaw(row: dict[str, str]) -> float:
+    x = float(row["orientation_x"])
+    y = float(row["orientation_y"])
+    z = float(row["orientation_z"])
+    w = float(row["orientation_w"])
+    return math.atan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z))
+
+
+def _geometry(
+    points: np.ndarray,
+    normals: np.ndarray | None = None,
+    lines: np.ndarray | None = None,
+) -> CorrespondenceGeometry:
+    count = len(points)
+    return CorrespondenceGeometry(
+        points=np.asarray(points, dtype=np.float64),
+        plane_normals=np.zeros((count, 3)) if normals is None else normals,
+        plane_mask=np.zeros(count, dtype=bool) if normals is None else np.ones(count, dtype=bool),
+        line_directions=np.zeros((count, 3)) if lines is None else lines,
+        line_mask=np.zeros(count, dtype=bool) if lines is None else np.ones(count, dtype=bool),
+    )
+
+
+def _synthetic_scenes() -> dict[str, CorrespondenceGeometry]:
+    grid = np.linspace(-10.0, 10.0, 21)
+    x, y = np.meshgrid(grid, grid)
+    plane_points = np.column_stack((x.ravel(), y.ravel(), np.zeros(x.size)))
+    plane_normals = np.tile([0.0, 0.0, 1.0], (len(plane_points), 1))
+
+    wall_a = np.column_stack((np.zeros(x.size), x.ravel(), y.ravel()))
+    wall_b = np.column_stack((x.ravel(), np.zeros(x.size), y.ravel()))
+    corner_points = np.vstack((wall_a, wall_b))
+    corner_normals = np.vstack(
+        (
+            np.tile([1.0, 0.0, 0.0], (len(wall_a), 1)),
+            np.tile([0.0, 1.0, 0.0], (len(wall_b), 1)),
+        )
+    )
+
+    t = np.linspace(-10.0, 10.0, 101)
+    line_x = np.column_stack((t, np.full_like(t, 3.0), np.full_like(t, 2.0)))
+    line_y = np.column_stack((np.full_like(t, -4.0), t, np.full_like(t, -2.0)))
+    line_z = np.column_stack((np.full_like(t, 5.0), np.full_like(t, -5.0), t))
+    line_points = np.vstack((line_x, line_y, line_z))
+    line_directions = np.vstack(
+        (
+            np.tile([1.0, 0.0, 0.0], (len(t), 1)),
+            np.tile([0.0, 1.0, 0.0], (len(t), 1)),
+            np.tile([0.0, 0.0, 1.0], (len(t), 1)),
+        )
+    )
+    return {
+        "single_plane": _geometry(plane_points, normals=plane_normals),
+        "orthogonal_planes": _geometry(corner_points, normals=corner_normals),
+        "three_axis_lines": _geometry(line_points, lines=line_directions),
+        "planes_plus_lines": CorrespondenceGeometry(
+            points=np.vstack((corner_points, line_points)),
+            plane_normals=np.vstack((corner_normals, np.zeros_like(line_points))),
+            plane_mask=np.r_[np.ones(len(corner_points), bool), np.zeros(len(line_points), bool)],
+            line_directions=np.vstack((np.zeros_like(corner_points), line_directions)),
+            line_mask=np.r_[np.zeros(len(corner_points), bool), np.ones(len(line_points), bool)],
+        ),
+    }
+
+
+def _voxel_downsample(points: np.ndarray, leaf: float) -> np.ndarray:
+    keys = np.floor(points / leaf).astype(np.int64)
+    _unique, indices = np.unique(keys, axis=0, return_index=True)
+    return points[np.sort(indices)]
+
+
+def _estimate_geometry(
+    transformed_scan: np.ndarray,
+    map_points: np.ndarray,
+    tree: cKDTree,
+    max_distance: float,
+    neighbors: int,
+    feature_threshold: float,
+) -> CorrespondenceGeometry:
+    distances, nearest = tree.query(transformed_scan, k=1, workers=-1)
+    valid = np.isfinite(distances) & (distances <= max_distance)
+    points = transformed_scan[valid]
+    nearest = nearest[valid]
+    if not len(points):
+        return _geometry(points)
+    _distances, neighborhoods = tree.query(map_points[nearest], k=neighbors, workers=-1)
+    samples = map_points[neighborhoods]
+    centered = samples - samples.mean(axis=1, keepdims=True)
+    covariance = np.einsum("nki,nkj->nij", centered, centered) / neighbors
+    eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+    scale = np.maximum(eigenvalues[:, 2], np.finfo(float).eps)
+    linearity = (eigenvalues[:, 2] - eigenvalues[:, 1]) / scale
+    planarity = (eigenvalues[:, 1] - eigenvalues[:, 0]) / scale
+    prefer_line = linearity > planarity
+    line_mask = prefer_line & (linearity >= feature_threshold)
+    plane_mask = (~prefer_line) & (planarity >= feature_threshold)
+    return CorrespondenceGeometry(
+        points=points,
+        plane_normals=eigenvectors[:, :, 0],
+        plane_mask=plane_mask,
+        line_directions=eigenvectors[:, :, 2],
+        line_mask=line_mask,
+    )
+
+
+def _serialize(result, runtime_sec: float) -> dict:
+    return {
+        "correspondence_count": result.correspondence_count,
+        "eigenvalues": result.eigenvalues.tolist(),
+        "weak_ratio": result.weak_ratio,
+        "numerical_nullity": result.numerical_nullity,
+        "direction_effective_support": result.direction_effective_support.tolist(),
+        "runtime_sec": runtime_sec,
+    }
+
+
+def _analyze(geometry: CorrespondenceGeometry) -> dict[str, dict]:
+    output = {}
+    for variant in VARIANTS:
+        started = time.monotonic()
+        result = variant.analyze(geometry)
+        output[variant.name] = _serialize(result, time.monotonic() - started)
+    return output
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scan-jobs-csv", required=True)
+    parser.add_argument("--reference-csv", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--map-voxel-size", type=float, default=0.75)
+    parser.add_argument("--scan-voxel-size", type=float, default=0.75)
+    parser.add_argument("--max-correspondence-distance", type=float, default=1.5)
+    parser.add_argument("--neighbors", type=int, default=12)
+    parser.add_argument("--feature-threshold", type=float, default=0.3)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    with Path(args.scan_jobs_csv).open(newline="", encoding="utf-8") as stream:
+        rows = list(csv.DictReader(stream))
+    with Path(args.reference_csv).open(newline="", encoding="utf-8") as stream:
+        reference = list(csv.DictReader(stream))
+    attempts: dict[str, dict[str, str]] = {}
+    for row in rows:
+        attempts.setdefault(row["attempt_id"], row)
+    map_paths = {row["map_path"] for row in rows}
+    if len(map_paths) != 1:
+        raise RuntimeError("exactly one map is required")
+    map_points = _voxel_downsample(
+        read_xyz_ply(Path(next(iter(map_paths)))), args.map_voxel_size
+    )
+    tree = cKDTree(map_points)
+
+    real_results = {}
+    for attempt_id, row in sorted(attempts.items()):
+        stamp = float(row["trigger_stamp_sec"])
+        target = min(reference, key=lambda item: abs(float(item["stamp_sec"]) - stamp))
+        yaw = _reference_yaw(target)
+        rotation = np.array(
+            [[math.cos(yaw), -math.sin(yaw), 0.0], [math.sin(yaw), math.cos(yaw), 0.0], [0.0, 0.0, 1.0]]
+        )
+        translation = np.array(
+            [float(target["position_x"]), float(target["position_y"]), float(target["position_z"])]
+        )
+        scan = _voxel_downsample(
+            read_xyz_pcd(Path(row["scan_pcd_path"])), args.scan_voxel_size
+        )
+        transformed = (rotation @ scan.T).T + translation
+        geometry = _estimate_geometry(
+            transformed, map_points, tree, args.max_correspondence_distance,
+            args.neighbors, args.feature_threshold,
+        )
+        real_results[attempt_id] = {
+            "matched_point_count": len(geometry.points),
+            "plane_count": int(geometry.plane_mask.sum()),
+            "line_count": int(geometry.line_mask.sum()),
+            "variants": _analyze(geometry),
+        }
+
+    synthetic = {name: _analyze(scene) for name, scene in _synthetic_scenes().items()}
+    report = {
+        "schema_version": 1,
+        "config": vars(args),
+        "synthetic": synthetic,
+        "koide": real_results,
+        "existing_ndt_hessian_precursor_repeats": "0/3",
+        "decision": "negative_result_no_runtime_promotion",
+        "decision_reason": (
+            "direction-contribution diagnostics are informative offline, but no causal "
+            "cross-repeat failure prediction has been demonstrated"
+        ),
+    }
+    output = Path(args.output_json)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"output_json": str(output), "decision": report["decision"]}))
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/correspondence_localizability/validation_2026_07_13.json
+++ b/experiments/correspondence_localizability/validation_2026_07_13.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "datasets": ["synthetic plane/corner/line scenes", "Koide outdoor_hard_01a at three bag offsets"],
+  "synthetic": {
+    "single_plane_nullity": 3,
+    "orthogonal_planes_nullity": 1,
+    "line_only_point_to_plane_nullity": 6,
+    "line_only_lp_icp_like_nullity": 0,
+    "planes_plus_lines_point_to_plane_nullity": 1,
+    "planes_plus_lines_lp_icp_like_nullity": 0
+  },
+  "koide": {
+    "matched_points": [3697, 2151, 626],
+    "point_to_plane_nullity": [2, 3, 2],
+    "plane_line_nullity": [2, 3, 2],
+    "point_to_plane_weak_ratio": [1.36e-6, 9.35e-7, 3.51e-6],
+    "plane_line_weak_ratio": [1.85e-6, 1.61e-6, 3.71e-6]
+  },
+  "existing_ndt_hessian_precursor_repeats": "0/3",
+  "decision": "negative_result_no_runtime_promotion",
+  "reason": "line features recover controlled synthetic observability, but did not change Koide nullity and no causal failure precursor was demonstrated"
+}

--- a/experiments/correspondence_localizability/variants.py
+++ b/experiments/correspondence_localizability/variants.py
@@ -1,0 +1,120 @@
+"""Hessian, X-ICP-like contribution, and LP-ICP-like mixed-feature variants.
+
+These are diagnostic approximations for controlled comparison, not claims of a
+verbatim reimplementation of either paper.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .interface import CorrespondenceGeometry
+from .interface import LocalizabilityResult
+
+
+def _skew_batch(points: np.ndarray) -> np.ndarray:
+    matrices = np.zeros((len(points), 3, 3), dtype=np.float64)
+    x, y, z = points.T
+    matrices[:, 0, 1] = -z
+    matrices[:, 0, 2] = y
+    matrices[:, 1, 0] = z
+    matrices[:, 1, 2] = -x
+    matrices[:, 2, 0] = -y
+    matrices[:, 2, 1] = x
+    return matrices
+
+
+def _motion_jacobians(points: np.ndarray) -> np.ndarray:
+    identity = np.broadcast_to(np.eye(3), (len(points), 3, 3))
+    return np.concatenate((identity, -_skew_batch(points)), axis=2)
+
+
+def _result(
+    name: str, hessians: np.ndarray, include_direction_support: bool
+) -> LocalizabilityResult:
+    if not len(hessians):
+        return LocalizabilityResult(
+            name, 0, np.zeros(6), np.eye(6), 0.0, 6, np.zeros(6)
+        )
+    information = hessians.sum(axis=0) / len(hessians)
+    eigenvalues, eigenvectors = np.linalg.eigh(0.5 * (information + information.T))
+    strongest = max(float(eigenvalues[-1]), np.finfo(float).eps)
+    support = np.zeros(6)
+    if include_direction_support:
+        contributions = np.einsum(
+            "ki,nij,kj->nk", eigenvectors.T, hessians, eigenvectors.T
+        )
+        sums = contributions.sum(axis=0)
+        squared_sums = np.square(contributions).sum(axis=0)
+        support = np.divide(
+            np.square(sums),
+            len(hessians) * squared_sums,
+            out=np.zeros(6),
+            where=squared_sums > 0.0,
+        )
+    return LocalizabilityResult(
+        name=name,
+        correspondence_count=len(hessians),
+        eigenvalues=eigenvalues,
+        eigenvectors=eigenvectors,
+        weak_ratio=max(0.0, float(eigenvalues[0]) / strongest),
+        numerical_nullity=int(np.count_nonzero(eigenvalues <= strongest * 1.0e-4)),
+        direction_effective_support=support,
+    )
+
+
+def _plane_hessians(geometry: CorrespondenceGeometry) -> np.ndarray:
+    points = geometry.points[geometry.plane_mask]
+    normals = geometry.plane_normals[geometry.plane_mask]
+    if not len(points):
+        return np.empty((0, 6, 6))
+    jacobians = np.einsum("ni,nij->nj", normals, _motion_jacobians(points))
+    return np.einsum("ni,nj->nij", jacobians, jacobians)
+
+
+def _line_hessians(geometry: CorrespondenceGeometry) -> np.ndarray:
+    points = geometry.points[geometry.line_mask]
+    directions = geometry.line_directions[geometry.line_mask]
+    if not len(points):
+        return np.empty((0, 6, 6))
+    motion = _motion_jacobians(points)
+    projectors = np.eye(3)[None, :, :] - np.einsum(
+        "ni,nj->nij", directions, directions
+    )
+    return np.einsum("nai,nab,nbj->nij", motion, projectors, motion)
+
+
+class HessianSpectrum:
+    name = "point_to_plane_hessian"
+
+    def analyze(self, geometry: CorrespondenceGeometry) -> LocalizabilityResult:
+        return _result(self.name, _plane_hessians(geometry), False)
+
+
+class XicpDirectionContribution:
+    name = "xicp_direction_contribution"
+
+    def analyze(self, geometry: CorrespondenceGeometry) -> LocalizabilityResult:
+        # The spectrum matches point-to-plane Hessian analysis; the additional
+        # effective-support vector exposes redundant concentration per eigendirection.
+        return _result(self.name, _plane_hessians(geometry), True)
+
+
+class LpicpPlaneLineContribution:
+    name = "lpicp_plane_line_contribution"
+
+    def analyze(self, geometry: CorrespondenceGeometry) -> LocalizabilityResult:
+        plane = _plane_hessians(geometry)
+        line = _line_hessians(geometry)
+        if not len(plane):
+            mixed = line
+        elif not len(line):
+            mixed = plane
+        else:
+            # Normalize feature families so a large class cannot dominate only
+            # because it supplied more correspondences.
+            plane = plane * (0.5 / len(plane))
+            line = line * (0.5 / len(line))
+            mixed = np.concatenate((plane, line), axis=0)
+            mixed = mixed * len(mixed)
+        return _result(self.name, mixed, True)

--- a/experiments/imu_bias_correction/__init__.py
+++ b/experiments/imu_bias_correction/__init__.py
@@ -1,0 +1,1 @@
+"""Comparable IMU preintegration bias-correction variants."""

--- a/experiments/imu_bias_correction/interface.py
+++ b/experiments/imu_bias_correction/interface.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class BiasFactor:
+    """One scalar rotation factor distilled from a 3-D preintegration interval."""
+
+    measured_delta_rad: float
+    integration_bias_rad_s: float
+    current_bias_rad_s: float
+    duration_sec: float
+    expected_delta_rad: float
+
+
+class BiasCorrectionStrategy(Protocol):
+    name: str
+    design: str
+
+    def correct(self, factors: list[BiasFactor]) -> list[float]:
+        ...

--- a/experiments/imu_bias_correction/validation_2026_07_13.json
+++ b/experiments/imu_bias_correction/validation_2026_07_13.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "dataset": "Koide outdoor_hard_01a, start_offset=85 s, duration=27 s",
+  "repeats": 3,
+  "synthetic_result": "per_factor_bias_snapshot exactly removes the scalar constant-rate bias error",
+  "runtime_change": "retain per-factor integration-bias snapshots and apply first-order correction at the current bias",
+  "koide_modes": {
+    "lidar_only": {"translation_rmse_median_m": 0.4695, "rotation_rmse_median_deg": 3.1022, "success_repeats": 0},
+    "deskew": {"translation_rmse_median_m": 1.3287, "rotation_rmse_median_deg": 8.2814, "success_repeats": 1, "latency_ratio": 1.3063},
+    "imu_pose_history": {"translation_rmse_median_m": 0.7427, "rotation_rmse_median_deg": 8.4262, "success_repeats": 1, "latency_ratio": 1.1156}
+  },
+  "decision": "retain_correctness_fix_but_do_not_enable_imu_or_deskew_by_default",
+  "reason": "all IMU-enabled candidates failed the all-repeat accuracy and safety gates"
+}

--- a/experiments/imu_bias_correction/variants.py
+++ b/experiments/imu_bias_correction/variants.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from experiments.imu_bias_correction.interface import BiasFactor
+
+
+def _correct_factor(factor: BiasFactor) -> float:
+    # d(delta_theta)/d(bg) = -dt for the scalar constant-rate fixture.
+    delta_bias = factor.current_bias_rad_s - factor.integration_bias_rad_s
+    return factor.measured_delta_rad - factor.duration_sec * delta_bias
+
+
+class UncorrectedFactors:
+    name = "uncorrected_factors"
+    design = "runtime baseline: reuse every stored delta at its original bias"
+
+    def correct(self, factors: list[BiasFactor]) -> list[float]:
+        return [factor.measured_delta_rad for factor in factors]
+
+
+class LatestFactorOnly:
+    name = "latest_factor_only"
+    design = "correct only the newest factor after each bias update"
+
+    def correct(self, factors: list[BiasFactor]) -> list[float]:
+        if not factors:
+            return []
+        corrected = [factor.measured_delta_rad for factor in factors]
+        corrected[-1] = _correct_factor(factors[-1])
+        return corrected
+
+
+class PerFactorBiasSnapshot:
+    name = "per_factor_bias_snapshot"
+    design = "correct every factor from its stored integration bias to the current bias"
+
+    def correct(self, factors: list[BiasFactor]) -> list[float]:
+        return [_correct_factor(factor) for factor in factors]

--- a/experiments/kiss_matcher_verifier/__init__.py
+++ b/experiments/kiss_matcher_verifier/__init__.py
@@ -1,0 +1,1 @@
+"""Offline BBS top-K verifier comparison."""

--- a/experiments/kiss_matcher_verifier/interface.py
+++ b/experiments/kiss_matcher_verifier/interface.py
@@ -1,0 +1,49 @@
+"""Shared contracts for offline global-verifier experiments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Iterable
+
+
+def angle_error_rad(lhs: float, rhs: float) -> float:
+    return abs(math.atan2(math.sin(lhs - rhs), math.cos(lhs - rhs)))
+
+
+@dataclass(frozen=True)
+class Candidate:
+    attempt_id: str
+    candidate_index: int
+    x: float
+    y: float
+    yaw_rad: float
+    oracle_recoverable: bool
+
+
+@dataclass(frozen=True)
+class GlobalEstimate:
+    valid: bool
+    x: float
+    y: float
+    yaw_rad: float
+    final_inliers: int
+    runtime_sec: float
+
+
+@dataclass(frozen=True)
+class Selection:
+    candidate: Candidate | None
+    accepted: bool
+    reason: str
+    translation_delta_m: float = math.inf
+    yaw_delta_rad: float = math.inf
+
+
+class CandidateSelector:
+    name = "selector"
+
+    def select(
+        self, candidates: Iterable[Candidate], estimate: GlobalEstimate | None = None
+    ) -> Selection:
+        raise NotImplementedError

--- a/experiments/kiss_matcher_verifier/run_comparison.py
+++ b/experiments/kiss_matcher_verifier/run_comparison.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Compare BBS, bounded NDT, and KISS-Matcher on one top-K job artifact.
+
+KISS-Matcher is optional research tooling. Install it in an isolated environment
+with ``python -m pip install kiss-matcher``; it is deliberately not a runtime ROS
+dependency. The script never publishes a reset pose.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+import statistics
+import time
+from typing import Any
+
+import numpy as np
+
+from experiments.point_cloud_io import read_xyz_pcd
+from experiments.point_cloud_io import read_xyz_ply
+from experiments.kiss_matcher_verifier.interface import Candidate
+from experiments.kiss_matcher_verifier.interface import GlobalEstimate
+from experiments.kiss_matcher_verifier.interface import angle_error_rad
+from experiments.kiss_matcher_verifier.variants import BbsFirstSelector
+from experiments.kiss_matcher_verifier.variants import KissNearestSelector
+
+
+def _as_bool(value: Any) -> bool:
+    return str(value).strip().lower() in {"true", "1", "yes"}
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        return list(csv.DictReader(stream))
+
+
+def _yaw_from_rotation(rotation: np.ndarray) -> float:
+    return math.atan2(float(rotation[1, 0]), float(rotation[0, 0]))
+
+
+def _nearest_reference(reference: list[dict[str, str]], stamp: float) -> dict[str, str]:
+    return min(reference, key=lambda row: abs(float(row["stamp_sec"]) - stamp))
+
+
+def _reference_yaw(row: dict[str, str]) -> float:
+    x = float(row["orientation_x"])
+    y = float(row["orientation_y"])
+    z = float(row["orientation_z"])
+    w = float(row["orientation_w"])
+    return math.atan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z))
+
+
+def _median(values: list[float]) -> float | None:
+    return statistics.median(values) if values else None
+
+
+def _estimate_medoid(estimates: list[GlobalEstimate]) -> GlobalEstimate:
+    def distance(lhs: GlobalEstimate, rhs: GlobalEstimate) -> float:
+        return math.hypot(lhs.x - rhs.x, lhs.y - rhs.y) + angle_error_rad(
+            lhs.yaw_rad, rhs.yaw_rad
+        )
+
+    return min(estimates, key=lambda item: sum(distance(item, other) for other in estimates))
+
+
+def _repeat_spread(estimates: list[GlobalEstimate]) -> tuple[float, float]:
+    xy_spread = 0.0
+    yaw_spread = 0.0
+    for index, lhs in enumerate(estimates):
+        for rhs in estimates[index + 1 :]:
+            xy_spread = max(xy_spread, math.hypot(lhs.x - rhs.x, lhs.y - rhs.y))
+            yaw_spread = max(yaw_spread, angle_error_rad(lhs.yaw_rad, rhs.yaw_rad))
+    return xy_spread, yaw_spread
+
+
+def _summarize_variant(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    accepted = [row for row in rows if row["accepted"]]
+    correct = [row for row in accepted if row["selected_oracle_recoverable"]]
+    return {
+        "attempt_count": len(rows),
+        "accepted_count": len(accepted),
+        "correct_accept_count": len(correct),
+        "false_accept_count": len(accepted) - len(correct),
+        "recovery_rate": len(correct) / len(rows) if rows else 0.0,
+        "precision": len(correct) / len(accepted) if accepted else None,
+        "median_runtime_sec": _median([float(row["runtime_sec"]) for row in rows]),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scan-jobs-csv", required=True)
+    parser.add_argument("--ndt-scores-csv", required=True)
+    parser.add_argument("--candidates-csv", required=True)
+    parser.add_argument("--reference-csv", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--voxel-size", type=float, default=1.0)
+    parser.add_argument("--min-final-inliers", type=int, default=5)
+    parser.add_argument("--max-candidate-delta-m", type=float, default=2.0)
+    parser.add_argument("--max-candidate-yaw-delta-deg", type=float, default=15.0)
+    parser.add_argument("--max-repeat-spread-m", type=float, default=2.0)
+    parser.add_argument("--max-repeat-yaw-spread-deg", type=float, default=15.0)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        import kiss_matcher
+    except ImportError as error:
+        raise SystemExit(
+            "kiss-matcher is required only for this experiment; install it in a venv"
+        ) from error
+
+    jobs = _read_csv(Path(args.scan_jobs_csv))
+    ndt_rows = _read_csv(Path(args.ndt_scores_csv))
+    oracle_rows = _read_csv(Path(args.candidates_csv))
+    oracle_by_candidate = {
+        (row["attempt_id"], int(row["candidate_index"])): row for row in oracle_rows
+    }
+    reference = _read_csv(Path(args.reference_csv))
+    by_attempt: dict[str, list[dict[str, str]]] = {}
+    for row in jobs:
+        by_attempt.setdefault(row["attempt_id"], []).append(row)
+
+    map_paths = {row["map_path"] for row in jobs}
+    if len(map_paths) != 1:
+        raise RuntimeError("comparison requires exactly one map")
+    target = read_xyz_ply(Path(next(iter(map_paths))))
+    target = target[np.isfinite(target).all(axis=1)]
+    bbs_selector = BbsFirstSelector()
+    kiss_selector = KissNearestSelector(
+        min_final_inliers=args.min_final_inliers,
+        max_translation_delta_m=args.max_candidate_delta_m,
+        max_yaw_delta_rad=math.radians(args.max_candidate_yaw_delta_deg),
+    )
+    output_rows: dict[str, list[dict[str, Any]]] = {
+        "bbs_first": [],
+        "ndt_bounded": [],
+        "kiss_nearest": [],
+    }
+    kiss_estimates: list[dict[str, Any]] = []
+
+    for attempt_id, attempt_rows in sorted(by_attempt.items()):
+        def is_recoverable(candidate_index: int) -> bool:
+            oracle = oracle_by_candidate[(attempt_id, candidate_index)]
+            return (
+                float(oracle["oracle_translation_error_m"]) <= 2.0
+                and float(oracle["oracle_yaw_error_deg"]) <= 15.0
+            )
+
+        candidates = [
+            Candidate(
+                attempt_id=attempt_id,
+                candidate_index=int(row["candidate_index"]),
+                x=float(row["initial_pose_x"]),
+                y=float(row["initial_pose_y"]),
+                yaw_rad=float(row["initial_yaw_rad"]),
+                oracle_recoverable=is_recoverable(int(row["candidate_index"])),
+            )
+            for row in attempt_rows
+        ]
+        bbs = bbs_selector.select(candidates)
+        output_rows["bbs_first"].append(
+            {
+                "attempt_id": attempt_id,
+                "accepted": bbs.accepted,
+                "selected_candidate_index": bbs.candidate.candidate_index if bbs.candidate else None,
+                "selected_oracle_recoverable": bool(
+                    bbs.candidate and bbs.candidate.oracle_recoverable
+                ),
+                "reason": bbs.reason,
+                "runtime_sec": 0.0,
+            }
+        )
+
+        attempt_ndt = [row for row in ndt_rows if row["attempt_id"] == attempt_id]
+        gated_ndt = [row for row in attempt_ndt if _as_bool(row["registration_gate_passed"])]
+        selected_ndt = min(gated_ndt, key=lambda row: float(row["score"])) if gated_ndt else None
+        output_rows["ndt_bounded"].append(
+            {
+                "attempt_id": attempt_id,
+                "accepted": selected_ndt is not None,
+                "selected_candidate_index": (
+                    int(selected_ndt["candidate_index"]) if selected_ndt else None
+                ),
+                "selected_oracle_recoverable": bool(
+                    selected_ndt and is_recoverable(int(selected_ndt["candidate_index"]))
+                ),
+                "reason": "passed_reset_disabled" if selected_ndt else "all_candidates_rejected",
+                "runtime_sec": sum(float(row["runtime_sec"]) for row in attempt_ndt),
+            }
+        )
+
+        scan = read_xyz_pcd(Path(attempt_rows[0]["scan_pcd_path"]))
+        scan = scan[np.isfinite(scan).all(axis=1)]
+        estimates: list[GlobalEstimate] = []
+        for repeat in range(args.repeats):
+            config = kiss_matcher.KISSMatcherConfig(args.voxel_size)
+            matcher = kiss_matcher.KISSMatcher(config)
+            started = time.monotonic()
+            result = matcher.estimate(scan, target)
+            runtime_sec = time.monotonic() - started
+            rotation = np.asarray(result.rotation)
+            translation = np.asarray(result.translation).reshape(3)
+            estimates.append(
+                GlobalEstimate(
+                    valid=bool(result.valid),
+                    x=float(translation[0]),
+                    y=float(translation[1]),
+                    yaw_rad=_yaw_from_rotation(rotation),
+                    final_inliers=int(matcher.get_num_final_inliers()),
+                    runtime_sec=runtime_sec,
+                )
+            )
+        medoid = _estimate_medoid(estimates)
+        repeat_spread_m, repeat_yaw_spread_rad = _repeat_spread(estimates)
+        repeat_consistent = (
+            all(item.valid for item in estimates)
+            and min(item.final_inliers for item in estimates) >= args.min_final_inliers
+            and repeat_spread_m <= args.max_repeat_spread_m
+            and repeat_yaw_spread_rad <= math.radians(args.max_repeat_yaw_spread_deg)
+        )
+        estimate = GlobalEstimate(
+            valid=medoid.valid and repeat_consistent,
+            x=medoid.x,
+            y=medoid.y,
+            yaw_rad=medoid.yaw_rad,
+            final_inliers=medoid.final_inliers,
+            runtime_sec=statistics.median(item.runtime_sec for item in estimates),
+        )
+        selection = kiss_selector.select(candidates, estimate)
+        target_reference = _nearest_reference(reference, float(attempt_rows[0]["trigger_stamp_sec"]))
+        gt_x = float(target_reference["position_x"])
+        gt_y = float(target_reference["position_y"])
+        gt_yaw = _reference_yaw(target_reference)
+        kiss_estimates.append(
+            {
+                "attempt_id": attempt_id,
+                "valid": estimate.valid,
+                "final_inliers": estimate.final_inliers,
+                "estimated_x": estimate.x,
+                "estimated_y": estimate.y,
+                "estimated_yaw_rad": estimate.yaw_rad,
+                "oracle_xy_error_m": math.hypot(estimate.x - gt_x, estimate.y - gt_y),
+                "oracle_yaw_error_deg": math.degrees(angle_error_rad(estimate.yaw_rad, gt_yaw)),
+                "repeat_runtime_sec": [item.runtime_sec for item in estimates],
+                "repeat_estimated_xy": [[item.x, item.y] for item in estimates],
+                "repeat_final_inliers": [item.final_inliers for item in estimates],
+                "repeat_consistent": repeat_consistent,
+                "repeat_xy_spread_m": repeat_spread_m,
+                "repeat_yaw_spread_deg": math.degrees(repeat_yaw_spread_rad),
+            }
+        )
+        output_rows["kiss_nearest"].append(
+            {
+                "attempt_id": attempt_id,
+                "accepted": selection.accepted,
+                "selected_candidate_index": (
+                    selection.candidate.candidate_index if selection.candidate else None
+                ),
+                "selected_oracle_recoverable": bool(
+                    selection.candidate and selection.candidate.oracle_recoverable
+                ),
+                "reason": selection.reason,
+                "runtime_sec": statistics.median(item.runtime_sec for item in estimates),
+                "candidate_translation_delta_m": selection.translation_delta_m,
+                "candidate_yaw_delta_deg": math.degrees(selection.yaw_delta_rad),
+            }
+        )
+
+    coverage_count = sum(
+        any(candidate.oracle_recoverable for candidate in [
+            Candidate(
+                attempt_id=attempt_id,
+                candidate_index=int(row["candidate_index"]),
+                x=float(row["initial_pose_x"]),
+                y=float(row["initial_pose_y"]),
+                yaw_rad=float(row["initial_yaw_rad"]),
+                oracle_recoverable=(
+                    float(oracle_by_candidate[(attempt_id, int(row["candidate_index"]))][
+                        "oracle_translation_error_m"
+                    ])
+                    <= 2.0
+                    and float(oracle_by_candidate[(attempt_id, int(row["candidate_index"]))][
+                        "oracle_yaw_error_deg"
+                    ])
+                    <= 15.0
+                ),
+            )
+            for row in rows
+        ])
+        for attempt_id, rows in by_attempt.items()
+    )
+    summary = {
+        "schema_version": 1,
+        "reset_published": False,
+        "attempt_count": len(by_attempt),
+        "candidate_set_oracle_coverage_count": coverage_count,
+        "candidate_set_oracle_coverage_rate": coverage_count / len(by_attempt),
+        "config": vars(args),
+        "variants": {name: _summarize_variant(rows) for name, rows in output_rows.items()},
+        "attempts": output_rows,
+        "kiss_global_estimates": kiss_estimates,
+    }
+    output = Path(args.output_json)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"output_json": str(output), "variants": summary["variants"]}))
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/kiss_matcher_verifier/validation_2026_07_13.json
+++ b/experiments/kiss_matcher_verifier/validation_2026_07_13.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "dataset": "Koide outdoor_hard_01a at bag offsets 30 s, 85 s, and 145 s",
+  "bbs_top_k": 5,
+  "candidate_set_oracle_coverage": "2/3",
+  "repeats_per_kiss_setting": 3,
+  "variants": {
+    "bbs_first": {"correct_accepts": 1, "false_accepts": 2, "recovery_rate": 0.3333},
+    "ndt_bounded": {"correct_accepts": 2, "false_accepts": 0, "recovery_rate": 0.6667, "median_attempt_runtime_sec": 0.7717},
+    "kiss_voxel_1_0_m": {"correct_accepts": 0, "false_accepts": 0, "recovery_rate": 0.0, "median_attempt_runtime_sec": 9.0600},
+    "kiss_voxel_2_0_m": {"correct_accepts": 0, "false_accepts": 0, "recovery_rate": 0.0, "median_attempt_runtime_sec": 2.5761},
+    "kiss_voxel_0_5_m": {"status": "stopped_after_180_sec", "peak_rss_gib_approx": 2.52}
+  },
+  "decision": "keep_existing_bounded_ndt_verifier",
+  "reason": "NDT reached the candidate-set coverage ceiling without false accepts; KISS always abstained and was slower or exceeded the resource gate"
+}

--- a/experiments/kiss_matcher_verifier/variants.py
+++ b/experiments/kiss_matcher_verifier/variants.py
@@ -1,0 +1,66 @@
+"""BBS baseline and KISS global-estimate candidate selectors."""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable
+
+from .interface import Candidate
+from .interface import CandidateSelector
+from .interface import GlobalEstimate
+from .interface import Selection
+from .interface import angle_error_rad
+
+
+class BbsFirstSelector(CandidateSelector):
+    name = "bbs_first"
+
+    def select(
+        self, candidates: Iterable[Candidate], estimate: GlobalEstimate | None = None
+    ) -> Selection:
+        ordered = sorted(candidates, key=lambda candidate: candidate.candidate_index)
+        if not ordered:
+            return Selection(None, False, "no_candidates")
+        return Selection(ordered[0], True, "bbs_first_no_gate", 0.0, 0.0)
+
+
+class KissNearestSelector(CandidateSelector):
+    name = "kiss_nearest"
+
+    def __init__(
+        self,
+        min_final_inliers: int = 5,
+        max_translation_delta_m: float = 2.0,
+        max_yaw_delta_rad: float = math.radians(15.0),
+        yaw_weight_m_per_rad: float = 1.0,
+    ) -> None:
+        self.min_final_inliers = min_final_inliers
+        self.max_translation_delta_m = max_translation_delta_m
+        self.max_yaw_delta_rad = max_yaw_delta_rad
+        self.yaw_weight_m_per_rad = yaw_weight_m_per_rad
+
+    def select(
+        self, candidates: Iterable[Candidate], estimate: GlobalEstimate | None = None
+    ) -> Selection:
+        ordered = list(candidates)
+        if not ordered:
+            return Selection(None, False, "no_candidates")
+        if estimate is None or not estimate.valid:
+            return Selection(None, False, "invalid_global_estimate")
+        if estimate.final_inliers < self.min_final_inliers:
+            return Selection(None, False, "insufficient_final_inliers")
+
+        def deltas(candidate: Candidate) -> tuple[float, float, float]:
+            translation = math.hypot(candidate.x - estimate.x, candidate.y - estimate.y)
+            yaw = angle_error_rad(candidate.yaw_rad, estimate.yaw_rad)
+            return translation + self.yaw_weight_m_per_rad * yaw, translation, yaw
+
+        selected = min(ordered, key=lambda candidate: deltas(candidate)[0])
+        _score, translation, yaw = deltas(selected)
+        if translation > self.max_translation_delta_m:
+            return Selection(
+                selected, False, "translation_delta_above_threshold", translation, yaw
+            )
+        if yaw > self.max_yaw_delta_rad:
+            return Selection(selected, False, "yaw_delta_above_threshold", translation, yaw)
+        return Selection(selected, True, "passed_reset_disabled", translation, yaw)

--- a/experiments/point_cloud_io.py
+++ b/experiments/point_cloud_io.py
@@ -1,0 +1,80 @@
+"""Minimal binary PLY/PCD XYZ readers shared by offline experiments."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+
+def read_xyz_ply(path: Path) -> np.ndarray:
+    """Read XYZ fields from a binary little-endian PLY vertex element."""
+    with path.open("rb") as stream:
+        vertex_count = 0
+        format_name = ""
+        properties: list[tuple[str, str]] = []
+        in_vertex = False
+        while True:
+            line = stream.readline().decode("ascii").strip()
+            if line.startswith("format "):
+                format_name = line.split()[1]
+            elif line.startswith("element vertex "):
+                vertex_count = int(line.split()[2])
+                in_vertex = True
+            elif line.startswith("element "):
+                in_vertex = False
+            elif in_vertex and line.startswith("property "):
+                _property, type_name, name = line.split()
+                properties.append((name, type_name))
+            elif line == "end_header":
+                break
+        if format_name != "binary_little_endian":
+            raise RuntimeError(f"only binary_little_endian PLY is supported: {path}")
+        formats = {"float": "<f4", "float32": "<f4", "double": "<f8"}
+        try:
+            dtype = np.dtype(
+                [(name, formats[type_name]) for name, type_name in properties]
+            )
+        except KeyError as error:
+            raise RuntimeError(
+                f"unsupported PLY vertex property type: {error}"
+            ) from error
+        vertices = np.fromfile(stream, dtype=dtype, count=vertex_count)
+    return np.column_stack((vertices["x"], vertices["y"], vertices["z"])).astype(
+        np.float32, copy=False
+    )
+
+
+def read_xyz_pcd(path: Path) -> np.ndarray:
+    """Read XYZ fields from an uncompressed binary PCD cloud."""
+    with path.open("rb") as stream:
+        header: dict[str, list[str]] = {}
+        while True:
+            tokens = stream.readline().decode("ascii").strip().split()
+            if not tokens:
+                continue
+            header[tokens[0].upper()] = tokens[1:]
+            if tokens[0].upper() == "DATA":
+                break
+        if header["DATA"][0].lower() != "binary":
+            raise RuntimeError(f"only binary PCD is supported: {path}")
+        fields = header["FIELDS"]
+        sizes = [int(value) for value in header["SIZE"]]
+        types = header["TYPE"]
+        counts = [int(value) for value in header.get("COUNT", ["1"] * len(fields))]
+        type_map = {
+            ("F", 4): "<f4",
+            ("F", 8): "<f8",
+            ("I", 4): "<i4",
+            ("U", 4): "<u4",
+        }
+        dtype_fields = []
+        for name, size, type_name, count in zip(fields, sizes, types, counts):
+            scalar = type_map[(type_name.upper(), size)]
+            field = (name, scalar) if count == 1 else (name, scalar, (count,))
+            dtype_fields.append(field)
+        points = int(header.get("POINTS", header["WIDTH"])[0])
+        cloud = np.fromfile(stream, dtype=np.dtype(dtype_fields), count=points)
+    return np.column_stack((cloud["x"], cloud["y"], cloud["z"])).astype(
+        np.float32, copy=False
+    )

--- a/include/lidar_localization/callback_state_coordinator.hpp
+++ b/include/lidar_localization/callback_state_coordinator.hpp
@@ -1,0 +1,54 @@
+#ifndef LIDAR_LOCALIZATION__CALLBACK_STATE_COORDINATOR_HPP_
+#define LIDAR_LOCALIZATION__CALLBACK_STATE_COORDINATOR_HPP_
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+
+namespace lidar_localization
+{
+
+// Coordinates state shared by the default callback group and the dedicated
+// /initialpose callback group. The recursive mutex is intentional: lifecycle
+// activation applies its configured initial pose through the same callback
+// implementation while already holding the state lock.
+class CallbackStateCoordinator
+{
+public:
+  using StateLock = std::unique_lock<std::recursive_mutex>;
+  using RegistrationExecutionLock = std::unique_lock<std::mutex>;
+
+  StateLock lockState()
+  {
+    return StateLock(state_mutex_);
+  }
+
+  RegistrationExecutionLock lockRegistrationExecution()
+  {
+    return RegistrationExecutionLock(registration_execution_mutex_);
+  }
+
+  std::uint64_t initialPoseGeneration() const
+  {
+    return initial_pose_generation_.load(std::memory_order_acquire);
+  }
+
+  void advanceInitialPoseGeneration()
+  {
+    initial_pose_generation_.fetch_add(1, std::memory_order_release);
+  }
+
+  bool initialPoseGenerationMatches(std::uint64_t generation) const
+  {
+    return initialPoseGeneration() == generation;
+  }
+
+private:
+  std::recursive_mutex state_mutex_;
+  std::mutex registration_execution_mutex_;
+  std::atomic<std::uint64_t> initial_pose_generation_{0};
+};
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION__CALLBACK_STATE_COORDINATOR_HPP_

--- a/include/lidar_localization/imu_gtsam_smoother.hpp
+++ b/include/lidar_localization/imu_gtsam_smoother.hpp
@@ -76,6 +76,8 @@ public:
     // Reset IMU accumulation
     current_preint_.reset();
     current_preint_.params = params_.imu_params;
+    current_preint_gyro_bias_ = gyro_bias_;
+    current_preint_accel_bias_ = accel_bias_;
   }
 
   /// Accumulate one IMU sample (called at IMU rate ~200Hz)
@@ -112,6 +114,8 @@ public:
 
     // Store IMU preintegration as between-factor
     entry.preint = current_preint_;
+    entry.preint_gyro_bias = current_preint_gyro_bias_;
+    entry.preint_accel_bias = current_preint_accel_bias_;
     entry.has_imu_factor = (current_preint_.dt_sum >= params_.min_imu_factor_dt);
 
     // Store NDT measurement
@@ -139,6 +143,8 @@ public:
     // Reset preintegration for next interval
     current_preint_.reset();
     current_preint_.params = params_.imu_params;
+    current_preint_gyro_bias_ = gyro_bias_;
+    current_preint_accel_bias_ = accel_bias_;
 
     last_stamp_ = stamp_sec;
     return true;
@@ -177,6 +183,8 @@ private:
 
     // IMU between-factor to this pose from previous
     ImuPreintegration preint;
+    Eigen::Vector3d preint_gyro_bias = Eigen::Vector3d::Zero();
+    Eigen::Vector3d preint_accel_bias = Eigen::Vector3d::Zero();
     bool has_imu_factor = false;
 
     // NDT measurement
@@ -192,6 +200,8 @@ private:
 
   // Current preintegration being accumulated
   ImuPreintegration current_preint_;
+  Eigen::Vector3d current_preint_gyro_bias_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d current_preint_accel_bias_ = Eigen::Vector3d::Zero();
 
   // Dead-reckoning state for init_guess prediction
   Eigen::Vector3d dr_p_ = Eigen::Vector3d::Zero();
@@ -232,15 +242,19 @@ private:
 
         const auto & pi = poses_[i - 1];
         const auto & pj = poses_[i];
-        const auto & preint = pj.preint;
+        const auto & stored_preint = pj.preint;
+        ImuPreintegration corrected_preint = stored_preint;
+        corrected_preint.correctByBias(
+          gyro_bias_ - pj.preint_gyro_bias,
+          accel_bias_ - pj.preint_accel_bias);
 
         // Compute residual
-        Eigen::Matrix<double, 9, 1> r = preint.computeResidual(
+        Eigen::Matrix<double, 9, 1> r = corrected_preint.computeResidual(
           pi.position, pi.velocity, pi.R,
           pj.position, pj.velocity, pj.R);
 
         // Information from preintegration covariance
-        Eigen::Matrix<double, 9, 9> covariance = preint.covariance;
+        Eigen::Matrix<double, 9, 9> covariance = stored_preint.covariance;
         covariance.diagonal().array() += params_.imu_factor_covariance_regularization;
         if (!covariance.allFinite()) continue;
         Eigen::Matrix<double, 9, 9> info =
@@ -250,7 +264,7 @@ private:
         info = 0.5 * (info + info.transpose());
 
         // Jacobians w.r.t. pose_i [p, v, theta] and pose_j [p, v, theta]
-        double dt = preint.dt_sum;
+        double dt = stored_preint.dt_sum;
         const Eigen::Vector3d & g = params_.imu_params.gravity;
         Eigen::Matrix3d Ri_T = pi.R.transpose();
 
@@ -279,16 +293,12 @@ private:
         // dr/d(biases) [9x3 for bg, 9x3 for ba]
         Eigen::Matrix<double, 9, 3> Jbg = Eigen::Matrix<double, 9, 3>::Zero();
         Eigen::Matrix<double, 9, 3> Jba = Eigen::Matrix<double, 9, 3>::Zero();
-        Jbg.block<3, 3>(0, 0) = -preint.d_dp_d_bg;
-        Jbg.block<3, 3>(3, 0) = -preint.d_dv_d_bg;
-        Jbg.block<3, 3>(6, 0) = -Jr_inv_r * so3::Exp(r_theta).transpose() *
-                                  so3::Jr(preint.d_dR_d_bg * (gyro_bias_ - gyro_bias_)) *
-                                  preint.d_dR_d_bg;
-        // Simplified: for small bias changes, this ≈ -Jr_inv_r * preint.d_dR_d_bg
-        Jbg.block<3, 3>(6, 0) = -Jr_inv_r * preint.d_dR_d_bg;
+        Jbg.block<3, 3>(0, 0) = -stored_preint.d_dp_d_bg;
+        Jbg.block<3, 3>(3, 0) = -stored_preint.d_dv_d_bg;
+        Jbg.block<3, 3>(6, 0) = -Jr_inv_r * stored_preint.d_dR_d_bg;
 
-        Jba.block<3, 3>(0, 0) = -preint.d_dp_d_ba;
-        Jba.block<3, 3>(3, 0) = -preint.d_dv_d_ba;
+        Jba.block<3, 3>(0, 0) = -stored_preint.d_dp_d_ba;
+        Jba.block<3, 3>(3, 0) = -stored_preint.d_dv_d_ba;
 
         int idx_i = (i - 1) * POSE_DIM;
         int idx_j = i * POSE_DIM;

--- a/include/lidar_localization/lidar_localization_component.hpp
+++ b/include/lidar_localization/lidar_localization_component.hpp
@@ -63,6 +63,7 @@
 #include "lidar_localization/alignment_retry_policy.hpp"
 #include "lidar_localization/alignment_pipeline_policy.hpp"
 #include "lidar_localization/alignment_status_policy.hpp"
+#include "lidar_localization/callback_state_coordinator.hpp"
 #include "lidar_localization/imu_preintegration_diagnostics_policy.hpp"
 #include "lidar_localization/imu_preintegration_guard_policy.hpp"
 #include "lidar_localization/measurement_gate_policy.hpp"
@@ -151,9 +152,11 @@ public:
   small_gicp::RegistrationPCL<pcl::PointXYZI, pcl::PointXYZI>::Ptr small_gicp_registration_;
 #endif
   pcl::VoxelGrid<pcl::PointXYZI> voxel_grid_filter_;
-  // Mutated and read from pose, scan, odom, and service callbacks. IMU
-  // preintegration and /initialpose use dedicated callback groups so high-rate
-  // replay and long scan registration do not starve reset handling.
+  // Mutated and read from pose, scan, odom, and lifecycle callbacks. The
+  // default callback group is mutually exclusive, while /initialpose has a
+  // dedicated group so a reset can interrupt long registration. Every access
+  // shared with that group is protected by callback_state_coordinator_.
+  lidar_localization::CallbackStateCoordinator callback_state_coordinator_;
   geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr corrent_pose_with_cov_stamped_ptr_;
   nav_msgs::msg::Path::SharedPtr path_ptr_;
   sensor_msgs::msg::PointCloud2::ConstSharedPtr last_scan_ptr_;
@@ -161,12 +164,6 @@ public:
   bool map_recieved_{false};
   bool initialpose_recieved_{false};
   double last_initial_pose_stamp_sec_{-1.0};
-  // Incremented on every accepted /initialpose. Scan processing snapshots it at
-  // seed selection and discards its alignment result if it changed by apply
-  // time: /initialpose runs on a dedicated callback group (MultiThreadedExecutor),
-  // so an accepted measurement seeded from the pre-reset belief would otherwise
-  // land after the reset and silently undo it.
-  std::atomic<std::uint64_t> initial_pose_generation_{0};
   pcl::PointCloud<pcl::PointXYZI>::Ptr full_map_cloud_ptr_;
   pcl::PointXYZI map_min_pt_{};
   pcl::PointXYZI map_max_pt_{};
@@ -203,8 +200,7 @@ public:
   double imu_prediction_correction_guard_translation_m_{2.0};
   double imu_prediction_correction_guard_yaw_deg_{10.0};
   int imu_prediction_correction_guard_warmup_accepts_{5};
-  // Atomic like initial_pose_generation_: read on the per-scan path without
-  // taking imu_preintegration_mutex_.
+  // Read on the per-scan path without taking imu_preintegration_mutex_.
   std::atomic<int> imu_guard_warmup_accepts_remaining_{0};
   ImuGtsamSmoother imu_smoother_;
   double last_imu_stamp_{0.0};
@@ -333,7 +329,8 @@ public:
   double last_accepted_pose_time_sec_{0.0};
   double predicted_pose_time_sec_{0.0};
   geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr latest_twist_msg_;
-  bool shutting_down_{false};
+  // Read by the dedicated IMU callback without taking the callback-state lock.
+  std::atomic<bool> shutting_down_{false};
   bool reinitialization_requested_{false};
   std::string reinitialization_request_reason_{"not_requested"};
   double reinitialization_request_score_{0.0};
@@ -440,12 +437,16 @@ public:
   lidar_localization::AlignmentAttempt runAlignmentAttempt(
     const Eigen::Matrix4f & attempt_init_guess,
     const Eigen::Matrix4f & crop_center_pose_matrix,
-    double scan_stamp_sec);
+    double scan_stamp_sec,
+    lidar_localization::CallbackStateCoordinator::StateLock & state_lock,
+    std::uint64_t seed_generation);
   lidar_localization::AlignmentPipelineResult runAlignmentPipelineForScan(
     const Eigen::Matrix4f & init_guess,
     double scan_stamp_sec,
     lidar_localization::RegistrationSeedSource seed_source,
-    bool imu_prediction_ready);
+    bool imu_prediction_ready,
+    lidar_localization::CallbackStateCoordinator::StateLock & state_lock,
+    std::uint64_t seed_generation);
   lidar_localization::MeasurementGateDecision evaluateMeasurementGateForAttempt(
     const lidar_localization::AlignmentAttempt & attempt);
   void logAlignmentPipelineRecovery(

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>tf2_eigen</build_depend>
   <build_depend>pcl_conversions</build_depend>
+  <depend>eigen</depend>
   <!-- Optional: builds the bbs_cpp backend for the global localization node.
        The build degrades gracefully (Python fallback) if it is unavailable. -->
   <build_depend>pybind11_vendor</build_depend>
@@ -38,6 +39,7 @@
   <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>tf2_eigen</exec_depend>
   <exec_depend>pcl_conversions</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/lidar_localization_component.cpp
+++ b/src/lidar_localization_component.cpp
@@ -227,8 +227,9 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
 CallbackReturn PCLLocalization::on_configure(const rclcpp_lifecycle::State &)
 {
   RCLCPP_INFO(get_logger(), "Configuring");
+  auto state_lock = callback_state_coordinator_.lockState();
 
-  shutting_down_ = false;
+  shutting_down_.store(false, std::memory_order_release);
   initializeParameters();
   initializePubSub();
   initializeRegistration();
@@ -243,6 +244,7 @@ CallbackReturn PCLLocalization::on_configure(const rclcpp_lifecycle::State &)
 CallbackReturn PCLLocalization::on_activate(const rclcpp_lifecycle::State &)
 {
   RCLCPP_INFO(get_logger(), "Activating");
+  auto state_lock = callback_state_coordinator_.lockState();
 
   pose_pub_->on_activate();
   path_pub_->on_activate();
@@ -371,6 +373,7 @@ CallbackReturn PCLLocalization::on_activate(const rclcpp_lifecycle::State &)
 CallbackReturn PCLLocalization::on_deactivate(const rclcpp_lifecycle::State &)
 {
   RCLCPP_INFO(get_logger(), "Deactivating");
+  auto state_lock = callback_state_coordinator_.lockState();
 
 #ifdef LIDAR_LOCALIZATION_HAVE_NAV2_BOND
   if (bond_) {
@@ -415,7 +418,8 @@ CallbackReturn PCLLocalization::on_error(const rclcpp_lifecycle::State & state)
 
 void PCLLocalization::releaseRuntimeResources(bool leak_target_clouds_for_shutdown)
 {
-  shutting_down_ = true;
+  shutting_down_.store(true, std::memory_order_release);
+  auto state_lock = callback_state_coordinator_.lockState();
 
 #ifdef LIDAR_LOCALIZATION_HAVE_NAV2_BOND
   bond_.reset();
@@ -443,6 +447,8 @@ void PCLLocalization::releaseRuntimeResources(bool leak_target_clouds_for_shutdo
   reinitialization_request_pub_.reset();
   pose_pub_.reset();
 
+  auto registration_execution_lock =
+    callback_state_coordinator_.lockRegistrationExecution();
   ndt_initializer_.reset();
   use_ndt_initializer_ = false;
   registration_ = nullptr;
@@ -452,6 +458,7 @@ void PCLLocalization::releaseRuntimeResources(bool leak_target_clouds_for_shutdo
 #ifdef LIDAR_LOCALIZATION_HAVE_SMALL_GICP
   small_gicp_registration_.reset();
 #endif
+  registration_execution_lock.unlock();
 
   {
     std::lock_guard<std::mutex> lock(imu_preintegration_mutex_);
@@ -1191,7 +1198,8 @@ void PCLLocalization::initializeRegistration()
 
 void PCLLocalization::initialPoseReceived(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg)
 {
-  if (shutting_down_) {return;}
+  auto state_lock = callback_state_coordinator_.lockState();
+  if (shutting_down_.load(std::memory_order_acquire)) {return;}
   RCLCPP_INFO(get_logger(), "initialPoseReceived");
   const auto admission = lidar_localization::decideInitialPoseAdmission(
     lidar_localization::InitialPoseAdmissionInput{
@@ -1225,7 +1233,7 @@ void PCLLocalization::initialPoseReceived(const geometry_msgs::msg::PoseWithCova
   }
   initialpose_recieved_ = true;
   last_initial_pose_stamp_sec_ = stamp_to_sec(msg->header.stamp);
-  initial_pose_generation_.fetch_add(1, std::memory_order_release);
+  callback_state_coordinator_.advanceInitialPoseGeneration();
   corrent_pose_with_cov_stamped_ptr_ = msg;
   {
     std::lock_guard<std::mutex> lock(imu_preintegration_mutex_);
@@ -1336,7 +1344,8 @@ void PCLLocalization::initialPoseReceived(const geometry_msgs::msg::PoseWithCova
 
 void PCLLocalization::mapReceived(const sensor_msgs::msg::PointCloud2::SharedPtr msg)
 {
-  if (shutting_down_) {return;}
+  auto state_lock = callback_state_coordinator_.lockState();
+  if (shutting_down_.load(std::memory_order_acquire)) {return;}
   RCLCPP_INFO(get_logger(), "mapReceived");
   pcl::PointCloud<pcl::PointXYZI>::Ptr map_cloud_ptr(new pcl::PointCloud<pcl::PointXYZI>);
 
@@ -1370,7 +1379,8 @@ void PCLLocalization::mapReceived(const sensor_msgs::msg::PointCloud2::SharedPtr
 
 void PCLLocalization::odomReceived(const nav_msgs::msg::Odometry::ConstSharedPtr msg)
 {
-  if (shutting_down_) {return;}
+  auto state_lock = callback_state_coordinator_.lockState();
+  if (shutting_down_.load(std::memory_order_acquire)) {return;}
 
   double current_odom_received_time = msg->header.stamp.sec +
     msg->header.stamp.nanosec * 1e-9;
@@ -1456,7 +1466,8 @@ void PCLLocalization::odomReceived(const nav_msgs::msg::Odometry::ConstSharedPtr
 void PCLLocalization::twistReceived(
   const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr msg)
 {
-  if (shutting_down_) {return;}
+  auto state_lock = callback_state_coordinator_.lockState();
+  if (shutting_down_.load(std::memory_order_acquire)) {return;}
   latest_twist_msg_ = msg;
 
   double stamp_sec = stamp_to_sec(msg->header.stamp);
@@ -1474,7 +1485,7 @@ void PCLLocalization::twistReceived(
 
 void PCLLocalization::imuReceived(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
 {
-  if (shutting_down_) {return;}
+  if (shutting_down_.load(std::memory_order_acquire)) {return;}
   // IMU preintegration buffering (always runs if enabled, independent of use_imu_)
   Eigen::Vector3d preintegration_gyro(
     msg->angular_velocity.x, msg->angular_velocity.y, msg->angular_velocity.z);
@@ -1569,8 +1580,10 @@ void PCLLocalization::imuReceived(const sensor_msgs::msg::Imu::ConstSharedPtr ms
         continuous_time_imu_orientation_ = Eigen::Quaternionf::Identity();
         continuous_time_imu_pose_history_.clear();
       } else if (lidar_localization::isValidImuPreintegrationDt(dt)) {
+        const Eigen::Vector3d deskew_gyro =
+          preintegration_gyro - imu_smoother_.gyro_bias_;
         const Eigen::Vector3f rotation_vector =
-          preintegration_gyro.cast<float>() * static_cast<float>(dt);
+          deskew_gyro.cast<float>() * static_cast<float>(dt);
         const float angle = rotation_vector.norm();
         if (std::isfinite(angle) && angle > 1e-9f) {
           const Eigen::Quaternionf delta(
@@ -1655,6 +1668,8 @@ void PCLLocalization::imuReceived(const sensor_msgs::msg::Imu::ConstSharedPtr ms
 
 void PCLLocalization::cloudReceived(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
+  auto state_lock = callback_state_coordinator_.lockState();
+  if (shutting_down_.load(std::memory_order_acquire)) {return;}
   double scan_stamp_sec = 0.0;
   if (!admitScanMessage(msg, &scan_stamp_sec)) {
     return;
@@ -1669,7 +1684,7 @@ void PCLLocalization::cloudReceived(const sensor_msgs::msg::PointCloud2::ConstSh
   setRegistrationSourceCloud(tmp_ptr);
 
   const std::uint64_t seed_generation =
-    initial_pose_generation_.load(std::memory_order_acquire);
+    callback_state_coordinator_.initialPoseGeneration();
   const SelectedRegistrationSeed selected_seed = selectRegistrationSeed(scan_stamp_sec);
   const bool imu_prediction_ready = selected_seed.imu_prediction_ready;
   const std::string registration_seed_source =
@@ -1680,9 +1695,14 @@ void PCLLocalization::cloudReceived(const sensor_msgs::msg::PointCloud2::ConstSh
     init_guess,
     scan_stamp_sec,
     selected_seed.source,
-    imu_prediction_ready);
+    imu_prediction_ready,
+    state_lock,
+    seed_generation);
 
-  if (initial_pose_generation_.load(std::memory_order_acquire) != seed_generation) {
+  if (
+    shutting_down_.load(std::memory_order_acquire) ||
+    !callback_state_coordinator_.initialPoseGenerationMatches(seed_generation))
+  {
     // An /initialpose was accepted while this scan was being aligned; the seed
     // (and therefore the result) belongs to the pre-reset belief, so applying
     // it would silently undo the reset.
@@ -1726,8 +1746,9 @@ bool PCLLocalization::admitScanMessage(
     current_scan_stamp_sec = stamp_to_sec(msg->header.stamp);
   }
 
+  const bool is_shutting_down = shutting_down_.load(std::memory_order_acquire);
   const bool timing_relevant =
-    !shutting_down_ && static_cast<bool>(msg) && map_recieved_ && initialpose_recieved_;
+    !is_shutting_down && static_cast<bool>(msg) && map_recieved_ && initialpose_recieved_;
   rclcpp::Time now;
   bool has_last_process_time = false;
   double elapsed_since_last_process_sec = 0.0;
@@ -1741,7 +1762,7 @@ bool PCLLocalization::admitScanMessage(
 
   const auto admission = lidar_localization::decideScanAdmission(
     lidar_localization::ScanAdmissionInput{
-      shutting_down_,
+      is_shutting_down,
       static_cast<bool>(msg),
       map_recieved_,
       initialpose_recieved_,
@@ -2544,7 +2565,9 @@ bool PCLLocalization::setInputTargetForPose(const Eigen::Matrix4f & center_pose_
 lidar_localization::AlignmentAttempt PCLLocalization::runAlignmentAttempt(
   const Eigen::Matrix4f & attempt_init_guess,
   const Eigen::Matrix4f & crop_center_pose_matrix,
-  double scan_stamp_sec)
+  double scan_stamp_sec,
+  lidar_localization::CallbackStateCoordinator::StateLock & state_lock,
+  std::uint64_t seed_generation)
 {
   lidar_localization::AlignmentAttempt attempt;
   attempt.init_guess = attempt_init_guess;
@@ -2556,9 +2579,28 @@ lidar_localization::AlignmentAttempt PCLLocalization::runAlignmentAttempt(
   pcl::PointCloud<pcl::PointXYZI> output_cloud;
   rclcpp::Clock system_clock;
   const rclcpp::Time time_align_start = system_clock.now();
-  registration_->align(output_cloud, attempt_init_guess);
+  // Only the backend call runs outside the shared-state lock. All seed, crop,
+  // recovery, and pose fields remain protected, while /initialpose can acquire
+  // the lock and reset state during this expensive operation.
+  state_lock.unlock();
+  try {
+    auto registration_execution_lock =
+      callback_state_coordinator_.lockRegistrationExecution();
+    registration_->align(output_cloud, attempt_init_guess);
+  } catch (...) {
+    state_lock.lock();
+    throw;
+  }
+  state_lock.lock();
   const rclcpp::Time time_align_end = system_clock.now();
   attempt.alignment_time_sec = time_align_end.seconds() - time_align_start.seconds();
+  if (
+    shutting_down_.load(std::memory_order_acquire) ||
+    !callback_state_coordinator_.initialPoseGenerationMatches(seed_generation))
+  {
+    attempt.target_ready = false;
+    return attempt;
+  }
   attempt.has_converged = registration_->hasConverged();
   attempt.fitness_score = registration_->getFitnessScore();
 
@@ -2598,10 +2640,17 @@ lidar_localization::AlignmentPipelineResult PCLLocalization::runAlignmentPipelin
   const Eigen::Matrix4f & init_guess,
   double scan_stamp_sec,
   lidar_localization::RegistrationSeedSource seed_source,
-  bool imu_prediction_ready)
+  bool imu_prediction_ready,
+  lidar_localization::CallbackStateCoordinator::StateLock & state_lock,
+  std::uint64_t seed_generation)
 {
   const lidar_localization::AlignmentAttempt primary_attempt =
-    runAlignmentAttempt(init_guess, init_guess, scan_stamp_sec);
+    runAlignmentAttempt(init_guess, init_guess, scan_stamp_sec, state_lock, seed_generation);
+  if (!callback_state_coordinator_.initialPoseGenerationMatches(seed_generation)) {
+    lidar_localization::AlignmentPipelineResult interrupted_result;
+    interrupted_result.selected_attempt = primary_attempt;
+    return interrupted_result;
+  }
   const int imu_guard_warmup_accepts_remaining =
     imu_guard_warmup_accepts_remaining_.load(std::memory_order_acquire);
   const bool force_retry_from_last_pose =
@@ -2626,7 +2675,8 @@ lidar_localization::AlignmentPipelineResult PCLLocalization::runAlignmentPipelin
       "imu_prediction_correction_guard_rejected"},
     [&]() {
       return runAlignmentAttempt(
-        last_accepted_pose_matrix_, last_accepted_pose_matrix_, scan_stamp_sec);
+        last_accepted_pose_matrix_, last_accepted_pose_matrix_, scan_stamp_sec,
+        state_lock, seed_generation);
     },
     [this](const lidar_localization::AlignmentAttempt & attempt) {
       return evaluateMeasurementGateForAttempt(attempt);
@@ -3331,7 +3381,12 @@ void PCLLocalization::setCurrentPoseFromMatrix(
 
 void PCLLocalization::publishCurrentPose(const builtin_interfaces::msg::Time & stamp)
 {
-  if (shutting_down_ || !pose_pub_ || !corrent_pose_with_cov_stamped_ptr_) {return;}
+  if (
+    shutting_down_.load(std::memory_order_acquire) ||
+    !pose_pub_ || !corrent_pose_with_cov_stamped_ptr_)
+  {
+    return;
+  }
   publishPoseMessage(*corrent_pose_with_cov_stamped_ptr_);
   if (!publishPoseTransform(stamp, corrent_pose_with_cov_stamped_ptr_->pose.pose)) {
     return;
@@ -3802,7 +3857,13 @@ void PCLLocalization::publishAlignmentDiagnosticStatus(
 
 void PCLLocalization::timerPublishPose()
 {
-  if (shutting_down_ || !pose_pub_ || !path_pub_ || !path_ptr_) {return;}
+  auto state_lock = callback_state_coordinator_.lockState();
+  if (
+    shutting_down_.load(std::memory_order_acquire) ||
+    !pose_pub_ || !path_pub_ || !path_ptr_)
+  {
+    return;
+  }
   if (!corrent_pose_with_cov_stamped_ptr_) {return;}
   geometry_msgs::msg::PoseWithCovarianceStamped pose_copy =
     lidar_localization::stampPoseWithCovariance(*corrent_pose_with_cov_stamped_ptr_, now());

--- a/test/test_callback_state_coordinator.cpp
+++ b/test/test_callback_state_coordinator.cpp
@@ -1,0 +1,128 @@
+#include "lidar_localization/callback_state_coordinator.hpp"
+
+#include <atomic>
+#include <cassert>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace
+{
+
+void test_recursive_lifecycle_entry()
+{
+  lidar_localization::CallbackStateCoordinator coordinator;
+  auto lifecycle_lock = coordinator.lockState();
+  auto initial_pose_lock = coordinator.lockState();
+  coordinator.advanceInitialPoseGeneration();
+  assert(coordinator.initialPoseGeneration() == 1);
+}
+
+void test_reset_invalidates_alignment_commit()
+{
+  lidar_localization::CallbackStateCoordinator coordinator;
+  int protected_pose = 10;
+
+  auto scan_lock = coordinator.lockState();
+  const std::uint64_t seed_generation = coordinator.initialPoseGeneration();
+  scan_lock.unlock();  // The expensive registration runs without the state lock.
+
+  std::thread reset_thread([&]() {
+    auto reset_lock = coordinator.lockState();
+    protected_pose = 20;
+    coordinator.advanceInitialPoseGeneration();
+  });
+  reset_thread.join();
+
+  scan_lock.lock();
+  const bool may_commit = coordinator.initialPoseGenerationMatches(seed_generation);
+  if (may_commit) {
+    protected_pose = 30;
+  }
+  assert(!may_commit);
+  assert(protected_pose == 20);
+}
+
+void test_parallel_state_updates_are_serialized()
+{
+  lidar_localization::CallbackStateCoordinator coordinator;
+  int protected_counter = 0;
+  constexpr int kThreadCount = 4;
+  constexpr int kUpdatesPerThread = 5000;
+  std::vector<std::thread> threads;
+  threads.reserve(kThreadCount);
+  for (int thread_index = 0; thread_index < kThreadCount; ++thread_index) {
+    threads.emplace_back([&]() {
+      for (int update = 0; update < kUpdatesPerThread; ++update) {
+        auto state_lock = coordinator.lockState();
+        ++protected_counter;
+      }
+    });
+  }
+  for (auto & thread : threads) {
+    thread.join();
+  }
+  assert(protected_counter == kThreadCount * kUpdatesPerThread);
+}
+
+void test_shutdown_waits_for_registration_without_lock_order_deadlock()
+{
+  lidar_localization::CallbackStateCoordinator coordinator;
+  std::mutex event_mutex;
+  std::condition_variable event;
+  bool registration_started = false;
+  bool allow_registration_to_finish = false;
+  bool shutdown_holds_state = false;
+  bool backend_destroyed = false;
+
+  std::thread scan_thread([&]() {
+    auto state_lock = coordinator.lockState();
+    state_lock.unlock();
+    {
+      auto execution_lock = coordinator.lockRegistrationExecution();
+      std::unique_lock<std::mutex> event_lock(event_mutex);
+      registration_started = true;
+      event.notify_all();
+      event.wait(event_lock, [&]() {return allow_registration_to_finish;});
+      assert(!backend_destroyed);
+    }
+    state_lock.lock();
+  });
+
+  {
+    std::unique_lock<std::mutex> event_lock(event_mutex);
+    event.wait(event_lock, [&]() {return registration_started;});
+  }
+  std::thread shutdown_thread([&]() {
+    auto state_lock = coordinator.lockState();
+    {
+      std::lock_guard<std::mutex> event_lock(event_mutex);
+      shutdown_holds_state = true;
+    }
+    event.notify_all();
+    auto execution_lock = coordinator.lockRegistrationExecution();
+    backend_destroyed = true;
+  });
+
+  {
+    std::unique_lock<std::mutex> event_lock(event_mutex);
+    event.wait(event_lock, [&]() {return shutdown_holds_state;});
+    allow_registration_to_finish = true;
+  }
+  event.notify_all();
+  scan_thread.join();
+  shutdown_thread.join();
+  assert(backend_destroyed);
+}
+
+}  // namespace
+
+int main()
+{
+  test_recursive_lifecycle_entry();
+  test_reset_invalidates_alignment_commit();
+  test_parallel_state_updates_are_serialized();
+  test_shutdown_waits_for_registration_without_lock_order_deadlock();
+  return 0;
+}

--- a/test/test_correspondence_localizability_experiment.py
+++ b/test/test_correspondence_localizability_experiment.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import numpy as np
+
+from experiments.correspondence_localizability.interface import CorrespondenceGeometry
+from experiments.correspondence_localizability.variants import HessianSpectrum
+from experiments.correspondence_localizability.variants import LpicpPlaneLineContribution
+from experiments.correspondence_localizability.variants import XicpDirectionContribution
+
+
+def plane_geometry():
+    x, y = np.meshgrid(np.linspace(-5.0, 5.0, 11), np.linspace(-5.0, 5.0, 11))
+    points = np.column_stack((x.ravel(), y.ravel(), np.zeros(x.size)))
+    return CorrespondenceGeometry(
+        points=points,
+        plane_normals=np.tile([0.0, 0.0, 1.0], (len(points), 1)),
+        plane_mask=np.ones(len(points), dtype=bool),
+        line_directions=np.zeros_like(points),
+        line_mask=np.zeros(len(points), dtype=bool),
+    )
+
+
+def test_single_plane_has_three_unobservable_directions():
+    result = HessianSpectrum().analyze(plane_geometry())
+    assert result.numerical_nullity == 3
+    assert result.weak_ratio == 0.0
+
+
+def test_xicp_variant_exposes_per_direction_support_without_changing_spectrum():
+    baseline = HessianSpectrum().analyze(plane_geometry())
+    xicp = XicpDirectionContribution().analyze(plane_geometry())
+    np.testing.assert_allclose(xicp.eigenvalues, baseline.eigenvalues)
+    assert np.count_nonzero(xicp.direction_effective_support) == 3
+
+
+def test_line_features_supply_information_when_planes_are_absent():
+    t = np.linspace(-5.0, 5.0, 51)
+    points = np.vstack(
+        (
+            np.column_stack((t, np.ones_like(t), np.zeros_like(t))),
+            np.column_stack((np.zeros_like(t), t, np.ones_like(t))),
+            np.column_stack((np.ones_like(t), np.zeros_like(t), t)),
+        )
+    )
+    directions = np.vstack(
+        (
+            np.tile([1.0, 0.0, 0.0], (len(t), 1)),
+            np.tile([0.0, 1.0, 0.0], (len(t), 1)),
+            np.tile([0.0, 0.0, 1.0], (len(t), 1)),
+        )
+    )
+    geometry = CorrespondenceGeometry(
+        points=points,
+        plane_normals=np.zeros_like(points),
+        plane_mask=np.zeros(len(points), dtype=bool),
+        line_directions=directions,
+        line_mask=np.ones(len(points), dtype=bool),
+    )
+    assert HessianSpectrum().analyze(geometry).correspondence_count == 0
+    assert LpicpPlaneLineContribution().analyze(geometry).numerical_nullity == 0
+
+
+if __name__ == "__main__":
+    test_single_plane_has_three_unobservable_directions()
+    test_xicp_variant_exposes_per_direction_support_without_changing_spectrum()
+    test_line_features_supply_information_when_planes_are_absent()

--- a/test/test_imu_bias_correction_experiment.py
+++ b/test/test_imu_bias_correction_experiment.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import unittest
+
+from experiments.imu_bias_correction.interface import BiasFactor
+from experiments.imu_bias_correction.variants import LatestFactorOnly
+from experiments.imu_bias_correction.variants import PerFactorBiasSnapshot
+from experiments.imu_bias_correction.variants import UncorrectedFactors
+
+
+def make_factor(true_rate, sensor_bias, integration_bias, current_bias, duration):
+    return BiasFactor(
+        measured_delta_rad=(true_rate + sensor_bias - integration_bias) * duration,
+        integration_bias_rad_s=integration_bias,
+        current_bias_rad_s=current_bias,
+        duration_sec=duration,
+        expected_delta_rad=true_rate * duration,
+    )
+
+
+class ImuBiasCorrectionExperimentTest(unittest.TestCase):
+    def test_every_factor_requires_its_own_linearization_bias(self):
+        factors = [
+            make_factor(0.20, 0.012, 0.000, 0.012, 0.5),
+            make_factor(-0.10, 0.012, 0.005, 0.012, 0.8),
+            make_factor(0.05, 0.012, 0.010, 0.012, 1.2),
+        ]
+        expected = [factor.expected_delta_rad for factor in factors]
+
+        baseline = UncorrectedFactors().correct(factors)
+        latest_only = LatestFactorOnly().correct(factors)
+        per_factor = PerFactorBiasSnapshot().correct(factors)
+
+        self.assertGreater(max(abs(a - b) for a, b in zip(baseline, expected)), 1e-3)
+        self.assertGreater(max(abs(a - b) for a, b in zip(latest_only, expected)), 1e-3)
+        self.assertLess(max(abs(a - b) for a, b in zip(per_factor, expected)), 1e-12)
+
+    def test_correction_is_noop_when_bias_did_not_change(self):
+        factors = [make_factor(0.3, 0.01, 0.01, 0.01, 0.4)]
+        for strategy in (UncorrectedFactors(), LatestFactorOnly(), PerFactorBiasSnapshot()):
+            self.assertAlmostEqual(
+                strategy.correct(factors)[0], factors[0].expected_delta_rad, places=12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_kiss_matcher_verifier_experiment.py
+++ b/test/test_kiss_matcher_verifier_experiment.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import math
+
+from experiments.kiss_matcher_verifier.interface import Candidate
+from experiments.kiss_matcher_verifier.interface import GlobalEstimate
+from experiments.kiss_matcher_verifier.variants import BbsFirstSelector
+from experiments.kiss_matcher_verifier.variants import KissNearestSelector
+
+
+def candidates():
+    return [
+        Candidate("a", 0, 10.0, 0.0, 0.0, False),
+        Candidate("a", 1, 1.0, 2.0, 0.1, True),
+    ]
+
+
+def test_bbs_selector_preserves_candidate_index_order():
+    selected = BbsFirstSelector().select(reversed(candidates()))
+    assert selected.accepted
+    assert selected.candidate.candidate_index == 0
+
+
+def test_kiss_selector_recovers_nearest_top_k_candidate():
+    estimate = GlobalEstimate(True, 1.1, 2.1, 0.12, 12, 0.2)
+    selected = KissNearestSelector().select(candidates(), estimate)
+    assert selected.accepted
+    assert selected.candidate.candidate_index == 1
+
+
+def test_kiss_selector_abstains_on_weak_or_distant_estimate():
+    weak = GlobalEstimate(True, 1.0, 2.0, 0.1, 4, 0.2)
+    assert KissNearestSelector().select(candidates(), weak).reason == "insufficient_final_inliers"
+    distant = GlobalEstimate(True, 50.0, 50.0, math.pi, 20, 0.2)
+    result = KissNearestSelector().select(candidates(), distant)
+    assert not result.accepted
+    assert result.reason == "translation_delta_above_threshold"
+
+
+if __name__ == "__main__":
+    test_bbs_selector_preserves_candidate_index_order()
+    test_kiss_selector_recovers_nearest_top_k_candidate()
+    test_kiss_selector_abstains_on_weak_or_distant_estimate()


### PR DESCRIPTION
## What changed

- fixes Eigen dependency propagation for ROS 2 builds
- serializes mutable callback state and protects registration backend lifetime during shutdown
- corrects per-factor IMU bias handling and gyro-bias use in pose history
- adds reproducible KISS-Matcher verifier, IMU bias, and correspondence-localizability experiments
- records Koide bag A/B results, including rejected candidates and safety gates
- synchronizes generated experiment decision/interface documentation

## Why

MultiThreadedExecutor callbacks could race with initial-pose resets and lifecycle teardown, while IMU factors did not retain the bias snapshot used during integration. Research candidates also needed repeatable accuracy, recovery, false-accept, latency, and safety evaluation before runtime adoption.

## Impact

The runtime keeps the bounded NDT verifier and conservative IMU defaults. Correctness fixes and concurrency protection are adopted; KISS-Matcher and LP-ICP/X-ICP-inspired diagnostics remain offline research tools because they did not clear the promotion gates.

## Validation

- ROS 2 Jazzy build passed
- CTest: 68/68 passed
- callback-state concurrency stress: 1000 repetitions passed
- Koide real-bag repeated A/B evaluation completed
- full experiment suite completed
- `git diff --check` passed

Humble CI and TSAN remain environment-limited; the limitation is documented.
