### PR TITLE
Evaluate startup false-convergence guards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ install(PROGRAMS
   scripts/run_nav2_reinit_supervisor_regression.sh
   scripts/run_recovery_action_experiments.py
   scripts/run_reinit_trigger_experiments.py
+  scripts/run_startup_integrity_experiments.py
   scripts/run_public_demo.sh
   scripts/run_public_validation_dashboard.sh
   scripts/run_v1_1_relocalization_smoke.sh
@@ -547,6 +548,14 @@ if(BUILD_TESTING)
       ${CMAKE_CURRENT_SOURCE_DIR}/test/test_correspondence_localizability_experiment.py
   )
   set_tests_properties(correspondence_localizability_experiment PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}")
+
+  add_test(
+    NAME startup_integrity_experiment
+    COMMAND ${Python3_EXECUTABLE}
+      -m pytest -q ${CMAKE_CURRENT_SOURCE_DIR}/test/test_startup_integrity_experiment.py
+  )
+  set_tests_properties(startup_integrity_experiment PROPERTIES
     ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}")
 
   add_executable(test_bbs_branch_and_bound

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -60,3 +60,10 @@
 - extensibility score: `94.0`
 - nearest alternative: `failure_kind_eager_reinit` at `78.08`
 - generated_from: `scripts/run_reinit_trigger_experiments.py`
+
+## Startup False-Convergence Integrity Monitor
+
+- runtime promotion: `none`
+- leading comparator: `peak_innovation` at `74.82`
+- reason: No candidate passes every repeated closed-loop fixture: correction-budget variants false-trigger on indoor_easy_02_live_r02 and miss indoor_kidnap_01_live_r02, while peak and fitness variants miss kidnaps.
+- generated_from: `scripts/run_startup_integrity_experiments.py`

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -174,3 +174,57 @@ Decide when bounded local recovery should stop and the system should escalate to
 - `seed_reuse_candidate_should_not_reinit`: pass=`True` decision=`stay_in_local_recovery` reason=`stay_in_local_recovery`
 - `short_gap_rejected_measurement_should_not_reinit`: pass=`True` decision=`stay_in_local_recovery` reason=`stay_in_local_recovery`
 - `short_gap_target_unavailable_should_not_reinit`: pass=`True` decision=`stay_in_local_recovery` reason=`stay_in_local_recovery`
+
+## Startup False-Convergence Integrity Monitor
+
+Detect a self-consistent but wrong NDT basin during the first five accepted updates, where scalar fitness remains healthy, without rejecting bounded Koide indoor startups.
+
+| Variant | Design | Benchmark | Readability | Extensibility | Overall |
+|---|---|---:|---:|---:|---:|
+| `peak_innovation` | single-update translation or yaw correction threshold | 71.4 | 65.8 | 94.0 | 74.82 |
+| `cumulative_translation` | startup cumulative translation-correction budget | 71.4 | 66.8 | 89.0 | 74.02 |
+| `normalized_innovation_energy` | startup normalized translation/yaw correction energy | 71.4 | 64.4 | 89.0 | 73.54 |
+| `fitness_only` | scalar NDT fitness threshold | 57.1 | 80.6 | 94.0 | 69.21 |
+
+### Research Context
+
+- [Scan Context: Egocentric Spatial Descriptor for Place Recognition Within 3D Point Cloud Map](https://gisbi-kim.github.io/publications/gkim-2018-iros.pdf): an independent global place descriptor can challenge a locally self-consistent NDT basin
+- [NDT-Transformer: Large-Scale 3D Point Cloud Localisation using the Normal Distribution Transform Representation](https://arxiv.org/abs/2103.12292): global retrieval over NDT-cell descriptors is a second candidate verifier family, separate from local registration fitness
+
+### Fixture Outcomes
+
+#### `peak_innovation`
+- `koide_indoor_easy_01`: pass=`True` decision=`no_trigger` reason=`must_not_trigger`
+- `koide_indoor_easy_02`: pass=`True` decision=`no_trigger` reason=`must_not_trigger`
+- `koide_indoor_easy_02_live_r02`: pass=`True` decision=`no_trigger` reason=`must_not_trigger`
+- `koide_indoor_hard_01`: pass=`True` decision=`no_trigger` reason=`must_not_trigger`
+- `koide_indoor_kidnap_01`: pass=`True` decision=`trigger_at_4` reason=`startup_peak_innovation`
+- `koide_indoor_kidnap_01_live_r02`: pass=`False` decision=`no_trigger` reason=`missing_trigger`
+- `koide_indoor_kidnap_02`: pass=`False` decision=`no_trigger` reason=`missing_trigger`
+
+#### `cumulative_translation`
+- `koide_indoor_easy_01`: pass=`True` decision=`no_trigger` reason=`must_not_trigger`
+- `koide_indoor_easy_02`: pass=`True` decision=`no_trigger` reason=`must_not_trigger`
+- `koide_indoor_easy_02_live_r02`: pass=`False` decision=`trigger_at_2` reason=`startup_translation_budget_exceeded`
+- `koide_indoor_hard_01`: pass=`True` decision=`no_trigger` reason=`must_not_trigger`
+- `koide_indoor_kidnap_01`: pass=`True` decision=`trigger_at_3` reason=`startup_translation_budget_exceeded`
+- `koide_indoor_kidnap_01_live_r02`: pass=`False` decision=`no_trigger` reason=`missing_trigger`
+- `koide_indoor_kidnap_02`: pass=`True` decision=`trigger_at_4` reason=`startup_translation_budget_exceeded`
+
+#### `normalized_innovation_energy`
+- `koide_indoor_easy_01`: pass=`True` decision=`no_trigger` reason=`must_not_trigger`
+- `koide_indoor_easy_02`: pass=`True` decision=`no_trigger` reason=`must_not_trigger`
+- `koide_indoor_easy_02_live_r02`: pass=`False` decision=`trigger_at_2` reason=`startup_innovation_energy_exceeded`
+- `koide_indoor_hard_01`: pass=`True` decision=`no_trigger` reason=`must_not_trigger`
+- `koide_indoor_kidnap_01`: pass=`True` decision=`trigger_at_1` reason=`startup_innovation_energy_exceeded`
+- `koide_indoor_kidnap_01_live_r02`: pass=`False` decision=`no_trigger` reason=`missing_trigger`
+- `koide_indoor_kidnap_02`: pass=`True` decision=`trigger_at_4` reason=`startup_innovation_energy_exceeded`
+
+#### `fitness_only`
+- `koide_indoor_easy_01`: pass=`True` decision=`no_trigger` reason=`must_not_trigger`
+- `koide_indoor_easy_02`: pass=`True` decision=`no_trigger` reason=`must_not_trigger`
+- `koide_indoor_easy_02_live_r02`: pass=`True` decision=`no_trigger` reason=`must_not_trigger`
+- `koide_indoor_hard_01`: pass=`True` decision=`no_trigger` reason=`must_not_trigger`
+- `koide_indoor_kidnap_01`: pass=`False` decision=`no_trigger` reason=`missing_trigger`
+- `koide_indoor_kidnap_01_live_r02`: pass=`False` decision=`no_trigger` reason=`missing_trigger`
+- `koide_indoor_kidnap_02`: pass=`False` decision=`no_trigger` reason=`missing_trigger`

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -205,3 +205,43 @@ Decide when bounded local recovery should stop and the system should escalate to
 - `gap_streak_score_reinit`: scorecard threshold
 - `failure_kind_eager_reinit`: event-driven rule table
 - `never_reinit`: minimal baseline
+
+
+## Startup False-Convergence Integrity Monitor
+
+Detect a self-consistent but wrong NDT basin during the first five accepted updates, where scalar fitness remains healthy, without rejecting bounded Koide indoor startups.
+
+### Minimal Interface
+
+- `reset() -> None`
+- `step(sample: StartupIntegritySample) -> StartupIntegrityDecision`
+
+### `StartupIntegritySample` fields
+
+- `index`
+- `fitness_score`
+- `correction_translation_m`
+- `correction_yaw_deg`
+
+### `StartupIntegrityDecision` fields
+
+- `request_reinitialization`
+- `reason`
+- `score`
+
+### Shared Fixtures
+
+- `koide_indoor_easy_01`: Bounded Koide indoor_easy_01 startup; any trigger is a false positive.
+- `koide_indoor_easy_02`: Bounded Koide indoor_easy_02 startup with a 0.39 m first correction; it must not trigger.
+- `koide_indoor_easy_02_live_r02`: A second bounded indoor_easy_02 replay with larger startup corrections; it exposes false-trigger overfitting.
+- `koide_indoor_hard_01`: Initially bounded Koide indoor_hard_01 startup; a detector must not pre-emptively trigger.
+- `koide_indoor_kidnap_01`: Koide indoor_kidnap_01 aliases to a wrong pose despite low NDT fitness; trigger by update four.
+- `koide_indoor_kidnap_01_live_r02`: A second aliased indoor_kidnap_01 replay with bounded first-five corrections; it exposes missed detections.
+- `koide_indoor_kidnap_02`: Koide indoor_kidnap_02 diverges through moderate repeated corrections; trigger by update four.
+
+### Candidate Families
+
+- `peak_innovation`: single-update translation or yaw correction threshold
+- `cumulative_translation`: startup cumulative translation-correction budget
+- `normalized_innovation_energy`: startup normalized translation/yaw correction energy
+- `fitness_only`: scalar NDT fitness threshold

--- a/experiments/reporting.py
+++ b/experiments/reporting.py
@@ -174,6 +174,14 @@ def write_experiments_doc(repo_root: Path, results: list[dict[str, Any]]) -> Non
                 f"{variant['benchmark_score']:.1f} | {variant['readability_score']:.1f} | "
                 f"{variant['extensibility_score']:.1f} | {variant['overall_score']:.2f} |"
             )
+        research_context = result.get("research_context", [])
+        if research_context:
+            lines += ["", "### Research Context", ""]
+            for reference in research_context:
+                lines.append(
+                    f"- [{reference['title']}]({reference['url']}): "
+                    f"{reference['relevance']}"
+                )
         lines += [
             "",
             "### Fixture Outcomes",
@@ -212,6 +220,17 @@ def write_decisions_doc(repo_root: Path, results: list[dict[str, Any]]) -> None:
     for result in results:
         best = result["variants"][0]
         runner_up = result["variants"][1] if len(result["variants"]) > 1 else None
+        if result.get("promotion_decision") == "no_promotion":
+            lines += [
+                f"## {result['title']}",
+                "",
+                "- runtime promotion: `none`",
+                f"- leading comparator: `{best['name']}` at `{best['overall_score']}`",
+                f"- reason: {result['promotion_reason']}",
+                f"- generated_from: `{result['generated_from']}`",
+                "",
+            ]
+            continue
         lines += [
             f"## {result['title']}",
             "",

--- a/experiments/startup_integrity/__init__.py
+++ b/experiments/startup_integrity/__init__.py
@@ -1,0 +1,1 @@
+"""Offline startup-integrity experiments for false-convergence detection."""

--- a/experiments/startup_integrity/fixtures/koide_indoor_easy_01.json
+++ b/experiments/startup_integrity/fixtures/koide_indoor_easy_01.json
@@ -1,0 +1,16 @@
+{
+  "name": "koide_indoor_easy_01",
+  "description": "Bounded Koide indoor_easy_01 startup; any trigger is a false positive.",
+  "source": "Koide indoor_easy_01 30 s replay, alignment_status.csv, first eight updates",
+  "expectation": {"must_not_trigger": true},
+  "samples": [
+    {"index": 0, "fitness_score": 0.037697, "correction_translation_m": 0.013118, "correction_yaw_deg": 0.357454},
+    {"index": 1, "fitness_score": 0.039447, "correction_translation_m": 0.014137, "correction_yaw_deg": 0.375205},
+    {"index": 2, "fitness_score": 0.044007, "correction_translation_m": 0.021153, "correction_yaw_deg": 0.119428},
+    {"index": 3, "fitness_score": 0.030847, "correction_translation_m": 0.015485, "correction_yaw_deg": 0.585723},
+    {"index": 4, "fitness_score": 0.032225, "correction_translation_m": 0.023302, "correction_yaw_deg": 0.030502},
+    {"index": 5, "fitness_score": 0.038326, "correction_translation_m": 0.037642, "correction_yaw_deg": 1.202182},
+    {"index": 6, "fitness_score": 0.034090, "correction_translation_m": 0.059343, "correction_yaw_deg": 1.120683},
+    {"index": 7, "fitness_score": 0.037813, "correction_translation_m": 0.045171, "correction_yaw_deg": 0.409448}
+  ]
+}

--- a/experiments/startup_integrity/fixtures/koide_indoor_easy_02.json
+++ b/experiments/startup_integrity/fixtures/koide_indoor_easy_02.json
@@ -1,0 +1,16 @@
+{
+  "name": "koide_indoor_easy_02",
+  "description": "Bounded Koide indoor_easy_02 startup with a 0.39 m first correction; it must not trigger.",
+  "source": "Koide indoor_easy_02 30 s replay, alignment_status.csv, first eight updates",
+  "expectation": {"must_not_trigger": true},
+  "samples": [
+    {"index": 0, "fitness_score": 0.233906, "correction_translation_m": 0.385473, "correction_yaw_deg": 1.478184},
+    {"index": 1, "fitness_score": 0.034110, "correction_translation_m": 0.326145, "correction_yaw_deg": 1.773128},
+    {"index": 2, "fitness_score": 0.492046, "correction_translation_m": 0.106934, "correction_yaw_deg": 0.109045},
+    {"index": 3, "fitness_score": 0.159069, "correction_translation_m": 0.070144, "correction_yaw_deg": 0.266367},
+    {"index": 4, "fitness_score": 0.207277, "correction_translation_m": 0.009597, "correction_yaw_deg": 0.708560},
+    {"index": 5, "fitness_score": 0.613096, "correction_translation_m": 0.101608, "correction_yaw_deg": 0.319710},
+    {"index": 6, "fitness_score": 0.036913, "correction_translation_m": 0.164676, "correction_yaw_deg": 1.925337},
+    {"index": 7, "fitness_score": 0.039935, "correction_translation_m": 0.095763, "correction_yaw_deg": 1.600432}
+  ]
+}

--- a/experiments/startup_integrity/fixtures/koide_indoor_easy_02_live_r02.json
+++ b/experiments/startup_integrity/fixtures/koide_indoor_easy_02_live_r02.json
@@ -1,0 +1,16 @@
+{
+  "name": "koide_indoor_easy_02_live_r02",
+  "description": "A second bounded indoor_easy_02 replay with larger startup corrections; it exposes false-trigger overfitting.",
+  "source": "Koide indoor_easy_02 closed-loop replay 2026-07-14, alignment_status.csv, first eight updates",
+  "expectation": {"must_not_trigger": true},
+  "samples": [
+    {"index": 0, "fitness_score": 0.233906, "correction_translation_m": 0.385473, "correction_yaw_deg": 1.478184},
+    {"index": 1, "fitness_score": 0.041242, "correction_translation_m": 0.306726, "correction_yaw_deg": 3.720954},
+    {"index": 2, "fitness_score": 0.016533, "correction_translation_m": 0.429343, "correction_yaw_deg": 2.606130},
+    {"index": 3, "fitness_score": 0.034298, "correction_translation_m": 0.322477, "correction_yaw_deg": 3.489692},
+    {"index": 4, "fitness_score": 0.068458, "correction_translation_m": 0.707079, "correction_yaw_deg": 6.854547},
+    {"index": 5, "fitness_score": 0.075410, "correction_translation_m": 0.379868, "correction_yaw_deg": 3.123085},
+    {"index": 6, "fitness_score": 0.047631, "correction_translation_m": 0.309563, "correction_yaw_deg": 5.218207},
+    {"index": 7, "fitness_score": 0.019831, "correction_translation_m": 0.165545, "correction_yaw_deg": 1.644413}
+  ]
+}

--- a/experiments/startup_integrity/fixtures/koide_indoor_hard_01.json
+++ b/experiments/startup_integrity/fixtures/koide_indoor_hard_01.json
@@ -1,0 +1,16 @@
+{
+  "name": "koide_indoor_hard_01",
+  "description": "Initially bounded Koide indoor_hard_01 startup; a detector must not pre-emptively trigger.",
+  "source": "Koide indoor_hard_01 30 s replay, alignment_status.csv, first eight updates",
+  "expectation": {"must_not_trigger": true},
+  "samples": [
+    {"index": 0, "fitness_score": 0.020081, "correction_translation_m": 0.028799, "correction_yaw_deg": 0.718098},
+    {"index": 1, "fitness_score": 0.003029, "correction_translation_m": 0.028119, "correction_yaw_deg": 0.904169},
+    {"index": 2, "fitness_score": 0.009491, "correction_translation_m": 0.007976, "correction_yaw_deg": 0.104873},
+    {"index": 3, "fitness_score": 0.012832, "correction_translation_m": 0.038506, "correction_yaw_deg": 0.336622},
+    {"index": 4, "fitness_score": 0.008401, "correction_translation_m": 0.040364, "correction_yaw_deg": 0.321375},
+    {"index": 5, "fitness_score": 0.004529, "correction_translation_m": 0.029175, "correction_yaw_deg": 0.416777},
+    {"index": 6, "fitness_score": 0.006790, "correction_translation_m": 0.016891, "correction_yaw_deg": 0.187251},
+    {"index": 7, "fitness_score": 0.007315, "correction_translation_m": 0.052491, "correction_yaw_deg": 0.151392}
+  ]
+}

--- a/experiments/startup_integrity/fixtures/koide_indoor_kidnap_01.json
+++ b/experiments/startup_integrity/fixtures/koide_indoor_kidnap_01.json
@@ -1,0 +1,16 @@
+{
+  "name": "koide_indoor_kidnap_01",
+  "description": "Koide indoor_kidnap_01 aliases to a wrong pose despite low NDT fitness; trigger by update four.",
+  "source": "Koide indoor_kidnap_01 30 s replay, alignment_status.csv, first eight updates; 11.10 m translation RMSE",
+  "expectation": {"should_trigger_by_index": 4},
+  "samples": [
+    {"index": 0, "fitness_score": 0.255351, "correction_translation_m": 0.359377, "correction_yaw_deg": 3.632233},
+    {"index": 1, "fitness_score": 0.250973, "correction_translation_m": 0.402504, "correction_yaw_deg": 5.128694},
+    {"index": 2, "fitness_score": 0.257884, "correction_translation_m": 0.298730, "correction_yaw_deg": 2.836114},
+    {"index": 3, "fitness_score": 0.256195, "correction_translation_m": 0.390997, "correction_yaw_deg": 5.184278},
+    {"index": 4, "fitness_score": 0.174225, "correction_translation_m": 1.226247, "correction_yaw_deg": 8.938875},
+    {"index": 5, "fitness_score": 0.179532, "correction_translation_m": 0.153959, "correction_yaw_deg": 5.307234},
+    {"index": 6, "fitness_score": 0.108636, "correction_translation_m": 0.289807, "correction_yaw_deg": 3.528120},
+    {"index": 7, "fitness_score": 0.099561, "correction_translation_m": 0.512177, "correction_yaw_deg": 8.249064}
+  ]
+}

--- a/experiments/startup_integrity/fixtures/koide_indoor_kidnap_01_live_r02.json
+++ b/experiments/startup_integrity/fixtures/koide_indoor_kidnap_01_live_r02.json
@@ -1,0 +1,16 @@
+{
+  "name": "koide_indoor_kidnap_01_live_r02",
+  "description": "A second aliased indoor_kidnap_01 replay with bounded first-five corrections; it exposes missed detections.",
+  "source": "Koide indoor_kidnap_01 closed-loop replay 2026-07-14, alignment_status.csv, first eight updates; 7.99 m translation RMSE",
+  "expectation": {"should_trigger_by_index": 4},
+  "samples": [
+    {"index": 0, "fitness_score": 0.355233, "correction_translation_m": 0.323035, "correction_yaw_deg": 3.082170},
+    {"index": 1, "fitness_score": 0.282798, "correction_translation_m": 0.275087, "correction_yaw_deg": 2.314930},
+    {"index": 2, "fitness_score": 0.270136, "correction_translation_m": 0.167076, "correction_yaw_deg": 0.391755},
+    {"index": 3, "fitness_score": 0.286703, "correction_translation_m": 0.113692, "correction_yaw_deg": 0.838790},
+    {"index": 4, "fitness_score": 0.307123, "correction_translation_m": 0.127422, "correction_yaw_deg": 1.441421},
+    {"index": 5, "fitness_score": 2.731270, "correction_translation_m": 0.139371, "correction_yaw_deg": 11.291606},
+    {"index": 6, "fitness_score": 3.033228, "correction_translation_m": 0.447004, "correction_yaw_deg": 1.958738},
+    {"index": 7, "fitness_score": 0.335211, "correction_translation_m": 0.378505, "correction_yaw_deg": 10.096553}
+  ]
+}

--- a/experiments/startup_integrity/fixtures/koide_indoor_kidnap_02.json
+++ b/experiments/startup_integrity/fixtures/koide_indoor_kidnap_02.json
@@ -1,0 +1,16 @@
+{
+  "name": "koide_indoor_kidnap_02",
+  "description": "Koide indoor_kidnap_02 diverges through moderate repeated corrections; trigger by update four.",
+  "source": "Koide indoor_kidnap_02 30 s replay, alignment_status.csv, first eight updates; 9.81 m translation RMSE",
+  "expectation": {"should_trigger_by_index": 4},
+  "samples": [
+    {"index": 0, "fitness_score": 0.297552, "correction_translation_m": 0.436340, "correction_yaw_deg": 3.819970},
+    {"index": 1, "fitness_score": 0.230090, "correction_translation_m": 0.078306, "correction_yaw_deg": 2.406117},
+    {"index": 2, "fitness_score": 0.203794, "correction_translation_m": 0.185685, "correction_yaw_deg": 1.567979},
+    {"index": 3, "fitness_score": 0.206986, "correction_translation_m": 0.364062, "correction_yaw_deg": 1.475832},
+    {"index": 4, "fitness_score": 0.194832, "correction_translation_m": 0.278289, "correction_yaw_deg": 2.884912},
+    {"index": 5, "fitness_score": 0.186300, "correction_translation_m": 0.125627, "correction_yaw_deg": 1.179311},
+    {"index": 6, "fitness_score": 0.174125, "correction_translation_m": 0.514947, "correction_yaw_deg": 0.404047},
+    {"index": 7, "fitness_score": 0.170978, "correction_translation_m": 0.015394, "correction_yaw_deg": 0.220586}
+  ]
+}

--- a/experiments/startup_integrity/interface.py
+++ b/experiments/startup_integrity/interface.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class StartupIntegritySample:
+    index: int
+    fitness_score: float
+    correction_translation_m: float
+    correction_yaw_deg: float
+
+
+@dataclass(frozen=True)
+class StartupIntegrityDecision:
+    request_reinitialization: bool
+    reason: str
+    score: Optional[float] = None
+
+
+class StartupIntegrityStrategy(Protocol):
+    name: str
+    design: str
+
+    def reset(self) -> None:
+        ...
+
+    def step(self, sample: StartupIntegritySample) -> StartupIntegrityDecision:
+        ...

--- a/experiments/startup_integrity/results.json
+++ b/experiments/startup_integrity/results.json
@@ -1,0 +1,391 @@
+{
+  "problem": "startup_integrity",
+  "title": "Startup False-Convergence Integrity Monitor",
+  "problem_statement": "Detect a self-consistent but wrong NDT basin during the first five accepted updates, where scalar fitness remains healthy, without rejecting bounded Koide indoor startups.",
+  "generated_from": "scripts/run_startup_integrity_experiments.py",
+  "promotion_decision": "no_promotion",
+  "promotion_reason": "No candidate passes every repeated closed-loop fixture: correction-budget variants false-trigger on indoor_easy_02_live_r02 and miss indoor_kidnap_01_live_r02, while peak and fitness variants miss kidnaps.",
+  "research_context": [
+    {
+      "title": "Scan Context: Egocentric Spatial Descriptor for Place Recognition Within 3D Point Cloud Map",
+      "url": "https://gisbi-kim.github.io/publications/gkim-2018-iros.pdf",
+      "relevance": "an independent global place descriptor can challenge a locally self-consistent NDT basin"
+    },
+    {
+      "title": "NDT-Transformer: Large-Scale 3D Point Cloud Localisation using the Normal Distribution Transform Representation",
+      "url": "https://arxiv.org/abs/2103.12292",
+      "relevance": "global retrieval over NDT-cell descriptors is a second candidate verifier family, separate from local registration fitness"
+    }
+  ],
+  "interface": {
+    "methods": [
+      "reset() -> None",
+      "step(sample: StartupIntegritySample) -> StartupIntegrityDecision"
+    ],
+    "sample_type": "StartupIntegritySample",
+    "sample_fields": [
+      "index",
+      "fitness_score",
+      "correction_translation_m",
+      "correction_yaw_deg"
+    ],
+    "decision_type": "StartupIntegrityDecision",
+    "decision_fields": [
+      "request_reinitialization",
+      "reason",
+      "score"
+    ]
+  },
+  "fixtures": [
+    {
+      "name": "koide_indoor_easy_01",
+      "description": "Bounded Koide indoor_easy_01 startup; any trigger is a false positive.",
+      "source": "Koide indoor_easy_01 30 s replay, alignment_status.csv, first eight updates"
+    },
+    {
+      "name": "koide_indoor_easy_02",
+      "description": "Bounded Koide indoor_easy_02 startup with a 0.39 m first correction; it must not trigger.",
+      "source": "Koide indoor_easy_02 30 s replay, alignment_status.csv, first eight updates"
+    },
+    {
+      "name": "koide_indoor_easy_02_live_r02",
+      "description": "A second bounded indoor_easy_02 replay with larger startup corrections; it exposes false-trigger overfitting.",
+      "source": "Koide indoor_easy_02 closed-loop replay 2026-07-14, alignment_status.csv, first eight updates"
+    },
+    {
+      "name": "koide_indoor_hard_01",
+      "description": "Initially bounded Koide indoor_hard_01 startup; a detector must not pre-emptively trigger.",
+      "source": "Koide indoor_hard_01 30 s replay, alignment_status.csv, first eight updates"
+    },
+    {
+      "name": "koide_indoor_kidnap_01",
+      "description": "Koide indoor_kidnap_01 aliases to a wrong pose despite low NDT fitness; trigger by update four.",
+      "source": "Koide indoor_kidnap_01 30 s replay, alignment_status.csv, first eight updates; 11.10 m translation RMSE"
+    },
+    {
+      "name": "koide_indoor_kidnap_01_live_r02",
+      "description": "A second aliased indoor_kidnap_01 replay with bounded first-five corrections; it exposes missed detections.",
+      "source": "Koide indoor_kidnap_01 closed-loop replay 2026-07-14, alignment_status.csv, first eight updates; 7.99 m translation RMSE"
+    },
+    {
+      "name": "koide_indoor_kidnap_02",
+      "description": "Koide indoor_kidnap_02 diverges through moderate repeated corrections; trigger by update four.",
+      "source": "Koide indoor_kidnap_02 30 s replay, alignment_status.csv, first eight updates; 9.81 m translation RMSE"
+    }
+  ],
+  "variants": [
+    {
+      "name": "peak_innovation",
+      "design": "single-update translation or yaw correction threshold",
+      "fixture_results": [
+        {
+          "fixture": "koide_indoor_easy_01",
+          "passed": true,
+          "outcome": "must_not_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_easy_02",
+          "passed": true,
+          "outcome": "must_not_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_easy_02_live_r02",
+          "passed": true,
+          "outcome": "must_not_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_hard_01",
+          "passed": true,
+          "outcome": "must_not_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_kidnap_01",
+          "passed": true,
+          "outcome": "within_expected_window",
+          "trigger_index": 4,
+          "trigger_reason": "startup_peak_innovation",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_kidnap_01_live_r02",
+          "passed": false,
+          "outcome": "missing_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_kidnap_02",
+          "passed": false,
+          "outcome": "missing_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        }
+      ],
+      "benchmark_score": 71.42857142857143,
+      "readability_score": 65.8,
+      "extensibility_score": 94.0,
+      "static_metrics": {
+        "implementation_file": "experiments/startup_integrity/variants/peak_innovation.py",
+        "loc": 16,
+        "branch_count": 3,
+        "max_nesting_depth": 0,
+        "state_field_count": 1,
+        "public_method_count": 2,
+        "import_count": 4,
+        "has_config_dataclass": true,
+        "readability_score": 65.8,
+        "extensibility_score": 94.0
+      },
+      "overall_score": 74.82
+    },
+    {
+      "name": "cumulative_translation",
+      "design": "startup cumulative translation-correction budget",
+      "fixture_results": [
+        {
+          "fixture": "koide_indoor_easy_01",
+          "passed": true,
+          "outcome": "must_not_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_easy_02",
+          "passed": true,
+          "outcome": "must_not_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_easy_02_live_r02",
+          "passed": false,
+          "outcome": "must_not_trigger",
+          "trigger_index": 2,
+          "trigger_reason": "startup_translation_budget_exceeded",
+          "trigger_score": 1.121542
+        },
+        {
+          "fixture": "koide_indoor_hard_01",
+          "passed": true,
+          "outcome": "must_not_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_kidnap_01",
+          "passed": true,
+          "outcome": "within_expected_window",
+          "trigger_index": 3,
+          "trigger_reason": "startup_translation_budget_exceeded",
+          "trigger_score": 1.451608
+        },
+        {
+          "fixture": "koide_indoor_kidnap_01_live_r02",
+          "passed": false,
+          "outcome": "missing_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_kidnap_02",
+          "passed": true,
+          "outcome": "within_expected_window",
+          "trigger_index": 4,
+          "trigger_reason": "startup_translation_budget_exceeded",
+          "trigger_score": 1.342682
+        }
+      ],
+      "benchmark_score": 71.42857142857143,
+      "readability_score": 66.8,
+      "extensibility_score": 89.0,
+      "static_metrics": {
+        "implementation_file": "experiments/startup_integrity/variants/cumulative_translation.py",
+        "loc": 16,
+        "branch_count": 2,
+        "max_nesting_depth": 1,
+        "state_field_count": 2,
+        "public_method_count": 2,
+        "import_count": 4,
+        "has_config_dataclass": true,
+        "readability_score": 66.8,
+        "extensibility_score": 89.0
+      },
+      "overall_score": 74.02
+    },
+    {
+      "name": "normalized_innovation_energy",
+      "design": "startup normalized translation/yaw correction energy",
+      "fixture_results": [
+        {
+          "fixture": "koide_indoor_easy_01",
+          "passed": true,
+          "outcome": "must_not_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_easy_02",
+          "passed": true,
+          "outcome": "must_not_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_easy_02_live_r02",
+          "passed": false,
+          "outcome": "must_not_trigger",
+          "trigger_index": 2,
+          "trigger_reason": "startup_innovation_energy_exceeded",
+          "trigger_score": 4.095188039391999
+        },
+        {
+          "fixture": "koide_indoor_hard_01",
+          "passed": true,
+          "outcome": "must_not_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_kidnap_01",
+          "passed": true,
+          "outcome": "within_expected_window",
+          "trigger_index": 1,
+          "trigger_reason": "startup_innovation_energy_exceeded",
+          "trigger_score": 4.288296782901563
+        },
+        {
+          "fixture": "koide_indoor_kidnap_01_live_r02",
+          "passed": false,
+          "outcome": "missing_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_kidnap_02",
+          "passed": true,
+          "outcome": "within_expected_window",
+          "trigger_index": 4,
+          "trigger_reason": "startup_innovation_energy_exceeded",
+          "trigger_score": 4.839990655349875
+        }
+      ],
+      "benchmark_score": 71.42857142857143,
+      "readability_score": 64.4,
+      "extensibility_score": 89.0,
+      "static_metrics": {
+        "implementation_file": "experiments/startup_integrity/variants/normalized_innovation_energy.py",
+        "loc": 18,
+        "branch_count": 2,
+        "max_nesting_depth": 1,
+        "state_field_count": 2,
+        "public_method_count": 2,
+        "import_count": 4,
+        "has_config_dataclass": true,
+        "readability_score": 64.4,
+        "extensibility_score": 89.0
+      },
+      "overall_score": 73.54
+    },
+    {
+      "name": "fitness_only",
+      "design": "scalar NDT fitness threshold",
+      "fixture_results": [
+        {
+          "fixture": "koide_indoor_easy_01",
+          "passed": true,
+          "outcome": "must_not_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_easy_02",
+          "passed": true,
+          "outcome": "must_not_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_easy_02_live_r02",
+          "passed": true,
+          "outcome": "must_not_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_hard_01",
+          "passed": true,
+          "outcome": "must_not_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_kidnap_01",
+          "passed": false,
+          "outcome": "missing_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_kidnap_01_live_r02",
+          "passed": false,
+          "outcome": "missing_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        },
+        {
+          "fixture": "koide_indoor_kidnap_02",
+          "passed": false,
+          "outcome": "missing_trigger",
+          "trigger_index": null,
+          "trigger_reason": "",
+          "trigger_score": null
+        }
+      ],
+      "benchmark_score": 57.142857142857146,
+      "readability_score": 80.6,
+      "extensibility_score": 94.0,
+      "static_metrics": {
+        "implementation_file": "experiments/startup_integrity/variants/fitness_only.py",
+        "loc": 12,
+        "branch_count": 1,
+        "max_nesting_depth": 0,
+        "state_field_count": 1,
+        "public_method_count": 2,
+        "import_count": 4,
+        "has_config_dataclass": true,
+        "readability_score": 80.6,
+        "extensibility_score": 94.0
+      },
+      "overall_score": 69.21
+    }
+  ],
+  "benchmark_score_mean": 67.85714285714286
+}

--- a/experiments/startup_integrity/variants/__init__.py
+++ b/experiments/startup_integrity/variants/__init__.py
@@ -1,0 +1,11 @@
+from .cumulative_translation import CumulativeTranslationMonitor
+from .fitness_only import FitnessOnlyMonitor
+from .normalized_innovation_energy import NormalizedInnovationEnergyMonitor
+from .peak_innovation import PeakInnovationMonitor
+
+__all__ = [
+    "CumulativeTranslationMonitor",
+    "FitnessOnlyMonitor",
+    "NormalizedInnovationEnergyMonitor",
+    "PeakInnovationMonitor",
+]

--- a/experiments/startup_integrity/variants/cumulative_translation.py
+++ b/experiments/startup_integrity/variants/cumulative_translation.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from experiments.startup_integrity.interface import StartupIntegrityDecision
+from experiments.startup_integrity.interface import StartupIntegritySample
+
+
+@dataclass(frozen=True)
+class Config:
+    startup_updates: int = 5
+    translation_budget_m: float = 1.1
+
+
+class CumulativeTranslationMonitor:
+    """Bound total translation corrections before the predictor stabilizes."""
+
+    name = "cumulative_translation"
+    design = "startup cumulative translation-correction budget"
+
+    def __init__(self, config: Config | None = None) -> None:
+        self.config = config or Config()
+        self.reset()
+
+    def reset(self) -> None:
+        self.cumulative_translation_m = 0.0
+
+    def step(self, sample: StartupIntegritySample) -> StartupIntegrityDecision:
+        if sample.index >= self.config.startup_updates:
+            return StartupIntegrityDecision(False, "startup_window_complete")
+        self.cumulative_translation_m += sample.correction_translation_m
+        trigger = self.cumulative_translation_m > self.config.translation_budget_m
+        reason = "startup_translation_budget_exceeded" if trigger else "startup_translation_bounded"
+        return StartupIntegrityDecision(trigger, reason, self.cumulative_translation_m)

--- a/experiments/startup_integrity/variants/fitness_only.py
+++ b/experiments/startup_integrity/variants/fitness_only.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from experiments.startup_integrity.interface import StartupIntegrityDecision
+from experiments.startup_integrity.interface import StartupIntegritySample
+
+
+@dataclass(frozen=True)
+class Config:
+    score_threshold: float = 15.0
+
+
+class FitnessOnlyMonitor:
+    """Runtime baseline: trust the scalar NDT fitness threshold."""
+
+    name = "fitness_only"
+    design = "scalar NDT fitness threshold"
+
+    def __init__(self, config: Config | None = None) -> None:
+        self.config = config or Config()
+
+    def reset(self) -> None:
+        return None
+
+    def step(self, sample: StartupIntegritySample) -> StartupIntegrityDecision:
+        trigger = sample.fitness_score > self.config.score_threshold
+        reason = "fitness_over_threshold" if trigger else "fitness_within_threshold"
+        return StartupIntegrityDecision(trigger, reason, sample.fitness_score)

--- a/experiments/startup_integrity/variants/normalized_innovation_energy.py
+++ b/experiments/startup_integrity/variants/normalized_innovation_energy.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from experiments.startup_integrity.interface import StartupIntegrityDecision
+from experiments.startup_integrity.interface import StartupIntegritySample
+
+
+@dataclass(frozen=True)
+class Config:
+    startup_updates: int = 5
+    translation_scale_m: float = 0.4
+    yaw_scale_deg: float = 4.0
+    energy_budget: float = 4.0
+
+
+class NormalizedInnovationEnergyMonitor:
+    """Accumulate normalized squared translation and yaw corrections."""
+
+    name = "normalized_innovation_energy"
+    design = "startup normalized translation/yaw correction energy"
+
+    def __init__(self, config: Config | None = None) -> None:
+        self.config = config or Config()
+        self.reset()
+
+    def reset(self) -> None:
+        self.energy = 0.0
+
+    def step(self, sample: StartupIntegritySample) -> StartupIntegrityDecision:
+        if sample.index >= self.config.startup_updates:
+            return StartupIntegrityDecision(False, "startup_window_complete")
+        translation = sample.correction_translation_m / self.config.translation_scale_m
+        yaw = abs(sample.correction_yaw_deg) / self.config.yaw_scale_deg
+        self.energy += translation * translation + yaw * yaw
+        trigger = self.energy > self.config.energy_budget
+        reason = "startup_innovation_energy_exceeded" if trigger else "startup_innovation_energy_bounded"
+        return StartupIntegrityDecision(trigger, reason, self.energy)

--- a/experiments/startup_integrity/variants/peak_innovation.py
+++ b/experiments/startup_integrity/variants/peak_innovation.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from experiments.startup_integrity.interface import StartupIntegrityDecision
+from experiments.startup_integrity.interface import StartupIntegritySample
+
+
+@dataclass(frozen=True)
+class Config:
+    startup_updates: int = 5
+    max_translation_m: float = 0.75
+    max_yaw_deg: float = 8.0
+
+
+class PeakInnovationMonitor:
+    """Reject one large registration correction during startup."""
+
+    name = "peak_innovation"
+    design = "single-update translation or yaw correction threshold"
+
+    def __init__(self, config: Config | None = None) -> None:
+        self.config = config or Config()
+
+    def reset(self) -> None:
+        return None
+
+    def step(self, sample: StartupIntegritySample) -> StartupIntegrityDecision:
+        active = sample.index < self.config.startup_updates
+        trigger = active and (
+            sample.correction_translation_m > self.config.max_translation_m
+            or abs(sample.correction_yaw_deg) > self.config.max_yaw_deg
+        )
+        reason = "startup_peak_innovation" if trigger else "startup_peak_bounded"
+        return StartupIntegrityDecision(trigger, reason)

--- a/scripts/run_experiment_suite.py
+++ b/scripts/run_experiment_suite.py
@@ -29,6 +29,7 @@ def main() -> int:
         repo_root / "scripts" / "run_measurement_acceptance_experiments.py",
         repo_root / "scripts" / "run_recovery_action_experiments.py",
         repo_root / "scripts" / "run_reinit_trigger_experiments.py",
+        repo_root / "scripts" / "run_startup_integrity_experiments.py",
     ]
     for script in scripts:
         subprocess.run([sys.executable, str(script)], check=True, cwd=repo_root)

--- a/scripts/run_startup_integrity_experiments.py
+++ b/scripts/run_startup_integrity_experiments.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+PACKAGE_NAME = "lidar_localization_ros2"
+
+
+def resolve_repo_root() -> Path:
+    script_path = Path(__file__).resolve()
+    candidates = [script_path.parents[1], script_path.parents[3] / "share" / PACKAGE_NAME]
+    for candidate in candidates:
+        if (candidate / "experiments" / "startup_integrity").is_dir():
+            return candidate
+    raise RuntimeError(f"Could not resolve repo root from {script_path}")
+
+
+repo_root = resolve_repo_root()
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+
+from experiments.reporting import compute_static_metrics
+from experiments.reporting import generate_combined_docs
+from experiments.reporting import overall_score
+from experiments.reporting import repo_relative_path
+from experiments.startup_integrity.interface import StartupIntegritySample
+from experiments.startup_integrity.variants import CumulativeTranslationMonitor
+from experiments.startup_integrity.variants import FitnessOnlyMonitor
+from experiments.startup_integrity.variants import NormalizedInnovationEnergyMonitor
+from experiments.startup_integrity.variants import PeakInnovationMonitor
+
+
+VARIANTS = [
+    FitnessOnlyMonitor,
+    PeakInnovationMonitor,
+    CumulativeTranslationMonitor,
+    NormalizedInnovationEnergyMonitor,
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run offline startup-integrity experiments.")
+    parser.add_argument(
+        "--output-json",
+        default=str(repo_root / "experiments" / "startup_integrity" / "results.json"),
+    )
+    return parser.parse_args()
+
+
+def load_fixture(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["fixture_path"] = str(path)
+    return data
+
+
+def to_sample(raw: dict[str, Any]) -> StartupIntegritySample:
+    return StartupIntegritySample(
+        index=int(raw["index"]),
+        fitness_score=float(raw["fitness_score"]),
+        correction_translation_m=float(raw["correction_translation_m"]),
+        correction_yaw_deg=float(raw["correction_yaw_deg"]),
+    )
+
+
+def evaluate_trigger(trigger_index: int | None, expectation: dict[str, Any]) -> tuple[bool, str]:
+    if expectation.get("must_not_trigger"):
+        return trigger_index is None, "must_not_trigger"
+    latest = int(expectation["should_trigger_by_index"])
+    if trigger_index is None:
+        return False, "missing_trigger"
+    return trigger_index <= latest, "within_expected_window" if trigger_index <= latest else "too_late"
+
+
+def run_variant_on_fixture(variant_cls: type, fixture: dict[str, Any]) -> dict[str, Any]:
+    variant = variant_cls()
+    variant.reset()
+    trigger_index = None
+    trigger_reason = ""
+    trigger_score = None
+    for raw in fixture["samples"]:
+        sample = to_sample(raw)
+        decision = variant.step(sample)
+        if trigger_index is None and decision.request_reinitialization:
+            trigger_index = sample.index
+            trigger_reason = decision.reason
+            trigger_score = decision.score
+    passed, outcome = evaluate_trigger(trigger_index, fixture["expectation"])
+    return {
+        "fixture": fixture["name"],
+        "passed": passed,
+        "outcome": outcome,
+        "trigger_index": trigger_index,
+        "trigger_reason": trigger_reason,
+        "trigger_score": trigger_score,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    fixtures = [
+        load_fixture(path)
+        for path in sorted((repo_root / "experiments" / "startup_integrity" / "fixtures").glob("*.json"))
+    ]
+    variants = []
+    for variant_cls in VARIANTS:
+        fixture_results = [run_variant_on_fixture(variant_cls, fixture) for fixture in fixtures]
+        benchmark_score = 100.0 * sum(result["passed"] for result in fixture_results) / len(fixtures)
+        static_metrics = compute_static_metrics(variant_cls)
+        result = {
+            "name": variant_cls.name,
+            "design": variant_cls.design,
+            "fixture_results": fixture_results,
+            "benchmark_score": benchmark_score,
+            "readability_score": static_metrics["readability_score"],
+            "extensibility_score": static_metrics["extensibility_score"],
+            "static_metrics": static_metrics,
+        }
+        result["overall_score"] = overall_score(
+            benchmark_score, result["readability_score"], result["extensibility_score"]
+        )
+        variants.append(result)
+    variants.sort(key=lambda item: (-item["overall_score"], -item["benchmark_score"], item["name"]))
+    results = {
+        "problem": "startup_integrity",
+        "title": "Startup False-Convergence Integrity Monitor",
+        "problem_statement": (
+            "Detect a self-consistent but wrong NDT basin during the first five accepted updates, "
+            "where scalar fitness remains healthy, without rejecting bounded Koide indoor startups."
+        ),
+        "generated_from": repo_relative_path(__file__),
+        "promotion_decision": "no_promotion",
+        "promotion_reason": (
+            "No candidate passes every repeated closed-loop fixture: correction-budget "
+            "variants false-trigger on indoor_easy_02_live_r02 and miss "
+            "indoor_kidnap_01_live_r02, while peak and fitness variants miss kidnaps."
+        ),
+        "research_context": [
+            {
+                "title": "Scan Context: Egocentric Spatial Descriptor for Place Recognition Within 3D Point Cloud Map",
+                "url": "https://gisbi-kim.github.io/publications/gkim-2018-iros.pdf",
+                "relevance": (
+                    "an independent global place descriptor can challenge a locally "
+                    "self-consistent NDT basin"
+                ),
+            },
+            {
+                "title": "NDT-Transformer: Large-Scale 3D Point Cloud Localisation using the Normal Distribution Transform Representation",
+                "url": "https://arxiv.org/abs/2103.12292",
+                "relevance": (
+                    "global retrieval over NDT-cell descriptors is a second candidate "
+                    "verifier family, separate from local registration fitness"
+                ),
+            },
+        ],
+        "interface": {
+            "methods": [
+                "reset() -> None",
+                "step(sample: StartupIntegritySample) -> StartupIntegrityDecision",
+            ],
+            "sample_type": "StartupIntegritySample",
+            "sample_fields": [
+                "index",
+                "fitness_score",
+                "correction_translation_m",
+                "correction_yaw_deg",
+            ],
+            "decision_type": "StartupIntegrityDecision",
+            "decision_fields": ["request_reinitialization", "reason", "score"],
+        },
+        "fixtures": [
+            {
+                "name": fixture["name"],
+                "description": fixture["description"],
+                "source": fixture["source"],
+            }
+            for fixture in fixtures
+        ],
+        "variants": variants,
+        "benchmark_score_mean": sum(item["benchmark_score"] for item in variants) / len(variants),
+    }
+    output_path = Path(args.output_json).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+    generate_combined_docs(repo_root)
+    print(json.dumps(results, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_startup_integrity_experiment.py
+++ b/test/test_startup_integrity_experiment.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from experiments.startup_integrity.interface import StartupIntegritySample
+from experiments.startup_integrity.variants import CumulativeTranslationMonitor
+from experiments.startup_integrity.variants import FitnessOnlyMonitor
+from experiments.startup_integrity.variants import NormalizedInnovationEnergyMonitor
+from experiments.startup_integrity.variants import PeakInnovationMonitor
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "experiments" / "startup_integrity" / "fixtures"
+VARIANTS = [
+    FitnessOnlyMonitor,
+    PeakInnovationMonitor,
+    CumulativeTranslationMonitor,
+    NormalizedInnovationEnergyMonitor,
+]
+
+
+def trigger_index(variant_cls: type, fixture: dict) -> int | None:
+    variant = variant_cls()
+    variant.reset()
+    for raw in fixture["samples"]:
+        decision = variant.step(StartupIntegritySample(**raw))
+        if decision.request_reinitialization:
+            return int(raw["index"])
+    return None
+
+
+def expected(fixture: dict, index: int | None) -> bool:
+    expectation = fixture["expectation"]
+    if expectation.get("must_not_trigger"):
+        return index is None
+    return index is not None and index <= int(expectation["should_trigger_by_index"])
+
+
+def test_no_candidate_passes_all_repeated_closed_loop_fixtures() -> None:
+    fixtures = [json.loads(path.read_text()) for path in sorted(FIXTURES.glob("*.json"))]
+    scores = {
+        variant.name: sum(expected(fixture, trigger_index(variant, fixture)) for fixture in fixtures)
+        for variant in VARIANTS
+    }
+    assert len(fixtures) == 7
+    assert max(scores.values()) == 5
+    assert scores["fitness_only"] == 4
+
+
+def test_repeated_runs_expose_budget_false_positive_and_false_negative() -> None:
+    by_name = {
+        path.stem: json.loads(path.read_text()) for path in FIXTURES.glob("*.json")
+    }
+    assert trigger_index(
+        CumulativeTranslationMonitor, by_name["koide_indoor_easy_02_live_r02"]
+    ) == 2
+    assert trigger_index(
+        CumulativeTranslationMonitor, by_name["koide_indoor_kidnap_01_live_r02"]
+    ) is None


### PR DESCRIPTION
## What changed

- adds a shared startup-integrity experiment with four false-convergence detector families
- adds seven Koide fixtures, including repeated closed-loop counterexamples
- records benchmark, readability, and extensibility scores in generated experiment documentation
- records a deliberate no-promotion decision because every candidate has a false positive or missed kidnap
- adds Scan Context and NDT-Transformer as research directions for an independent global verifier

## Why

`indoor_kidnap_01` can report healthy NDT diagnostics while being roughly 11 m from ground truth. Scalar fitness and correction-derived guards must be tested against repeated normal and kidnapped runs before they can affect runtime behavior.

## Impact

Runtime localization behavior is unchanged. All candidate guards remain under `experiments/`; none is promoted into `src/`, `include/`, `launch/`, or `param/`.

## Validation

- Jazzy workspace build passed
- focused CTest passed
- startup-integrity pytest: 2 passed
- full focused experiment suite passed
- repeated five-sequence Koide closed-loop replay exposed both false-trigger and missed-detection counterexamples
- `git diff --check` passed
