### PR TITLE
Validate Koide IMU rotation prediction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,6 +750,10 @@ if(BUILD_TESTING)
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_analyze_koide_imu_consistency.py
   )
   add_test(
+    NAME koide_imu_yaw_prediction_analysis
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_koide_imu_yaw_prediction_analysis.py
+  )
+  add_test(
     NAME benchmark_compare_runs
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_benchmark_compare_runs.py
   )

--- a/experiments/imu_yaw_prediction/README.md
+++ b/experiments/imu_yaw_prediction/README.md
@@ -1,0 +1,33 @@
+# Koide IMU rotation prediction experiment
+
+This experiment checks whether gyro-only relative rotation can safely seed local NDT tracking.
+It does not add global localization and does not integrate acceleration or position.
+
+`run_dataset_analysis.py` analyzes all 11 Koide sequences. It compares raw identity axes,
+signed-axis permutations, and a fitted Wahba rotation; searches LiDAR/IMU time offset; reports
+gravity convention, apparent bias, static-TF agreement, and timestamp coverage. The standalone
+`imu_rotation_prediction.hpp` candidate uses bounded interpolation, trapezoidal SO(3)
+integration, and coverage/duration/sample-gap rejection. Its test can be run with:
+
+```bash
+g++ -std=c++17 -I/usr/include/eigen3 -Iexperiments/imu_yaw_prediction \
+  experiments/imu_yaw_prediction/test_imu_rotation_prediction.cpp -o /tmp/test_imu_rotation_prediction
+/tmp/test_imu_rotation_prediction
+```
+
+The full offline result is stored outside the repository at
+`/media/sasaki/aiueo/datasets/koide_hard_localization/generated/imu_yaw_validation_20260714`.
+The compact result and runtime A/B gates are in `results.json`.
+
+## Decision
+
+Do not promote this candidate to runtime. Indoor `indoor_easy_01` regressed from 0.053 m to
+1.314 m translation RMSE and from 1.68 to 2.42 degrees rotation RMSE. Outdoor runs were close,
+but `outdoor_kidnap_a` also slightly worsened final rotation error. The full-loop indoor runs
+were therefore stopped by the early regression gate rather than spending additional runtime on
+an already rejected method. The production LiDAR-only path and global-localization behavior are
+unchanged.
+
+One contaminated run is intentionally excluded: an interrupted benchmark left a rosbag process
+on the same ROS domain, producing alternating scan timestamps about 64 seconds apart. Clean runs
+used isolated domains and no surviving replay processes.

--- a/experiments/imu_yaw_prediction/__init__.py
+++ b/experiments/imu_yaw_prediction/__init__.py
@@ -1,0 +1,1 @@
+"""Koide local yaw-prediction calibration experiments."""

