### PR TITLE
Validate LiDAR IMU time offset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -754,6 +754,10 @@ if(BUILD_TESTING)
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_koide_imu_yaw_prediction_analysis.py
   )
   add_test(
+    NAME imu_time_offset_analysis
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_imu_time_offset_analysis.py
+  )
+  add_test(
     NAME benchmark_compare_runs
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_benchmark_compare_runs.py
   )

--- a/experiments/imu_time_offset/README.md
+++ b/experiments/imu_time_offset/README.md
@@ -1,0 +1,39 @@
+# LiDAR-IMU time-offset experiment
+
+This experiment tests whether a fixed timestamp correction is identifiable and safe enough for
+a bounded runtime A/B test. It does not change production parameters or global localization.
+
+The approach follows LI-Init's motion-alignment initialization and LI-Calib's continuous-time
+treatment of asynchronous measurements:
+
+- [Robust Real-time LiDAR-inertial Initialization](https://arxiv.org/abs/2202.11006)
+- [Targetless Calibration of LiDAR-IMU System Based on Continuous-time Batch Estimation](https://arxiv.org/abs/2007.14759)
+
+The analyzer integrates gyro measurements over consecutive LiDAR/reference intervals while
+jointly fitting rotation and bias. A fine offset sweep is supplemented by a quadratic sub-grid
+estimate, the score at zero offset, the width of the near-optimal basin, and independent
+30-second window estimates. A runtime candidate must improve rotational RMSE over zero by 2%,
+have a one-percent basin no wider than 30 ms, and remain stable within 10 ms MAD across windows.
+
+Run all 11 Koide sequences with:
+
+```bash
+python3 experiments/imu_time_offset/run_dataset_analysis.py \
+  --data-root /media/sasaki/aiueo/datasets/koide_hard_localization \
+  --output-dir /media/sasaki/aiueo/datasets/koide_hard_localization/generated/imu_time_offset_20260714
+```
+
+## Decision
+
+Do not promote timestamp correction to production. The offline sweep found stable 1--4 ms
+estimates on most normal sequences and a much larger 46 ms estimate on `outdoor_kidnap_a`.
+That largest, most identifiable candidate was used as the bounded runtime gate. Compared with
+zero offset over the same 30-second replay, 46 ms increased translation RMSE from 0.1147 m to
+0.2012 m and rotation RMSE from 0.378 degrees to 1.204 degrees. Final translation error rose
+from 0.284 m to 1.097 m and final rotation error from 0.365 degrees to 7.058 degrees.
+
+The offline objective aligns gyro rotation with the ground-truth trajectory, but improving that
+objective does not guarantee better interaction with the current preintegration, scan timing,
+and NDT correction loop. The runtime parameter candidate was therefore removed. Production
+behavior remains unchanged; only the offline identifiability analyzer and recorded rejection
+evidence are retained.

--- a/experiments/imu_time_offset/__init__.py
+++ b/experiments/imu_time_offset/__init__.py
@@ -1,0 +1,1 @@
+"""Offline LiDAR-IMU time-offset validation experiment."""

--- a/experiments/imu_time_offset/results.json
+++ b/experiments/imu_time_offset/results.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "date": "2026-07-14",
+  "dataset_sequence_count": 11,
+  "offline_analysis": {
+    "full_results": "/media/sasaki/aiueo/datasets/koide_hard_localization/generated/imu_time_offset_20260714/summary.json",
+    "normal_sequence_offset_range_ms": [1.1, 3.6],
+    "outdoor_kidnap_a_offset_ms": 46.0,
+    "outdoor_kidnap_b_offset_ms": 35.4,
+    "outdoor_kidnap_b_window_mad_ms": 19.9
+  },
+  "runtime_ab": {
+    "sequence": "outdoor_kidnap_a",
+    "duration_sec": 30.0,
+    "baseline_offset_ms": 0.0,
+    "candidate_offset_ms": 45.9895,
+    "baseline": {
+      "translation_rmse_m": 0.11468331420202565,
+      "translation_error_last_m": 0.2836281166450853,
+      "rotation_rmse_deg": 0.37751401062455,
+      "rotation_error_last_deg": 0.365461493708264,
+      "matched_sample_count": 38,
+      "deskew_applied_ratio": 0.526
+    },
+    "candidate": {
+      "translation_rmse_m": 0.2012479323409892,
+      "translation_error_last_m": 1.09686234117455,
+      "rotation_rmse_deg": 1.2035264410757562,
+      "rotation_error_last_deg": 7.058011831891512,
+      "matched_sample_count": 36,
+      "deskew_applied_ratio": 0.684
+    },
+    "artifacts": "/media/sasaki/aiueo/datasets/koide_hard_localization/generated/imu_time_offset_20260714/runtime_ab_verified"
+  },
+  "promotion_decision": "rejected",
+  "reason": "The largest stable offline offset regressed every runtime trajectory metric, so the timestamp correction candidate was removed from production code.",
+  "production_runtime_changed": false
+}

--- a/experiments/imu_time_offset/run_dataset_analysis.py
+++ b/experiments/imu_time_offset/run_dataset_analysis.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Evaluate LiDAR-IMU temporal-offset identifiability on every Koide sequence."""
+
+import argparse
+import json
+from pathlib import Path
+import statistics
+import subprocess
+import sys
+
+
+SEQUENCES = {
+    "indoor_easy_01": ("/imu", "/points2/decompressed", "indoor"),
+    "indoor_easy_02": ("/imu", "/points2/decompressed", "indoor"),
+    "indoor_hard_01": ("/imu", "/points2/decompressed", "indoor"),
+    "indoor_kidnap_01": ("/imu", "/points2/decompressed", "indoor"),
+    "indoor_kidnap_02": ("/imu", "/points2/decompressed", "indoor"),
+    "outdoor_hard_01a": ("/livox/imu", "/livox/points", "outdoor"),
+    "outdoor_hard_01b": ("/livox/imu", "/livox/points", "outdoor"),
+    "outdoor_hard_02a": ("/livox/imu", "/livox/points", "outdoor"),
+    "outdoor_hard_02b": ("/livox/imu", "/livox/points", "outdoor"),
+    "outdoor_kidnap_a": ("/livox/imu", "/livox/points", "outdoor"),
+    "outdoor_kidnap_b": ("/livox/imu", "/livox/points", "outdoor"),
+}
+
+
+def classify_offset_candidate(metrics):
+    reasons = []
+    if metrics["window_count"] < 2:
+        reasons.append("insufficient_windows")
+    if metrics["search_boundary_window_count"] > 0:
+        reasons.append("window_hit_search_boundary")
+    if metrics["relative_rmse_improvement_over_zero"] < 0.02:
+        reasons.append("less_than_2pct_better_than_zero")
+    width = metrics["one_percent_best_width_sec"]
+    if width is None or width > 0.03:
+        reasons.append("broad_minimum")
+    mad = metrics["window_offset_mad_sec"]
+    if mad is None or mad > 0.01:
+        reasons.append("window_offset_unstable")
+    median = metrics["window_offset_median_sec"]
+    if median is None or abs(metrics["refined_offset_sec"] - median) > 0.015:
+        reasons.append("full_and_window_estimates_disagree")
+    return {
+        "decision": "runtime_ab_candidate" if not reasons else "reject",
+        "reasons": reasons,
+    }
+
+
+def compact_result(name, family, report):
+    alignment = report["between_cloud_alignment"]
+    identifiable = alignment["offset_identifiability"]
+    windows = report["time_offset_windows"]
+    metrics = {
+        "sequence": name,
+        "family": family,
+        "point_time_available": bool(report["point_time_hypotheses"]),
+        "best_grid_offset_sec": alignment["imu_minus_reference_time_offset_sec"],
+        "refined_offset_sec": identifiable["quadratic_refined_offset_sec"],
+        "zero_offset_rmse_rad_s": identifiable["zero_offset_rmse_rad_s"],
+        "best_offset_rmse_rad_s": identifiable["best_offset_rmse_rad_s"],
+        "relative_rmse_improvement_over_zero": identifiable[
+            "relative_rmse_improvement_over_zero"],
+        "one_percent_best_width_sec": identifiable["one_percent_best_width_sec"],
+        "best_at_search_boundary": identifiable["best_at_search_boundary"],
+        "window_count": windows["window_count"],
+        "window_offset_median_sec": windows.get("offset_median_sec"),
+        "window_offset_mad_sec": windows.get("offset_mad_sec"),
+        "window_offset_min_sec": windows.get("offset_min_sec"),
+        "window_offset_max_sec": windows.get("offset_max_sec"),
+        "search_boundary_window_count": windows.get(
+            "search_boundary_window_count", 0),
+    }
+    metrics.update(classify_offset_candidate(metrics))
+    return metrics
+
+
+def aggregate(results):
+    families = {}
+    for family in sorted({item["family"] for item in results}):
+        selected = [item for item in results if item["family"] == family]
+        families[family] = {
+            "sequence_count": len(selected),
+            "runtime_ab_candidate_count": sum(
+                item["decision"] == "runtime_ab_candidate" for item in selected),
+            "median_refined_offset_sec": statistics.median(
+                item["refined_offset_sec"] for item in selected),
+            "max_abs_refined_offset_sec": max(
+                abs(item["refined_offset_sec"]) for item in selected),
+        }
+    return families
+
+
+def markdown_report(summary):
+    lines = [
+        "# Koide LiDAR-IMU time-offset analysis",
+        "",
+        "Positive offset means the matching IMU measurement has a later timestamp than LiDAR.",
+        "The runtime gate requires a narrow optimum, at least 2% improvement over zero, and",
+        "agreement across 30-second windows. Indoor clouds have no per-point time field, so",
+        "their estimates can validate IMU prediction timing but cannot enable point deskew.",
+        "",
+        "| sequence | offset ms | zero improvement | width ms | window median/MAD ms | decision |",
+        "|---|---:|---:|---:|---:|---|",
+    ]
+    for item in summary["sequences"]:
+        median = item["window_offset_median_sec"]
+        mad = item["window_offset_mad_sec"]
+        window = "n/a" if median is None or mad is None else f"{median*1000:.1f}/{mad*1000:.1f}"
+        width = item["one_percent_best_width_sec"]
+        lines.append(
+            f"| {item['sequence']} | {item['refined_offset_sec']*1000:.1f} | "
+            f"{item['relative_rmse_improvement_over_zero']*100:.2f}% | "
+            f"{'n/a' if width is None else f'{width*1000:.1f}'} | {window} | "
+            f"{item['decision']} |")
+    lines.extend(["", f"Overall decision: **{summary['promotion_decision']}**", ""])
+    return "\n".join(lines)
+
+
+def main():
+    repo = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-root", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--sequence", action="append", choices=SEQUENCES)
+    parser.add_argument("--max-scans", type=int, default=0)
+    parser.add_argument("--offset-step-sec", type=float, default=0.001)
+    parser.add_argument("--window-sec", type=float, default=30.0)
+    parser.add_argument("--window-step-sec", type=float, default=0.005)
+    parser.add_argument(
+        "--analyzer", type=Path,
+        default=repo / "scripts" / "analyze_koide_imu_consistency.py")
+    args = parser.parse_args()
+
+    names = args.sequence or list(SEQUENCES)
+    assets = args.data_root / "generated" / "localization_gif_benchmarks" / "assets"
+    details = args.output_dir / "sequences"
+    details.mkdir(parents=True, exist_ok=True)
+    results = []
+    for name in names:
+        imu_topic, cloud_topic, family = SEQUENCES[name]
+        output = details / f"{name}.json"
+        command = [
+            sys.executable, str(args.analyzer),
+            "--bag", str(args.data_root / "sequences" / name),
+            "--reference", str(assets / f"{name}_reference.csv"),
+            "--output", str(output),
+            "--imu-topic", imu_topic,
+            "--cloud-topic", cloud_topic,
+            "--max-scans", str(args.max_scans),
+            "--time-offset-step-sec", str(args.offset_step_sec),
+            "--time-offset-window-sec", str(args.window_sec),
+            "--time-offset-window-step-sec", str(args.window_step_sec),
+        ]
+        print(f"Analyzing {name}...", flush=True)
+        subprocess.run(command, check=True, stdout=subprocess.DEVNULL)
+        results.append(compact_result(name, family, json.loads(output.read_text())))
+
+    candidates = [item for item in results if item["decision"] == "runtime_ab_candidate"]
+    deskew_candidates = [item for item in candidates if item["point_time_available"]]
+    summary = {
+        "schema_version": 1,
+        "purpose": "LiDAR-IMU temporal-offset validation; no global localization",
+        "sequence_count": len(results),
+        "all_expected_sequences_analyzed": set(names) == set(SEQUENCES),
+        "sequences": results,
+        "families": aggregate(results),
+        "runtime_ab_candidates": [item["sequence"] for item in candidates],
+        "deskew_runtime_ab_candidates": [item["sequence"] for item in deskew_candidates],
+        "promotion_decision": (
+            "run_bounded_runtime_ab" if deskew_candidates else
+            "reject_runtime_offset_no_stable_deskew_candidate"),
+    }
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+    (args.output_dir / "summary.md").write_text(markdown_report(summary))
+    print(args.output_dir / "summary.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze_koide_imu_consistency.py
+++ b/scripts/analyze_koide_imu_consistency.py
@@ -423,7 +423,8 @@ def evaluate_hypothesis(name, scans, imu_times, gyro, ref_times, ref_quats):
 
 def evaluate_between_cloud_stamps(
         scans, imu_times, gyro, ref_times, ref_quats,
-        offset_min_sec=-0.25, offset_max_sec=0.25, offset_step_sec=0.005):
+        offset_min_sec=-0.25, offset_max_sec=0.25, offset_step_sec=0.005,
+        include_offset_profile=True):
     """Fit gyro axes/bias and IMU-reference time offset between cloud stamps.
 
     Unlike the per-point scan-time hypotheses, this works for clouds without a
@@ -476,6 +477,33 @@ def evaluate_between_cloud_stamps(
 
     _, offset, source, target, durations, rotation, bias, fitted = min(
         candidates, key=lambda item: item[0])
+    ordered_candidates = sorted(candidates, key=lambda item: item[1])
+    best_index = min(
+        range(len(ordered_candidates)), key=lambda index: ordered_candidates[index][0])
+    best_rmse = ordered_candidates[best_index][0]
+    zero_candidate = min(ordered_candidates, key=lambda item: abs(item[1]))
+    refined_offset = offset
+    if 0 < best_index < len(ordered_candidates) - 1:
+        left = ordered_candidates[best_index - 1]
+        center = ordered_candidates[best_index]
+        right = ordered_candidates[best_index + 1]
+        denominator = left[0] - 2.0 * center[0] + right[0]
+        if denominator > 0.0:
+            refinement = 0.5 * (left[0] - right[0]) / denominator
+            refined_offset = (
+                center[1] + float(np.clip(refinement, -1.0, 1.0)) * offset_step_sec)
+    near_best = [item[1] for item in ordered_candidates if item[0] <= best_rmse * 1.01]
+    identifiability = {
+        "zero_offset_rmse_rad_s": zero_candidate[0],
+        "best_offset_rmse_rad_s": best_rmse,
+        "relative_rmse_improvement_over_zero": (
+            (zero_candidate[0] - best_rmse) / zero_candidate[0]
+            if zero_candidate[0] > 0.0 else 0.0),
+        "one_percent_best_width_sec": (
+            max(near_best) - min(near_best) if near_best else None),
+        "quadratic_refined_offset_sec": refined_offset,
+        "best_at_search_boundary": best_index in (0, len(ordered_candidates) - 1),
+    }
     identity = residual_summary(np.eye(3), np.zeros(3), source, target, durations)
     permutations = []
     for matrix in right_handed_axis_permutations():
@@ -484,7 +512,7 @@ def evaluate_between_cloud_stamps(
         summary = residual_summary(matrix, permutation_bias, source, target, durations)
         permutations.append((summary["rate_rmse_rad_s"], matrix, permutation_bias, summary))
     _, axis_matrix, axis_bias, axis_summary = min(permutations, key=lambda item: item[0])
-    return {
+    result = {
         "usable_interval_count": int(len(source)),
         "imu_minus_reference_time_offset_sec": offset,
         "offset_search": {
@@ -493,6 +521,7 @@ def evaluate_between_cloud_stamps(
             "step_sec": offset_step_sec,
             "candidate_count": len(candidates),
         },
+        "offset_identifiability": identifiability,
         "identity": identity,
         "wahba": {
             **fitted,
@@ -506,6 +535,65 @@ def evaluate_between_cloud_stamps(
             "gyro_bias_sensor_rad_s": axis_bias.tolist(),
         },
     }
+    if include_offset_profile:
+        result["offset_profile"] = [
+            {"offset_sec": item[1], "rate_rmse_rad_s": item[0]}
+            for item in ordered_candidates
+        ]
+    return result
+
+
+def evaluate_time_offset_windows(
+        scans, imu_times, gyro, ref_times, ref_quats,
+        window_sec=30.0, offset_min_sec=-0.25, offset_max_sec=0.25,
+        offset_step_sec=0.005):
+    """Measure whether an offset estimate remains stable across time windows."""
+    if window_sec <= 0.0 or not scans:
+        return {"window_sec": window_sec, "window_count": 0, "windows": []}
+    first_stamp = scans[0][0]
+    grouped = {}
+    for scan in scans:
+        index = int(math.floor((scan[0] - first_stamp) / window_sec))
+        grouped.setdefault(index, []).append(scan)
+    windows = []
+    for index, selected in sorted(grouped.items()):
+        if len(selected) < 11:
+            continue
+        try:
+            result = evaluate_between_cloud_stamps(
+                selected, imu_times, gyro, ref_times, ref_quats,
+                offset_min_sec, offset_max_sec, offset_step_sec,
+                include_offset_profile=False)
+        except RuntimeError:
+            continue
+        identifiability = result["offset_identifiability"]
+        windows.append({
+            "start_sec": selected[0][0],
+            "end_sec": selected[-1][0],
+            "scan_count": len(selected),
+            "offset_sec": result["imu_minus_reference_time_offset_sec"],
+            "quadratic_refined_offset_sec": identifiability[
+                "quadratic_refined_offset_sec"],
+            "relative_rmse_improvement_over_zero": identifiability[
+                "relative_rmse_improvement_over_zero"],
+            "one_percent_best_width_sec": identifiability[
+                "one_percent_best_width_sec"],
+            "best_at_search_boundary": identifiability[
+                "best_at_search_boundary"],
+        })
+    offsets = np.asarray([item["quadratic_refined_offset_sec"] for item in windows])
+    summary = {"window_sec": window_sec, "window_count": len(windows), "windows": windows}
+    if offsets.size:
+        median = float(np.median(offsets))
+        summary.update({
+            "offset_median_sec": median,
+            "offset_mad_sec": float(np.median(np.abs(offsets - median))),
+            "offset_min_sec": float(np.min(offsets)),
+            "offset_max_sec": float(np.max(offsets)),
+            "search_boundary_window_count": sum(
+                item["best_at_search_boundary"] for item in windows),
+        })
+    return summary
 
 
 def main():
@@ -519,6 +607,8 @@ def main():
     parser.add_argument("--time-offset-min-sec", type=float, default=-0.25)
     parser.add_argument("--time-offset-max-sec", type=float, default=0.25)
     parser.add_argument("--time-offset-step-sec", type=float, default=0.005)
+    parser.add_argument("--time-offset-window-sec", type=float, default=30.0)
+    parser.add_argument("--time-offset-window-step-sec", type=float, default=0.005)
     args = parser.parse_args()
     ref_times, ref_quats = load_reference(args.reference)
     bag = read_bag(
@@ -526,6 +616,10 @@ def main():
     interval_alignment = evaluate_between_cloud_stamps(
         bag["scans"], bag["imu_times"], bag["gyro"], ref_times, ref_quats,
         args.time_offset_min_sec, args.time_offset_max_sec, args.time_offset_step_sec)
+    offset_windows = evaluate_time_offset_windows(
+        bag["scans"], bag["imu_times"], bag["gyro"], ref_times, ref_quats,
+        args.time_offset_window_sec, args.time_offset_min_sec,
+        args.time_offset_max_sec, args.time_offset_window_step_sec)
     point_time_hypotheses = {}
     if sum(scan[1] is not None and scan[1] > 0.0 for scan in bag["scans"]) >= 10:
         point_time_hypotheses = {
@@ -548,7 +642,7 @@ def main():
             static_rotation.T @ fitted_rotation)
     cloud_times = np.asarray([scan[0] for scan in bag["scans"]])
     report = {
-        "schema_version": 2,
+        "schema_version": 3,
         "bag": str(args.bag.resolve()),
         "reference": str(args.reference.resolve()),
         "imu_topic": args.imu_topic,
@@ -564,6 +658,7 @@ def main():
         "cloud_timing": timing_summary(
             cloud_times, bag["cloud_header_minus_record"]),
         "between_cloud_alignment": interval_alignment,
+        "time_offset_windows": offset_windows,
         "accelerometer": accel,
         "point_time_hypotheses": point_time_hypotheses,
     }

--- a/scripts/benchmark_runner
+++ b/scripts/benchmark_runner
@@ -174,6 +174,7 @@ class ManagedProcessCleanup:
             self._cleaned = True
             processes = list(reversed(self._processes))
             monitor = self._monitor
+        child_process_groups = set(direct_child_process_ids())
         if monitor is not None:
             monitor.stop()
             monitor.join(timeout=2.0)
@@ -186,6 +187,9 @@ class ManagedProcessCleanup:
                     managed.stderr_stream.close()
                 except OSError:
                     pass
+        child_process_groups.update(direct_child_process_ids())
+        for process_group_id in child_process_groups:
+            force_stop_process_group(process_group_id)
 
 
 def build_stats(samples: List[Dict[str, float]]) -> Dict[str, Optional[float]]:
@@ -267,6 +271,25 @@ def process_group_exists(process_group_id: int) -> bool:
     except PermissionError:
         return True
     return True
+
+
+def direct_child_process_ids() -> List[int]:
+    path = f"/proc/{os.getpid()}/task/{os.getpid()}/children"
+    try:
+        with open(path, "r", encoding="utf-8") as stream:
+            return [int(value) for value in stream.read().split()]
+    except (FileNotFoundError, OSError, ValueError):
+        return []
+
+
+def force_stop_process_group(process_group_id: int) -> None:
+    """Final Linux fail-safe for a child launched just before registration."""
+    if not process_group_exists(process_group_id):
+        return
+    try:
+        os.killpg(process_group_id, signal.SIGKILL)
+    except ProcessLookupError:
+        return
 
 
 def wait_for_process_group_exit(
@@ -460,9 +483,14 @@ def wait_for_pid(pattern: str, timeout_sec: float) -> Optional[int]:
     return None
 
 
-def exit_on_termination_signal(signum: int, _frame: object) -> None:
-    """Convert SIGTERM into normal interpreter unwinding so atexit cleanup runs."""
-    raise SystemExit(128 + signum)
+def install_termination_signal_handlers(cleanup: ManagedProcessCleanup) -> None:
+    """Synchronously clean managed groups before leaving on SIGINT or SIGTERM."""
+    def handle(signum: int, _frame: object) -> None:
+        cleanup.stop_all()
+        raise SystemExit(128 + signum)
+
+    signal.signal(signal.SIGINT, handle)
+    signal.signal(signal.SIGTERM, handle)
 
 
 def main() -> int:
@@ -470,7 +498,7 @@ def main() -> int:
     os.makedirs(args.output_dir, exist_ok=True)
     cleanup = ManagedProcessCleanup(args.shutdown_timeout)
     atexit.register(cleanup.stop_all)
-    signal.signal(signal.SIGTERM, exit_on_termination_signal)
+    install_termination_signal_handlers(cleanup)
 
     pose_csv_path = os.path.join(args.output_dir, "pose_trace.csv")
     diagnostic_csv_path = os.path.join(args.output_dir, "alignment_status.csv")

--- a/test/test_analyze_koide_imu_consistency.py
+++ b/test/test_analyze_koide_imu_consistency.py
@@ -72,6 +72,33 @@ class ImuConsistencyMathTest(unittest.TestCase):
         self.assertAlmostEqual(
             result["imu_minus_reference_time_offset_sec"], true_offset, delta=0.011)
         self.assertLess(result["wahba"]["rate_rmse_rad_s"], 1e-3)
+        identifiability = result["offset_identifiability"]
+        self.assertAlmostEqual(
+            identifiability["quadratic_refined_offset_sec"], true_offset, delta=0.011)
+        self.assertGreater(
+            identifiability["relative_rmse_improvement_over_zero"], 0.9)
+        self.assertFalse(identifiability["best_at_search_boundary"])
+        self.assertEqual(len(result["offset_profile"]), 31)
+
+    def test_time_offset_windows_report_stability(self):
+        imu_times = np.linspace(0.0, 16.0, 16001)
+        true_offset = -0.04
+        angular_rate = 0.3 + 0.12 * np.sin(2.1 * (imu_times - true_offset))
+        gyro = np.column_stack((
+            np.zeros_like(imu_times), np.zeros_like(imu_times), angular_rate))
+        cloud_times = np.arange(1.0, 15.0, 0.1)
+        yaw = 0.3 * cloud_times - (0.12 / 2.1) * np.cos(2.1 * cloud_times)
+        quaternions = np.column_stack((
+            np.zeros_like(yaw), np.zeros_like(yaw),
+            np.sin(0.5 * yaw), np.cos(0.5 * yaw)))
+        scans = [(stamp, None, "lidar") for stamp in cloud_times]
+        result = MODULE.evaluate_time_offset_windows(
+            scans, imu_times, gyro, cloud_times, quaternions,
+            window_sec=3.0, offset_min_sec=-0.1, offset_max_sec=0.1,
+            offset_step_sec=0.01)
+        self.assertEqual(result["window_count"], 5)
+        self.assertAlmostEqual(result["offset_median_sec"], true_offset, delta=0.012)
+        self.assertLess(result["offset_mad_sec"], 0.012)
 
     def test_accelerometer_unit_scale_distinguishes_g_and_si(self):
         g_samples = np.tile([0.0, 0.0, 1.0], (20, 1))

--- a/test/test_imu_time_offset_analysis.py
+++ b/test/test_imu_time_offset_analysis.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+from pathlib import Path
+import unittest
+
+
+SCRIPT = (Path(__file__).resolve().parents[1] / "experiments" /
+          "imu_time_offset" / "run_dataset_analysis.py")
+SPEC = importlib.util.spec_from_file_location("imu_time_offset_analysis", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class ImuTimeOffsetAnalysisTest(unittest.TestCase):
+    def test_manifest_covers_all_eleven_sequences(self):
+        self.assertEqual(len(MODULE.SEQUENCES), 11)
+        self.assertEqual(
+            sum(value[2] == "outdoor" for value in MODULE.SEQUENCES.values()), 6)
+
+    def test_stable_narrow_offset_becomes_runtime_candidate(self):
+        metrics = {
+            "window_count": 5,
+            "search_boundary_window_count": 0,
+            "relative_rmse_improvement_over_zero": 0.08,
+            "one_percent_best_width_sec": 0.02,
+            "window_offset_mad_sec": 0.004,
+            "window_offset_median_sec": 0.04,
+            "refined_offset_sec": 0.043,
+        }
+        self.assertEqual(
+            MODULE.classify_offset_candidate(metrics)["decision"],
+            "runtime_ab_candidate")
+
+    def test_flat_or_unstable_offset_is_rejected(self):
+        metrics = {
+            "window_count": 4,
+            "search_boundary_window_count": 0,
+            "relative_rmse_improvement_over_zero": 0.005,
+            "one_percent_best_width_sec": 0.08,
+            "window_offset_mad_sec": 0.03,
+            "window_offset_median_sec": -0.02,
+            "refined_offset_sec": 0.04,
+        }
+        result = MODULE.classify_offset_candidate(metrics)
+        self.assertEqual(result["decision"], "reject")
+        self.assertIn("broad_minimum", result["reasons"])
+        self.assertIn("window_offset_unstable", result["reasons"])
+
+    def test_recorded_runtime_gate_rejects_promotion(self):
+        result = json.loads(
+            (SCRIPT.parent / "results.json").read_text(encoding="utf-8"))
+        self.assertEqual(result["dataset_sequence_count"], 11)
+        self.assertEqual(result["promotion_decision"], "rejected")
+        self.assertFalse(result["production_runtime_changed"])
+        runtime = result["runtime_ab"]
+        self.assertGreater(
+            runtime["candidate"]["translation_rmse_m"],
+            runtime["baseline"]["translation_rmse_m"])
+        self.assertGreater(
+            runtime["candidate"]["rotation_rmse_deg"],
+            runtime["baseline"]["rotation_rmse_deg"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- extend the Koide IMU analyzer with a fine offset profile, sub-grid estimate, zero-offset comparison, and 30-second window stability metrics
- add an all-11-sequence LiDAR–IMU time-offset experiment with JSON/Markdown reporting and recorded runtime rejection evidence
- document the LI-Init/LI-Calib motivation and why the candidate was not promoted
- strengthen benchmark shutdown by synchronously cleaning on SIGINT/SIGTERM and adding a direct-child process-group fail-safe

## Findings

Most normal Koide sequences produced 1–4 ms offline estimates. `outdoor_kidnap_a` produced the strongest stable candidate at 45.9895 ms, but the verified 30-second runtime A/B regressed translation RMSE from 0.1147 m to 0.2012 m and rotation RMSE from 0.378° to 1.204°. The runtime parameter candidate was removed, so production localization behavior remains unchanged.

## Validation

- Koide offline analysis: all 11 sequences
- verified 30-second runtime A/B on `outdoor_kidnap_a`
- benchmark cleanup stress test: 40 consecutive SIGINT/SIGTERM runs
- Jazzy package build succeeded
- CTest: 73/73 passed
- `git diff --check` passed