--- a/experiments/imu_yaw_prediction/imu_rotation_prediction.hpp
+++ b/experiments/imu_yaw_prediction/imu_rotation_prediction.hpp
@@ -1,0 +1,197 @@
+#ifndef LIDAR_LOCALIZATION_EXPERIMENT_IMU_ROTATION_PREDICTION_HPP_
+#define LIDAR_LOCALIZATION_EXPERIMENT_IMU_ROTATION_PREDICTION_HPP_
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <deque>
+#include <iterator>
+#include <vector>
+
+namespace lidar_localization
+{
+
+enum class ImuRotationPredictionStatus
+{
+  kReady = 0,
+  kDisabled,
+  kInvalidInterval,
+  kDurationTooLarge,
+  kInsufficientCoverage,
+  kSampleGapTooLarge,
+  kNonFiniteSample,
+};
+
+inline const char * imuRotationPredictionStatusName(ImuRotationPredictionStatus status)
+{
+  switch (status) {
+    case ImuRotationPredictionStatus::kReady: return "imu_rotation_prediction_ready";
+    case ImuRotationPredictionStatus::kDisabled: return "imu_rotation_prediction_disabled";
+    case ImuRotationPredictionStatus::kInvalidInterval:
+      return "imu_rotation_prediction_invalid_interval";
+    case ImuRotationPredictionStatus::kDurationTooLarge:
+      return "imu_rotation_prediction_duration_too_large";
+    case ImuRotationPredictionStatus::kInsufficientCoverage:
+      return "imu_rotation_prediction_insufficient_coverage";
+    case ImuRotationPredictionStatus::kSampleGapTooLarge:
+      return "imu_rotation_prediction_sample_gap_too_large";
+    case ImuRotationPredictionStatus::kNonFiniteSample:
+      return "imu_rotation_prediction_non_finite_sample";
+  }
+  return "imu_rotation_prediction_unknown";
+}
+
+struct ImuRotationSample
+{
+  double stamp_sec{0.0};
+  Eigen::Vector3d angular_velocity_base_rad_s{Eigen::Vector3d::Zero()};
+};
+
+struct ImuRotationPredictionResult
+{
+  ImuRotationPredictionStatus status{ImuRotationPredictionStatus::kInsufficientCoverage};
+  Eigen::Matrix3f relative_rotation{Eigen::Matrix3f::Identity()};
+  double duration_sec{0.0};
+  double max_sample_gap_sec{0.0};
+  std::size_t integrated_sample_count{0};
+
+  bool ready() const {return status == ImuRotationPredictionStatus::kReady;}
+};
+
+class ImuRotationPredictionBuffer
+{
+public:
+  explicit ImuRotationPredictionBuffer(double history_duration_sec = 2.0)
+  : history_duration_sec_(history_duration_sec) {}
+
+  bool addSample(double stamp_sec, const Eigen::Vector3d & angular_velocity_base_rad_s)
+  {
+    if (!std::isfinite(stamp_sec) || !angular_velocity_base_rad_s.allFinite()) {
+      return false;
+    }
+    if (!samples_.empty() && stamp_sec <= samples_.back().stamp_sec) {
+      return false;
+    }
+    samples_.push_back({stamp_sec, angular_velocity_base_rad_s});
+    const double oldest_stamp = stamp_sec - history_duration_sec_;
+    while (samples_.size() > 2 && samples_[1].stamp_sec < oldest_stamp) {
+      samples_.pop_front();
+    }
+    return true;
+  }
+
+  void clear() {samples_.clear();}
+  std::size_t size() const {return samples_.size();}
+
+  ImuRotationPredictionResult predict(
+    double start_sec, double end_sec, double max_duration_sec,
+    double max_sample_gap_sec) const
+  {
+    ImuRotationPredictionResult result;
+    result.duration_sec = end_sec - start_sec;
+    if (!std::isfinite(start_sec) || !std::isfinite(end_sec) || end_sec <= start_sec) {
+      result.status = ImuRotationPredictionStatus::kInvalidInterval;
+      return result;
+    }
+    if (max_duration_sec <= 0.0 || result.duration_sec > max_duration_sec) {
+      result.status = ImuRotationPredictionStatus::kDurationTooLarge;
+      return result;
+    }
+    if (
+      samples_.size() < 2 || samples_.front().stamp_sec > start_sec ||
+      samples_.back().stamp_sec < end_sec)
+    {
+      result.status = ImuRotationPredictionStatus::kInsufficientCoverage;
+      return result;
+    }
+
+    std::vector<ImuRotationSample> window;
+    window.reserve(samples_.size() + 2);
+    window.push_back({start_sec, interpolate(start_sec)});
+    for (const auto & sample : samples_) {
+      if (sample.stamp_sec > start_sec && sample.stamp_sec < end_sec) {
+        window.push_back(sample);
+      }
+    }
+    window.push_back({end_sec, interpolate(end_sec)});
+
+    Eigen::Quaterniond rotation = Eigen::Quaterniond::Identity();
+    for (std::size_t index = 1; index < window.size(); ++index) {
+      const double dt = window[index].stamp_sec - window[index - 1].stamp_sec;
+      result.max_sample_gap_sec = std::max(result.max_sample_gap_sec, dt);
+      if (!std::isfinite(dt) || dt <= 0.0 ||
+        max_sample_gap_sec <= 0.0 || dt > max_sample_gap_sec)
+      {
+        result.status = ImuRotationPredictionStatus::kSampleGapTooLarge;
+        return result;
+      }
+      const Eigen::Vector3d mean_rate = 0.5 * (
+        window[index - 1].angular_velocity_base_rad_s +
+        window[index].angular_velocity_base_rad_s);
+      if (!mean_rate.allFinite()) {
+        result.status = ImuRotationPredictionStatus::kNonFiniteSample;
+        return result;
+      }
+      const Eigen::Vector3d rotation_vector = mean_rate * dt;
+      const double angle = rotation_vector.norm();
+      if (angle > 1e-12) {
+        rotation = (rotation * Eigen::Quaterniond(
+          Eigen::AngleAxisd(angle, rotation_vector / angle))).normalized();
+      }
+      ++result.integrated_sample_count;
+    }
+    result.relative_rotation = rotation.toRotationMatrix().cast<float>();
+    if (!result.relative_rotation.allFinite()) {
+      result.status = ImuRotationPredictionStatus::kNonFiniteSample;
+      result.relative_rotation = Eigen::Matrix3f::Identity();
+      return result;
+    }
+    result.status = ImuRotationPredictionStatus::kReady;
+    return result;
+  }
+
+private:
+  Eigen::Vector3d interpolate(double stamp_sec) const
+  {
+    auto right = std::lower_bound(
+      samples_.begin(), samples_.end(), stamp_sec,
+      [](const ImuRotationSample & sample, double stamp) {
+        return sample.stamp_sec < stamp;
+      });
+    if (right == samples_.begin()) {
+      return right->angular_velocity_base_rad_s;
+    }
+    if (right == samples_.end()) {
+      return samples_.back().angular_velocity_base_rad_s;
+    }
+    if (right->stamp_sec == stamp_sec) {
+      return right->angular_velocity_base_rad_s;
+    }
+    const auto left = std::prev(right);
+    const double fraction =
+      (stamp_sec - left->stamp_sec) / (right->stamp_sec - left->stamp_sec);
+    return left->angular_velocity_base_rad_s + fraction * (
+      right->angular_velocity_base_rad_s - left->angular_velocity_base_rad_s);
+  }
+
+  double history_duration_sec_{2.0};
+  std::deque<ImuRotationSample> samples_;
+};
+
+inline Eigen::Matrix4f applyImuRotationPrediction(
+  const Eigen::Matrix4f & accepted_pose,
+  const Eigen::Matrix4f & translation_seed,
+  const Eigen::Matrix3f & relative_rotation)
+{
+  Eigen::Matrix4f result = translation_seed;
+  result.block<3, 3>(0, 0) =
+    accepted_pose.block<3, 3>(0, 0) * relative_rotation;
+  return result;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_EXPERIMENT_IMU_ROTATION_PREDICTION_HPP_

--- a/experiments/imu_yaw_prediction/results.json
+++ b/experiments/imu_yaw_prediction/results.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "date": "2026-07-14",
+  "dataset_sequence_count": 11,
+  "offline_analysis": {
+    "full_results": "/media/sasaki/aiueo/datasets/koide_hard_localization/generated/imu_yaw_validation_20260714/summary.json",
+    "indoor_rate_rmse_rad_s": {
+      "identity_median": 1.0536,
+      "identity_worst": 2.49,
+      "signed_axis_median": 0.0775,
+      "signed_axis_worst": 0.356,
+      "wahba_median": 0.0361,
+      "wahba_worst": 0.35
+    },
+    "outdoor_rate_rmse_rad_s": {
+      "identity_median": 0.0651,
+      "identity_worst": 0.0813,
+      "wahba_median": 0.0628,
+      "wahba_worst": 0.0799
+    },
+    "maximum_absolute_time_offset_sec": {
+      "indoor": 0.005,
+      "outdoor_hard": 0.005,
+      "outdoor_kidnap": 0.045
+    }
+  },
+  "runtime_ab": [
+    {
+      "sequence": "indoor_easy_01",
+      "duration_sec": 8.0,
+      "lidar_only": {"translation_rmse_m": 0.05284, "rotation_rmse_deg": 1.67677},
+      "imu_rotation": {"translation_rmse_m": 1.31443, "rotation_rmse_deg": 2.41686},
+      "decision": "reject"
+    },
+    {
+      "sequence": "outdoor_hard_01a",
+      "duration_sec": 8.0,
+      "lidar_only": {"translation_rmse_m": 0.17624, "rotation_rmse_deg": 0.60179},
+      "imu_rotation": {"translation_rmse_m": 0.17416, "rotation_rmse_deg": 0.53217},
+      "decision": "insufficient_for_promotion"
+    },
+    {
+      "sequence": "outdoor_kidnap_a",
+      "duration_sec": 30.0,
+      "lidar_only": {"translation_rmse_m": 0.22, "rotation_rmse_deg": 0.60276, "rotation_error_last_deg": 3.87328},
+      "imu_rotation": {"translation_rmse_m": 0.20934, "rotation_rmse_deg": 0.58145, "rotation_error_last_deg": 3.98249},
+      "decision": "reject_last_rotation_regression"
+    }
+  ],
+  "promotion_decision": "rejected",
+  "reason": "The candidate regressed indoor translation and rotation, and slightly regressed final rotation on the outdoor kidnap run. It remains experiment-only and is not connected to runtime parameters."
+}

--- a/experiments/imu_yaw_prediction/run_dataset_analysis.py
+++ b/experiments/imu_yaw_prediction/run_dataset_analysis.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Run the offline IMU/LiDAR consistency analysis on every Koide sequence."""
+
+import argparse
+import json
+from pathlib import Path
+import statistics
+import subprocess
+import sys
+
+
+SEQUENCES = {
+    "indoor_easy_01": ("/imu", "/points2/decompressed", "indoor"),
+    "indoor_easy_02": ("/imu", "/points2/decompressed", "indoor"),
+    "indoor_hard_01": ("/imu", "/points2/decompressed", "indoor"),
+    "indoor_kidnap_01": ("/imu", "/points2/decompressed", "indoor"),
+    "indoor_kidnap_02": ("/imu", "/points2/decompressed", "indoor"),
+    "outdoor_hard_01a": ("/livox/imu", "/livox/points", "outdoor"),
+    "outdoor_hard_01b": ("/livox/imu", "/livox/points", "outdoor"),
+    "outdoor_hard_02a": ("/livox/imu", "/livox/points", "outdoor"),
+    "outdoor_hard_02b": ("/livox/imu", "/livox/points", "outdoor"),
+    "outdoor_kidnap_a": ("/livox/imu", "/livox/points", "outdoor"),
+    "outdoor_kidnap_b": ("/livox/imu", "/livox/points", "outdoor"),
+}
+
+
+def compact_sequence_result(name, family, report):
+    alignment = report["between_cloud_alignment"]
+    accel = report["accelerometer"]
+    extrinsic = report["static_imu_to_cloud_extrinsic"]
+    return {
+        "sequence": name,
+        "family": family,
+        "imu_frame_ids": report["imu_frame_ids"],
+        "cloud_frame_ids": report["cloud_frame_ids"],
+        "imu_sample_count": report["imu_sample_count"],
+        "cloud_scan_count": report["cloud_scan_count"],
+        "imu_period_median_sec": report["imu_timing"]["median_period_sec"],
+        "cloud_period_median_sec": report["cloud_timing"]["median_period_sec"],
+        "imu_header_minus_record_median_sec": report["imu_timing"][
+            "median_header_minus_record_sec"],
+        "cloud_header_minus_record_median_sec": report["cloud_timing"][
+            "median_header_minus_record_sec"],
+        "imu_minus_reference_time_offset_sec": alignment[
+            "imu_minus_reference_time_offset_sec"],
+        "identity_rate_rmse_rad_s": alignment["identity"]["rate_rmse_rad_s"],
+        "signed_axis_rate_rmse_rad_s": alignment[
+            "best_right_handed_signed_axis_mapping"]["rate_rmse_rad_s"],
+        "wahba_rate_rmse_rad_s": alignment["wahba"]["rate_rmse_rad_s"],
+        "signed_axis_mapping": alignment[
+            "best_right_handed_signed_axis_mapping"]["matrix"],
+        "imu_to_reference_rotation": alignment["wahba"][
+            "imu_to_reference_rotation"],
+        "rotation_from_identity_deg": alignment["wahba"][
+            "rotation_from_identity_deg"],
+        "gyro_bias_sensor_rad_s": alignment["wahba"]["gyro_bias_sensor_rad_s"],
+        "static_extrinsic_difference_deg": (
+            extrinsic["fitted_rotation_difference_deg"] if extrinsic else None),
+        "accel_units": accel["input_units"],
+        "accel_scale_to_m_s2": accel["scale_to_m_s2"],
+        "gravity_world_sign": accel.get("gravity_world_sign"),
+        "gravity_direction_sensor": accel.get("gravity_direction_sensor"),
+        "apparent_accel_bias_sensor_m_s2": accel.get(
+            "apparent_accel_bias_sensor_m_s2"),
+        "accel_quiet_residual_rmse_m_s2": accel.get(
+            "quiet_corrected_residual_rmse_m_s2"),
+        "point_time_available": bool(report["point_time_hypotheses"]),
+    }
+
+
+def aggregate_results(results):
+    aggregate = {}
+    for family in sorted({result["family"] for result in results}):
+        selected = [result for result in results if result["family"] == family]
+        variants = {}
+        for variant, field in (
+            ("identity", "identity_rate_rmse_rad_s"),
+            ("signed_axis", "signed_axis_rate_rmse_rad_s"),
+            ("wahba", "wahba_rate_rmse_rad_s"),
+        ):
+            values = [result[field] for result in selected]
+            variants[variant] = {
+                "median_rate_rmse_rad_s": statistics.median(values),
+                "worst_rate_rmse_rad_s": max(values),
+            }
+        aggregate[family] = {
+            "sequence_count": len(selected),
+            "variants": variants,
+            "max_abs_time_offset_sec": max(
+                abs(result["imu_minus_reference_time_offset_sec"])
+                for result in selected),
+            "accel_units": sorted({result["accel_units"] for result in selected}),
+            "gravity_world_signs": sorted({
+                result["gravity_world_sign"] for result in selected
+                if result["gravity_world_sign"] is not None}),
+            "max_static_extrinsic_difference_deg": max(
+                (result["static_extrinsic_difference_deg"] for result in selected
+                 if result["static_extrinsic_difference_deg"] is not None),
+                default=None),
+        }
+    return aggregate
+
+
+def main():
+    repo = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-root", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--max-scans", type=int, default=0,
+                        help="0 analyzes every cloud scan")
+    parser.add_argument("--sequence", action="append", choices=SEQUENCES)
+    parser.add_argument(
+        "--analyzer", type=Path,
+        default=repo / "scripts" / "analyze_koide_imu_consistency.py")
+    args = parser.parse_args()
+
+    names = args.sequence or list(SEQUENCES)
+    assets = args.data_root / "generated" / "localization_gif_benchmarks" / "assets"
+    details = args.output_dir / "sequences"
+    details.mkdir(parents=True, exist_ok=True)
+    compact = []
+    for name in names:
+        imu_topic, cloud_topic, family = SEQUENCES[name]
+        output = details / f"{name}.json"
+        command = [
+            sys.executable, str(args.analyzer),
+            "--bag", str(args.data_root / "sequences" / name),
+            "--reference", str(assets / f"{name}_reference.csv"),
+            "--output", str(output),
+            "--imu-topic", imu_topic,
+            "--cloud-topic", cloud_topic,
+            "--max-scans", str(args.max_scans),
+        ]
+        print(f"Analyzing {name}...", flush=True)
+        subprocess.run(command, check=True, stdout=subprocess.DEVNULL)
+        compact.append(compact_sequence_result(name, family, json.loads(output.read_text())))
+
+    summary = {
+        "schema_version": 1,
+        "purpose": "Koide local yaw prediction calibration; no global localization",
+        "sequence_count": len(compact),
+        "all_expected_sequences_analyzed": set(names) == set(SEQUENCES),
+        "sequences": compact,
+        "families": aggregate_results(compact),
+    }
+    summary_path = args.output_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n")
+    print(summary_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/imu_yaw_prediction/test_imu_rotation_prediction.cpp
+++ b/experiments/imu_yaw_prediction/test_imu_rotation_prediction.cpp
@@ -1,0 +1,44 @@
+#include "imu_rotation_prediction.hpp"
+
+#include <Eigen/Core>
+
+#include <cassert>
+#include <cmath>
+
+int main()
+{
+  using lidar_localization::ImuRotationPredictionBuffer;
+  using lidar_localization::ImuRotationPredictionStatus;
+
+  ImuRotationPredictionBuffer buffer;
+  for (int index = 0; index <= 100; ++index) {
+    assert(buffer.addSample(
+      0.01 * index, Eigen::Vector3d(0.0, 0.0, 1.0)));
+  }
+  const auto prediction = buffer.predict(0.2, 0.8, 1.0, 0.02);
+  assert(prediction.ready());
+  const Eigen::Matrix3f expected = Eigen::AngleAxisf(
+    0.6f, Eigen::Vector3f::UnitZ()).toRotationMatrix();
+  assert(prediction.relative_rotation.isApprox(expected, 1e-5f));
+  assert(prediction.integrated_sample_count >= 60);
+
+  const auto too_long = buffer.predict(0.1, 0.9, 0.5, 0.02);
+  assert(too_long.status == ImuRotationPredictionStatus::kDurationTooLarge);
+  const auto uncovered = buffer.predict(-0.1, 0.2, 1.0, 0.02);
+  assert(uncovered.status == ImuRotationPredictionStatus::kInsufficientCoverage);
+
+  ImuRotationPredictionBuffer gap_buffer;
+  assert(gap_buffer.addSample(0.0, Eigen::Vector3d::Zero()));
+  assert(gap_buffer.addSample(0.2, Eigen::Vector3d::Zero()));
+  const auto gap = gap_buffer.predict(0.0, 0.2, 1.0, 0.05);
+  assert(gap.status == ImuRotationPredictionStatus::kSampleGapTooLarge);
+
+  Eigen::Matrix4f accepted = Eigen::Matrix4f::Identity();
+  Eigen::Matrix4f translation_seed = Eigen::Matrix4f::Identity();
+  translation_seed(0, 3) = 2.5f;
+  const Eigen::Matrix4f combined = lidar_localization::applyImuRotationPrediction(
+    accepted, translation_seed, expected);
+  assert(std::abs(combined(0, 3) - 2.5f) < 1e-6f);
+  assert((combined.block<3, 3>(0, 0).isApprox(expected, 1e-5f)));
+  return 0;
+}

--- a/package.xml
+++ b/package.xml
@@ -40,6 +40,8 @@
   <exec_depend>tf2_eigen</exec_depend>
   <exec_depend>pcl_conversions</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-pil</exec_depend>
+  <exec_depend>rosbag2_py</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/scripts/analyze_koide_imu_consistency.py
+++ b/scripts/analyze_koide_imu_consistency.py
@@ -85,6 +85,38 @@ def integrate_gyro(times, gyro, start, end):
     return np.trapezoid(samples, sample_times, axis=0)
 
 
+def cumulative_trapezoid(times, values):
+    """Return an integral lookup table with the same length as the samples."""
+    if len(times) != len(values) or len(times) < 2:
+        raise ValueError("at least two timestamped samples are required")
+    dt = np.diff(times)
+    if np.any(dt <= 0.0):
+        raise ValueError("sample timestamps must be strictly increasing")
+    cumulative = np.zeros_like(values, dtype=float)
+    cumulative[1:] = np.cumsum(
+        0.5 * (values[:-1] + values[1:]) * dt[:, None], axis=0)
+    return cumulative
+
+
+def interpolate_vectors(times, values, query):
+    query = np.asarray(query)
+    return np.column_stack([
+        np.interp(query, times, values[:, axis]) for axis in range(values.shape[1])
+    ])
+
+
+def integrate_from_cumulative(times, cumulative, starts, ends):
+    starts = np.asarray(starts)
+    ends = np.asarray(ends)
+    valid = ((ends > starts) & (starts >= times[0]) & (ends <= times[-1]))
+    result = np.full((len(starts), cumulative.shape[1]), np.nan)
+    if np.any(valid):
+        result[valid] = (
+            interpolate_vectors(times, cumulative, ends[valid]) -
+            interpolate_vectors(times, cumulative, starts[valid]))
+    return result, valid
+
+
 def wahba(source, target):
     covariance = target.T @ source
     u, _, vt = np.linalg.svd(covariance)
@@ -175,31 +207,180 @@ def read_bag(uri, imu_topic, cloud_topic, max_scans):
     reader.open(rosbag2_py.StorageOptions(uri=str(uri), storage_id="sqlite3"),
                 rosbag2_py.ConverterOptions("", ""))
     types = {item.name: item.type for item in reader.get_all_topics_and_types()}
+    missing = [topic for topic in (imu_topic, cloud_topic) if topic not in types]
+    if missing:
+        raise RuntimeError(f"bag is missing required topics: {', '.join(missing)}")
     wanted = {imu_topic, cloud_topic}
+    if "/tf_static" in types:
+        wanted.add("/tf_static")
     reader.set_filter(rosbag2_py.StorageFilter(topics=list(wanted)))
     classes = {topic: get_message(types[topic]) for topic in wanted}
-    imu_times, gyro, scans = [], [], []
+    imu_times, gyro, accel, scans = [], [], [], []
+    imu_header_minus_record, cloud_header_minus_record = [], []
     imu_frames, cloud_frames = set(), set()
+    static_transforms = []
     while reader.has_next():
-        topic, raw, _ = reader.read_next()
+        topic, raw, record_stamp_ns = reader.read_next()
         message = deserialize_message(raw, classes[topic])
+        if topic == "/tf_static":
+            for transform in message.transforms:
+                static_transforms.append({
+                    "parent": transform.header.frame_id,
+                    "child": transform.child_frame_id,
+                    "translation": [
+                        transform.transform.translation.x,
+                        transform.transform.translation.y,
+                        transform.transform.translation.z,
+                    ],
+                    "rotation_xyzw": [
+                        transform.transform.rotation.x,
+                        transform.transform.rotation.y,
+                        transform.transform.rotation.z,
+                        transform.transform.rotation.w,
+                    ],
+                })
+            continue
         stamp = float(message.header.stamp.sec) + 1e-9 * message.header.stamp.nanosec
         if topic == imu_topic:
             imu_frames.add(message.header.frame_id)
             imu_times.append(stamp)
             gyro.append([message.angular_velocity.x, message.angular_velocity.y,
                          message.angular_velocity.z])
-        elif len(scans) < max_scans:
+            accel.append([message.linear_acceleration.x, message.linear_acceleration.y,
+                          message.linear_acceleration.z])
+            imu_header_minus_record.append(stamp - 1e-9 * record_stamp_ns)
+        elif max_scans <= 0 or len(scans) < max_scans:
             cloud_frames.add(message.header.frame_id)
             duration = point_time_duration(message)
-            if duration is not None and duration > 0.0:
-                scans.append((stamp, duration, message.header.frame_id))
-    return np.asarray(imu_times), np.asarray(gyro), scans, sorted(imu_frames), sorted(cloud_frames)
+            scans.append((stamp, duration, message.header.frame_id))
+            cloud_header_minus_record.append(stamp - 1e-9 * record_stamp_ns)
+    return {
+        "imu_times": np.asarray(imu_times),
+        "gyro": np.asarray(gyro),
+        "accel": np.asarray(accel),
+        "scans": scans,
+        "imu_frames": sorted(imu_frames),
+        "cloud_frames": sorted(cloud_frames),
+        "imu_header_minus_record": np.asarray(imu_header_minus_record),
+        "cloud_header_minus_record": np.asarray(cloud_header_minus_record),
+        "static_transforms": static_transforms,
+    }
+
+
+def timing_summary(times, header_minus_record):
+    delta = np.diff(times)
+    positive_delta = delta[delta > 0.0]
+    return {
+        "sample_count": int(len(times)),
+        "median_period_sec": float(np.median(positive_delta)) if positive_delta.size else None,
+        "p95_period_sec": float(np.percentile(positive_delta, 95)) if positive_delta.size else None,
+        "non_monotonic_count": int(np.count_nonzero(delta <= 0.0)),
+        "median_header_minus_record_sec": (
+            float(np.median(header_minus_record)) if header_minus_record.size else None),
+        "p95_abs_header_minus_record_sec": (
+            float(np.percentile(np.abs(header_minus_record), 95))
+            if header_minus_record.size else None),
+    }
+
+
+def accelerometer_unit_scale(accel):
+    median_norm = float(np.median(np.linalg.norm(accel, axis=1)))
+    if 0.5 <= median_norm <= 1.5:
+        return "g", 9.80665, median_norm
+    if 5.0 <= median_norm <= 15.0:
+        return "m_s2", 1.0, median_norm
+    return "unknown", None, median_norm
+
+
+def accelerometer_summary(
+        imu_times, gyro, accel, ref_times, ref_quats,
+        imu_to_reference_rotation, imu_minus_reference_offset_sec):
+    units, scale, median_norm = accelerometer_unit_scale(accel)
+    summary = {
+        "input_units": units,
+        "scale_to_m_s2": scale,
+        "median_norm_input_units": median_norm,
+    }
+    if scale is None:
+        summary["status"] = "unknown_acceleration_units"
+        return summary
+
+    count = min(len(imu_times), 5000)
+    indices = np.linspace(0, len(imu_times) - 1, count, dtype=int)
+    sample_times = imu_times[indices] - imu_minus_reference_offset_sec
+    sample_accel = accel[indices] * scale
+    sample_gyro = gyro[indices]
+    quaternions = []
+    valid_indices = []
+    for local_index, stamp in enumerate(sample_times):
+        quaternion = interpolate_quaternion(ref_times, ref_quats, stamp)
+        if quaternion is not None:
+            quaternions.append(quaternion)
+            valid_indices.append(local_index)
+    if len(valid_indices) < 100:
+        summary["status"] = "insufficient_reference_overlap"
+        summary["usable_sample_count"] = len(valid_indices)
+        return summary
+
+    sample_accel = sample_accel[valid_indices]
+    sample_gyro = sample_gyro[valid_indices]
+    reference_rotations = np.asarray([quat_to_matrix(q) for q in quaternions])
+    sensor_to_reference = np.asarray(imu_to_reference_rotation)
+    measured_world = np.einsum(
+        "nij,nj->ni", reference_rotations,
+        (sensor_to_reference @ sample_accel.T).T)
+
+    gyro_norm = np.linalg.norm(sample_gyro, axis=1)
+    accel_norm_error = np.abs(np.linalg.norm(sample_accel, axis=1) - 9.80665)
+    quiet_metric = gyro_norm + 0.1 * accel_norm_error
+    quiet_count = max(100, len(quiet_metric) // 5)
+    quiet = np.argsort(quiet_metric)[:quiet_count]
+    gravity_sign = 1.0 if np.median(measured_world[quiet, 2]) >= 0.0 else -1.0
+    expected_world = np.array([0.0, 0.0, gravity_sign * 9.80665])
+    expected_reference = np.einsum(
+        "nji,j->ni", reference_rotations, expected_world)
+    expected_sensor = (sensor_to_reference.T @ expected_reference.T).T
+    residual_sensor = sample_accel - expected_sensor
+    apparent_bias = np.median(residual_sensor[quiet], axis=0)
+    corrected_residual = residual_sensor - apparent_bias
+
+    summary.update({
+        "status": "ok",
+        "usable_sample_count": len(valid_indices),
+        "quiet_sample_count": int(quiet_count),
+        "gravity_world_sign": "+Z" if gravity_sign > 0.0 else "-Z",
+        "gravity_direction_sensor": (
+            np.median(expected_sensor[quiet], axis=0) / 9.80665).tolist(),
+        "apparent_accel_bias_sensor_m_s2": apparent_bias.tolist(),
+        "quiet_corrected_residual_rmse_m_s2": float(np.sqrt(np.mean(
+            np.sum(corrected_residual[quiet] ** 2, axis=1)))),
+    })
+    return summary
+
+
+def static_imu_to_cloud_transform(static_transforms, imu_frames, cloud_frames):
+    for transform in static_transforms:
+        if transform["parent"] in cloud_frames and transform["child"] in imu_frames:
+            return {
+                **transform,
+                "imu_to_cloud_rotation": quat_to_matrix(
+                    transform["rotation_xyzw"]).tolist(),
+            }
+        if transform["parent"] in imu_frames and transform["child"] in cloud_frames:
+            rotation = quat_to_matrix(transform["rotation_xyzw"])
+            return {
+                **transform,
+                "imu_to_cloud_rotation": rotation.T.tolist(),
+                "inverted": True,
+            }
+    return None
 
 
 def evaluate_hypothesis(name, scans, imu_times, gyro, ref_times, ref_quats):
     source, target, durations = [], [], []
     for stamp, duration, _ in scans:
+        if duration is None or duration <= 0.0:
+            continue
         start, end = ((stamp, stamp + duration) if name == "start" else
                       (stamp - duration, stamp))
         q0 = interpolate_quaternion(ref_times, ref_quats, start)
@@ -240,6 +421,93 @@ def evaluate_hypothesis(name, scans, imu_times, gyro, ref_times, ref_quats):
     }
 
 
+def evaluate_between_cloud_stamps(
+        scans, imu_times, gyro, ref_times, ref_quats,
+        offset_min_sec=-0.25, offset_max_sec=0.25, offset_step_sec=0.005):
+    """Fit gyro axes/bias and IMU-reference time offset between cloud stamps.
+
+    Unlike the per-point scan-time hypotheses, this works for clouds without a
+    time field and directly measures the rotation seed needed by local tracking.
+    A positive offset means the IMU timestamps are later than the matching
+    LiDAR/reference timestamps.
+    """
+    stamps = np.asarray([scan[0] for scan in scans])
+    starts, ends, target, durations = [], [], [], []
+    for start, end in zip(stamps[:-1], stamps[1:]):
+        duration = end - start
+        if duration <= 0.0 or duration > 0.5:
+            continue
+        q0 = interpolate_quaternion(ref_times, ref_quats, start)
+        q1 = interpolate_quaternion(ref_times, ref_quats, end)
+        if q0 is None or q1 is None:
+            continue
+        starts.append(start)
+        ends.append(end)
+        target.append(rotation_log(quat_to_matrix(q0).T @ quat_to_matrix(q1)))
+        durations.append(duration)
+    starts = np.asarray(starts)
+    ends = np.asarray(ends)
+    target = np.asarray(target)
+    durations = np.asarray(durations)
+    if len(starts) < 10:
+        raise RuntimeError(f"only {len(starts)} usable between-cloud intervals")
+
+    cumulative = cumulative_trapezoid(imu_times, gyro)
+    candidates = []
+    offsets = np.arange(
+        offset_min_sec, offset_max_sec + 0.5 * offset_step_sec, offset_step_sec)
+    for offset in offsets:
+        source, valid = integrate_from_cumulative(
+            imu_times, cumulative, starts + offset, ends + offset)
+        if np.count_nonzero(valid) < 10:
+            continue
+        candidate_source = source[valid]
+        candidate_target = target[valid]
+        candidate_durations = durations[valid]
+        rotation, bias = fit_rotation_and_bias(
+            candidate_source, candidate_target, candidate_durations)
+        residual = residual_summary(
+            rotation, bias, candidate_source, candidate_target, candidate_durations)
+        candidates.append((
+            residual["rate_rmse_rad_s"], float(offset), candidate_source,
+            candidate_target, candidate_durations, rotation, bias, residual))
+    if not candidates:
+        raise RuntimeError("no time-offset candidate overlaps the IMU stream")
+
+    _, offset, source, target, durations, rotation, bias, fitted = min(
+        candidates, key=lambda item: item[0])
+    identity = residual_summary(np.eye(3), np.zeros(3), source, target, durations)
+    permutations = []
+    for matrix in right_handed_axis_permutations():
+        permutation_bias = np.median(
+            (source - (matrix.T @ target.T).T) / durations[:, None], axis=0)
+        summary = residual_summary(matrix, permutation_bias, source, target, durations)
+        permutations.append((summary["rate_rmse_rad_s"], matrix, permutation_bias, summary))
+    _, axis_matrix, axis_bias, axis_summary = min(permutations, key=lambda item: item[0])
+    return {
+        "usable_interval_count": int(len(source)),
+        "imu_minus_reference_time_offset_sec": offset,
+        "offset_search": {
+            "min_sec": offset_min_sec,
+            "max_sec": offset_max_sec,
+            "step_sec": offset_step_sec,
+            "candidate_count": len(candidates),
+        },
+        "identity": identity,
+        "wahba": {
+            **fitted,
+            "imu_to_reference_rotation": rotation.tolist(),
+            "rotation_from_identity_deg": rotation_angle_deg(rotation),
+            "gyro_bias_sensor_rad_s": bias.tolist(),
+        },
+        "best_right_handed_signed_axis_mapping": {
+            **axis_summary,
+            "matrix": axis_matrix.tolist(),
+            "gyro_bias_sensor_rad_s": axis_bias.tolist(),
+        },
+    }
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--bag", type=Path, required=True)
@@ -248,29 +516,61 @@ def main():
     parser.add_argument("--imu-topic", default="/livox/imu")
     parser.add_argument("--cloud-topic", default="/livox/points")
     parser.add_argument("--max-scans", type=int, default=2000)
+    parser.add_argument("--time-offset-min-sec", type=float, default=-0.25)
+    parser.add_argument("--time-offset-max-sec", type=float, default=0.25)
+    parser.add_argument("--time-offset-step-sec", type=float, default=0.005)
     args = parser.parse_args()
     ref_times, ref_quats = load_reference(args.reference)
-    imu_times, gyro, scans, imu_frames, cloud_frames = read_bag(
+    bag = read_bag(
         args.bag, args.imu_topic, args.cloud_topic, args.max_scans)
+    interval_alignment = evaluate_between_cloud_stamps(
+        bag["scans"], bag["imu_times"], bag["gyro"], ref_times, ref_quats,
+        args.time_offset_min_sec, args.time_offset_max_sec, args.time_offset_step_sec)
+    point_time_hypotheses = {}
+    if sum(scan[1] is not None and scan[1] > 0.0 for scan in bag["scans"]) >= 10:
+        point_time_hypotheses = {
+            name: evaluate_hypothesis(
+                name, bag["scans"], bag["imu_times"], bag["gyro"],
+                ref_times, ref_quats)
+            for name in ("start", "end")
+        }
+    imu_offset = interval_alignment["imu_minus_reference_time_offset_sec"]
+    accel = accelerometer_summary(
+        bag["imu_times"], bag["gyro"], bag["accel"], ref_times, ref_quats,
+        interval_alignment["wahba"]["imu_to_reference_rotation"], imu_offset)
+    static_extrinsic = static_imu_to_cloud_transform(
+        bag["static_transforms"], bag["imu_frames"], bag["cloud_frames"])
+    if static_extrinsic is not None:
+        fitted_rotation = np.asarray(
+            interval_alignment["wahba"]["imu_to_reference_rotation"])
+        static_rotation = np.asarray(static_extrinsic["imu_to_cloud_rotation"])
+        static_extrinsic["fitted_rotation_difference_deg"] = rotation_angle_deg(
+            static_rotation.T @ fitted_rotation)
+    cloud_times = np.asarray([scan[0] for scan in bag["scans"]])
     report = {
-        "schema_version": 1,
+        "schema_version": 2,
         "bag": str(args.bag.resolve()),
         "reference": str(args.reference.resolve()),
         "imu_topic": args.imu_topic,
         "cloud_topic": args.cloud_topic,
-        "imu_sample_count": int(len(imu_times)),
-        "cloud_scan_count": len(scans),
-        "imu_frame_ids": imu_frames,
-        "cloud_frame_ids": cloud_frames,
-        "imu_frame_ids_match_cloud": imu_frames == cloud_frames,
-        "hypotheses": {
-            name: evaluate_hypothesis(name, scans, imu_times, gyro, ref_times, ref_quats)
-            for name in ("start", "end")
-        },
+        "imu_sample_count": int(len(bag["imu_times"])),
+        "cloud_scan_count": len(bag["scans"]),
+        "imu_frame_ids": bag["imu_frames"],
+        "cloud_frame_ids": bag["cloud_frames"],
+        "imu_frame_ids_match_cloud": bag["imu_frames"] == bag["cloud_frames"],
+        "static_imu_to_cloud_extrinsic": static_extrinsic,
+        "imu_timing": timing_summary(
+            bag["imu_times"], bag["imu_header_minus_record"]),
+        "cloud_timing": timing_summary(
+            cloud_times, bag["cloud_header_minus_record"]),
+        "between_cloud_alignment": interval_alignment,
+        "accelerometer": accel,
+        "point_time_hypotheses": point_time_hypotheses,
     }
-    report["preferred_cloud_stamp_reference"] = min(
-        report["hypotheses"],
-        key=lambda name: report["hypotheses"][name]["wahba"]["rate_rmse_rad_s"])
+    report["preferred_cloud_stamp_reference"] = (
+        min(point_time_hypotheses,
+            key=lambda name: point_time_hypotheses[name]["wahba"]["rate_rmse_rad_s"])
+        if point_time_hypotheses else "unavailable_no_point_time_field")
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(report, indent=2) + "\n")
     print(json.dumps(report, indent=2))

--- a/test/test_analyze_koide_imu_consistency.py
+++ b/test/test_analyze_koide_imu_consistency.py
@@ -46,6 +46,39 @@ class ImuConsistencyMathTest(unittest.TestCase):
         midpoint = MODULE.quat_slerp(start, end, 0.5)
         self.assertTrue(np.allclose(midpoint, [0.0, 0.0, math.sqrt(0.5), math.sqrt(0.5)]))
 
+    def test_cumulative_integration_handles_vector_rate(self):
+        times = np.linspace(0.0, 2.0, 201)
+        rates = np.column_stack((times, np.ones_like(times) * 2.0, -times))
+        cumulative = MODULE.cumulative_trapezoid(times, rates)
+        integral, valid = MODULE.integrate_from_cumulative(
+            times, cumulative, np.array([0.25]), np.array([1.75]))
+        self.assertTrue(valid[0])
+        self.assertTrue(np.allclose(integral[0], [1.5, 3.0, -1.5], atol=1e-9))
+
+    def test_between_cloud_alignment_recovers_time_offset(self):
+        imu_times = np.linspace(0.0, 12.0, 12001)
+        true_offset = 0.08
+        angular_rate = 0.2 + 0.08 * np.sin(1.7 * (imu_times - true_offset))
+        gyro = np.column_stack((
+            np.zeros_like(imu_times), np.zeros_like(imu_times), angular_rate))
+        cloud_times = np.arange(1.0, 11.0, 0.1)
+        yaw = 0.2 * cloud_times - (0.08 / 1.7) * np.cos(1.7 * cloud_times)
+        quaternions = np.column_stack((
+            np.zeros_like(yaw), np.zeros_like(yaw), np.sin(0.5 * yaw), np.cos(0.5 * yaw)))
+        scans = [(stamp, None, "lidar") for stamp in cloud_times]
+        result = MODULE.evaluate_between_cloud_stamps(
+            scans, imu_times, gyro, cloud_times, quaternions,
+            offset_min_sec=-0.15, offset_max_sec=0.15, offset_step_sec=0.01)
+        self.assertAlmostEqual(
+            result["imu_minus_reference_time_offset_sec"], true_offset, delta=0.011)
+        self.assertLess(result["wahba"]["rate_rmse_rad_s"], 1e-3)
+
+    def test_accelerometer_unit_scale_distinguishes_g_and_si(self):
+        g_samples = np.tile([0.0, 0.0, 1.0], (20, 1))
+        si_samples = np.tile([0.0, 0.0, -9.81], (20, 1))
+        self.assertEqual(MODULE.accelerometer_unit_scale(g_samples)[0], "g")
+        self.assertEqual(MODULE.accelerometer_unit_scale(si_samples)[0], "m_s2")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_koide_imu_yaw_prediction_analysis.py
+++ b/test/test_koide_imu_yaw_prediction_analysis.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+from pathlib import Path
+import unittest
+
+
+SCRIPT = (Path(__file__).resolve().parents[1] / "experiments" /
+          "imu_yaw_prediction" / "run_dataset_analysis.py")
+SPEC = importlib.util.spec_from_file_location("imu_dataset_analysis", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class KoideImuDatasetAnalysisTest(unittest.TestCase):
+    def test_aggregate_keeps_families_and_variant_scores_separate(self):
+        template = {
+            "identity_rate_rmse_rad_s": 1.0,
+            "signed_axis_rate_rmse_rad_s": 0.2,
+            "wahba_rate_rmse_rad_s": 0.1,
+            "imu_minus_reference_time_offset_sec": 0.01,
+            "accel_units": "m_s2",
+            "gravity_world_sign": "+Z",
+            "static_extrinsic_difference_deg": 0.5,
+        }
+        results = [
+            {**template, "family": "indoor"},
+            {**template, "family": "indoor", "wahba_rate_rmse_rad_s": 0.3},
+            {**template, "family": "outdoor", "accel_units": "g",
+             "static_extrinsic_difference_deg": None},
+        ]
+        aggregate = MODULE.aggregate_results(results)
+        self.assertEqual(aggregate["indoor"]["sequence_count"], 2)
+        self.assertAlmostEqual(
+            aggregate["indoor"]["variants"]["wahba"]["median_rate_rmse_rad_s"],
+            0.2)
+        self.assertEqual(aggregate["outdoor"]["accel_units"], ["g"])
+
+    def test_manifest_covers_all_eleven_sequences(self):
+        self.assertEqual(len(MODULE.SEQUENCES), 11)
+        self.assertEqual(
+            sum(family == "indoor" for _, _, family in MODULE.SEQUENCES.values()), 5)
+
+    def test_recorded_result_rejects_runtime_promotion(self):
+        result_path = SCRIPT.parent / "results.json"
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        self.assertEqual(result["dataset_sequence_count"], 11)
+        self.assertEqual(result["promotion_decision"], "rejected")
+        indoor = next(
+            run for run in result["runtime_ab"]
+            if run["sequence"] == "indoor_easy_01")
+        self.assertGreater(
+            indoor["imu_rotation"]["translation_rmse_m"],
+            indoor["lidar_only"]["translation_rmse_m"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Analyze IMU/LiDAR frame alignment, timestamp offset, gravity convention, and apparent bias across all 11 Koide sequences.
- Add an experiment-only bounded SO(3) gyro predictor and reproducible tests.
- Record LiDAR-only versus IMU-seed A/B results and the rejection decision.
- Declare python3-pil and rosbag2_py dependencies required by installed scripts.

## Why

The indoor and outdoor bags use different IMU conventions. The candidate improved some outdoor windows but regressed indoor localization, so it is not promoted into the runtime localizer. Global localization and production LiDAR-only behavior are unchanged.

## Validation

- All 11 Koide sequences analyzed offline.
- Jazzy build and 70/70 tests passed.
- Humble Docker build and 70/70 tests passed.
- git diff --check passed.