### PR TITLE
Improve IMU preintegration stability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,6 +471,37 @@ if(BUILD_TESTING)
     COMMAND test_imu_preintegration_diagnostics_policy
   )
 
+  add_executable(test_imu_seed_consistency_policy
+    test/test_imu_seed_consistency_policy.cpp)
+  target_include_directories(test_imu_seed_consistency_policy PRIVATE
+    include)
+  add_test(
+    NAME imu_seed_consistency_policy
+    COMMAND test_imu_seed_consistency_policy
+  )
+
+  add_executable(test_imu_queue_policy
+    test/test_imu_queue_policy.cpp)
+  target_include_directories(test_imu_queue_policy PRIVATE
+    include ${EIGEN3_INCLUDE_DIRS})
+  target_link_libraries(test_imu_queue_policy
+    Eigen3::Eigen)
+  add_test(
+    NAME imu_queue_policy
+    COMMAND test_imu_queue_policy
+  )
+
+  add_executable(test_imu_initialization_policy
+    test/test_imu_initialization_policy.cpp)
+  target_include_directories(test_imu_initialization_policy PRIVATE
+    include ${EIGEN3_INCLUDE_DIRS})
+  target_link_libraries(test_imu_initialization_policy
+    Eigen3::Eigen)
+  add_test(
+    NAME imu_initialization_policy
+    COMMAND test_imu_initialization_policy
+  )
+
   add_executable(test_deskew_readiness_policy
     test/test_deskew_readiness_policy.cpp)
   target_include_directories(test_deskew_readiness_policy PRIVATE

--- a/docs/imu_estimation.md
+++ b/docs/imu_estimation.md
@@ -70,8 +70,12 @@ It is registered in `CMakeLists.txt` and runs under `colcon test` as
 A LiDAR localizer must not let a bad IMU integration drag the pose. The guard
 policy (`imu_preintegration_guard_policy.hpp`) enforces that:
 
-- IMU preintegration is used as the registration seed/prediction path; the
-  accepted LiDAR registration measurement remains the published pose anchor;
+- the default-on consistency gate first compares IMU predictions with accepted
+  LiDAR poses without applying them to registration; only the configured number
+  of consecutive translation-and-rotation passes permits the next IMU seed;
+- after permission, IMU preintegration can be used as the registration
+  seed/prediction path while the accepted LiDAR measurement remains the
+  published pose anchor;
 - if the IMU prediction and the NDT correction disagree by more than
   `imu_prediction_correction_guard_translation_m` (2.0 m) or
   `imu_prediction_correction_guard_yaw_deg` (10.0°), or the smoother update is
@@ -79,6 +83,10 @@ policy (`imu_preintegration_guard_policy.hpp`) enforces that:
   and resets the IMU smoother to that measurement before continuing;
 - fallback mode is reserved for an already-disabled IMU preintegration state;
 - the guard is itself unit-tested (`test_imu_preintegration_guard_policy.cpp`).
+- finite threshold violations or non-finite predictions immediately revoke
+  seed permission; a temporarily unavailable prediction cannot be used for
+  that scan but does not erase an already established gate
+  (`test_imu_seed_consistency_policy.cpp`).
 
 This is the same design principle as the rest of the stack (see
 [pose_covariance.md](pose_covariance.md), the G3 reinitialization guard): a
@@ -91,6 +99,12 @@ component that feeds itself must not be able to diverge unbounded.
 | `use_imu` | `false` | Enable the legacy IMU correction path |
 | `use_imu_preintegration` | `true` | Use the guarded preintegration smoother from `/imu`, independent of `use_imu` |
 | `imu_preintegration_use_base_frame_transform` | `false` | Transform IMU samples into the base frame before integrating |
+| `imu_accel_scale` | `1.0` | Multiply incoming acceleration before integration; use `9.80665` only for drivers/bags that publish acceleration in `g` rather than m/s² |
+| `imu_seed_consistency_gate_enabled` | `true` | Keep IMU prediction diagnostic-only until consecutive LiDAR comparisons pass |
+| `imu_seed_consistency_max_translation_error_m` | `0.5` | Maximum open-loop IMU-vs-LiDAR translation error for one pass |
+| `imu_seed_consistency_max_rotation_error_deg` | `5.0` | Maximum open-loop IMU-vs-LiDAR rotation error for one pass |
+| `imu_seed_consistency_required_consecutive_passes` | `5` | Consecutive passes required before an IMU prediction may seed registration |
+| `imu_dual_queue_enabled` | `true` | LIO-SAM-style optimization/prediction queues with correction-time repropagation and velocity/bias retention; set `false` only for the legacy single-stream A/B baseline |
 | `use_continuous_time_deskew` | `false` | Experimental default-off hook that deskews the pre-voxel scan using per-point timing and IMU-predicted relative motion |
 | `continuous_time_deskew_mode` | `relative_motion` | Experimental motion source: `relative_motion`, `imu_pose_history`, or `lidar_constant_velocity` |
 | `continuous_time_cloud_stamp_reference` | `start` | Whether the cloud header is the scan `start` or `end`; Koide Livox uses `start` |

--- a/docs/imu_estimation.md
+++ b/docs/imu_estimation.md
@@ -94,17 +94,32 @@ component that feeds itself must not be able to diverge unbounded.
 
 ## Parameters
 
+### Backend and input units
+
 | Parameter | Default | Meaning |
 | --- | --- | --- |
 | `use_imu` | `false` | Enable the legacy IMU correction path |
 | `use_imu_preintegration` | `true` | Use the guarded preintegration smoother from `/imu`, independent of `use_imu` |
 | `imu_preintegration_use_base_frame_transform` | `false` | Transform IMU samples into the base frame before integrating |
 | `imu_accel_scale` | `1.0` | Multiply incoming acceleration before integration; use `9.80665` only for drivers/bags that publish acceleration in `g` rather than m/s² |
+| `imu_dual_queue_enabled` | `true` | LIO-SAM-style optimization/prediction queues with correction-time repropagation and velocity/bias retention; set `false` only for the legacy single-stream A/B baseline |
+
+### Seed safety and correction guards
+
+| Parameter | Default | Meaning |
+| --- | --- | --- |
 | `imu_seed_consistency_gate_enabled` | `true` | Keep IMU prediction diagnostic-only until consecutive LiDAR comparisons pass |
 | `imu_seed_consistency_max_translation_error_m` | `0.5` | Maximum open-loop IMU-vs-LiDAR translation error for one pass |
 | `imu_seed_consistency_max_rotation_error_deg` | `5.0` | Maximum open-loop IMU-vs-LiDAR rotation error for one pass |
 | `imu_seed_consistency_required_consecutive_passes` | `5` | Consecutive passes required before an IMU prediction may seed registration |
-| `imu_dual_queue_enabled` | `true` | LIO-SAM-style optimization/prediction queues with correction-time repropagation and velocity/bias retention; set `false` only for the legacy single-stream A/B baseline |
+| `imu_prediction_correction_guard_translation_m` | `2.0` | Reset the IMU smoother if IMU-vs-NDT translation disagrees beyond this |
+| `imu_prediction_correction_guard_yaw_deg` | `10.0` | Reset the IMU smoother if IMU-vs-NDT yaw disagrees beyond this |
+| `imu_prediction_correction_guard_warmup_accepts` | `5` | Accepted NDT corrections required before enforcing the correction guard |
+
+### Continuous-time deskew and diagnostics (experimental)
+
+| Parameter | Default | Meaning |
+| --- | --- | --- |
 | `use_continuous_time_deskew` | `false` | Experimental default-off hook that deskews the pre-voxel scan using per-point timing and IMU-predicted relative motion |
 | `continuous_time_deskew_mode` | `relative_motion` | Experimental motion source: `relative_motion`, `imu_pose_history`, or `lidar_constant_velocity` |
 | `continuous_time_cloud_stamp_reference` | `start` | Whether the cloud header is the scan `start` or `end`; Koide Livox uses `start` |
@@ -112,6 +127,11 @@ component that feeds itself must not be able to diverge unbounded.
 | `continuous_time_pose_history_duration_sec` | `2.0` | Bounded rotation-only IMU pose-history horizon used by `imu_pose_history` |
 | `enable_localizability_guard` | `false` | Experimental XY scan-covariance proxy; suppress the previous-delta seed only below its threshold |
 | `localizability_min_xy_eigen_ratio` | `0.05` | Minimum XY covariance eigenvalue ratio for the proxy guard |
+
+### Preintegration noise and factor model
+
+| Parameter | Default | Meaning |
+| --- | --- | --- |
 | `imu_gyro_noise_density` | `0.01` | rad/s/√Hz |
 | `imu_accel_noise_density` | `0.1` | m/s²/√Hz |
 | `imu_gyro_random_walk` | `0.0001` | rad/s²/√Hz |
@@ -119,8 +139,6 @@ component that feeds itself must not be able to diverge unbounded.
 | `imu_bias_prior_sigma_gyro` | `0.01` | gyro bias prior σ |
 | `imu_bias_prior_sigma_accel` | `0.1` | accel bias prior σ |
 | `imu_ndt_sigma_z` / `_roll` / `_pitch` | `0.1` / `0.05` / `0.05` | NDT prior σ on the axes IMU constrains most |
-| `imu_prediction_correction_guard_translation_m` | `2.0` | reset IMU smoother if IMU-vs-NDT disagree beyond this |
-| `imu_prediction_correction_guard_yaw_deg` | `10.0` | reset IMU smoother if IMU-vs-NDT yaw disagree beyond this |
 
 Set the noise densities from your IMU datasheet (or an Allan-variance run) for
 best results; the defaults are MEMS-grade ballpark values.

--- a/docs/research_driven_development_plan.md
+++ b/docs/research_driven_development_plan.md
@@ -194,6 +194,19 @@ alignment p95 `<=1.2`とした。全candidateがFAILしたため、既定値はd
 なお全modeでcrash、NaN、再初期化要求は0だった。共有機のCPU使用率が高いため、latency値は
 候補間gateにのみ使い、一般性能claimにはしない。
 
+### R1 IMU/scan時刻同期buffer result (2026-07-14): negative
+
+NDT計算中に未来時刻のIMUがsmootherへ入る可能性を切り分けるため、変換済みIMUをbufferし、
+対象cloud時刻までだけ積分するprototypeを同じ85--112 s区間で実行した。0.65 sのIMU gap後に
+回復する処理を含めても、deskew適用率は`3.8%`、trajectory coverageは`6.3%`、translation
+RMSEは`6.599 m`だった。最初の不正確なIMU seed後にregistrationが連続rejectされ、accepted
+poseからの正しい積分窓が1 sを超えたためである。時刻同期だけでは、初期速度0やbiasを含む
+open-loop seed誤差を解決できない。prototypeはrevertした。測定値と判断は
+[`../experiments/imu_scan_time_sync/README.md`](../experiments/imu_scan_time_sync/README.md)に残す。
+
+次のIMU runtime候補は、初期速度を観測または推定し、NDTへ接続する前のopen-loop seed accuracy
+gateを通すことを前提とする。deskew適用率だけを上げる変更は引き続き採用しない。
+
 ## Phase R2: Localizability診断と退化方向の抑制
 
 仮説: scalar fitnessだけではcorridor aliasや旋回時の弱拘束方向を判別できない。
@@ -324,6 +337,36 @@ Boreasでは閾値sweepを再開する前にdata contractを検証する。
 
 目安は1人で既存machineを使うengineering effortであり、dataset downloadやidle-machine待ちは
 含まない。各gateで仮説が反証された場合、次phaseへ機械的に進まず本書へnegative resultを追記する。
+
+## IMU seed consistency gate result (2026-07-14)
+
+直接のsmoother state保持やscan時刻queueの試作は、最初の不正確な予測がNDTのfeedback loopへ
+入った後にKoideで大きく悪化した。代わりにopen-loop比較を先行させる。IMU予測と受理済み
+LiDAR poseを比較し、0.5 mかつ5度以内を5回連続で満たすまでseedを禁止する。欠測、非有限値、
+閾値超過または非有限予測ではfail closedする。確立前の欠測は連続列を切るが、確立後の一時的な
+予測欠測は不一致の証拠ではないためpermissionを保持し、そのscanでは予測自体を使用しない。
+
+Koide `outdoor_hard_01a`先頭30秒では、並進誤差中央値0.995 m、回転誤差中央値5.25度、
+最長合格列4/5だった。このため44 alignment rowでIMU seedは0回だった。これは安全gateの
+期待どおりの結果であり、IMU精度改善を意味しない。詳細とmachine-readable値は
+`experiments/imu_seed_consistency/`に保存した。
+
+その後、noise densityの離散化で`density^2 / dt`が欠落していたことと、Koide Livox
+accelerationがm/s²ではなく`g`単位であることを特定した。単位修正、明示scale=9.80665、
+初期速度、状態保持、scan-bounded dual queueを組み合わせた先頭30秒の候補は、並進予測
+中央値0.064 m、回転0.763度、seed 38/47、reject streak 0、coverage 98.0%、並進RMSE
+0.079 mとなった。同じscaleのsingle-stream対照はcoverage 76.0%、並進RMSE 0.242 m、
+reject streak 8だった。詳細は`experiments/imu_dual_queue/`に保存した。
+
+その後、1秒window境界に10 msのtimestamp/scheduler jitter許容を設け（1.1秒の実gapは拒否）、
+IMU coverageが無い受理scanではIMU factorを捏造せずpose-only anchorとしてvelocity/biasを保持した。
+`outdoor_hard_01a`先頭30秒、同bagのoffset 85秒、`outdoor_hard_02a`先頭30秒を各3 repeatした結果、
+dual queueは全9 runでreject streak 0、coverage worst 96.7%以上となった。このmulti-window/
+multi-sequence gateを通過したため`imu_dual_queue_enabled=true`へ昇格した。
+
+dual queueとrelative-motion deskewを組み合わせた追加gateでは、`outdoor_hard_01a`は3/3通過したが、
+`outdoor_hard_02a`のtranslation RMSE中央値がno-deskew 0.095 mから0.146 mへ悪化した。
+したがってdual queue本体のみ採用し、continuous-time deskewはdefault-offを維持する。
 
 ## 直近の着手項目
 

--- a/experiments/imu_dual_queue/README.md
+++ b/experiments/imu_dual_queue/README.md
@@ -1,0 +1,80 @@
+# Scan-bounded dual IMU queue experiment
+
+Date: 2026-07-14
+
+This candidate follows the LIO-SAM separation between an optimization IMU
+queue and a prediction/repropagation queue. It also preserves optimized
+velocity and bias across accepted LiDAR updates, integrates only causal samples
+through the scan timestamp, and keeps the consistency gate in front of the NDT
+seed.
+
+## Bugs found before the passing probe
+
+1. `gyro_noise_density` and `accel_noise_density` are continuous densities in
+   `/sqrt(Hz)`, but the discrete measurement variance omitted division by
+   `dt`. At 200 Hz this made the IMU factor roughly 200 times overconfident.
+2. Koide `outdoor_hard_01a` publishes Livox acceleration in `g`, not m/s².
+   Offline LI-Init-style analysis measured the required scale as `9.80665`.
+3. Resetting velocity to zero at every correction produced metre-scale
+   open-loop errors. The candidate transfers optimized velocity/bias and uses a
+   bounded LiDAR finite-difference velocity only when a reset is unavoidable.
+
+All three issues have analytical or behavioral regression tests. The
+dataset-specific acceleration scale remains an explicit parameter; it is not
+auto-guessed at runtime.
+
+## Same-window result
+
+Dataset: Koide `outdoor_hard_01a`, first 30 seconds. Both IMU modes used
+`imu_accel_scale=9.80665`; only the candidate enabled the dual queue.
+
+| Metric | Current single stream | Dual queue candidate |
+| --- | ---: | ---: |
+| Finite open-loop comparisons | 40 | 43 |
+| Translation prediction median | 0.988 m | 0.064 m |
+| Rotation prediction median | 4.633 deg | 0.763 deg |
+| IMU seed rows | 2/46 | 38/47 |
+| Reject streak max | 8 | 0 |
+| Pose coverage | 22.80/30 s (76.0%) | 29.40/30 s (98.0%) |
+| Translation RMSE | 0.242 m | 0.079 m |
+| Rotation RMSE | 2.486 deg | 1.084 deg |
+| Translation end error | 1.391 m | 0.057 m |
+| Rotation end error | 14.314 deg | 0.354 deg |
+| Alignment latency median | 0.297 s | 0.272 s |
+| Alignment latency p95 | 0.412 s | 0.391 s |
+
+Candidate artifacts are on the external SSD under
+`generated/imu_dual_queue_covariance_probe_20260714`; the single-stream control
+is under `generated/imu_single_queue_covariance_probe_20260714`.
+
+## Decision
+
+The initial probe was followed by three repeats on each of three fixtures.
+
+| Fixture | Candidate median (worst) coverage | Translation RMSE | Rotation RMSE | End translation | End rotation | Reject max | Seed ratio | Latency p95 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `outdoor_hard_01a`, 0–30 s | 98.0% (98.0%) | 0.085 (0.085) m | 1.134 (1.185) deg | 0.054 (0.057) m | 0.330 (0.350) deg | 0 | 85.4% (84.8%) | 0.323 (0.336) s |
+| `outdoor_hard_01a`, 85–112 s | 96.7% (96.7%) | 0.073 (0.081) m | 0.895 (1.061) deg | 0.031 (0.034) m | 0.517 (0.535) deg | 0 | 69.0% (67.5%) | 0.442 (0.457) s |
+| `outdoor_hard_02a`, 0–30 s | 98.7% (98.3%) | 0.095 (0.096) m | 1.051 (1.141) deg | 0.117 (0.125) m | 1.101 (1.122) deg | 0 | 86.0% (74.5%) | 0.323 (0.375) s |
+
+The remaining nondeterministic failure was traced to a `1.000281 s` scan
+interval being rejected by an exact `1.000000 s` guard. A 10 ms timestamp/
+scheduler tolerance admits this boundary case while still rejecting genuine
+`1.1 s` gaps. Accepted scans without causal IMU coverage now advance through a
+pose-only anchor rather than erasing optimized velocity and bias.
+
+The dual queue passed all nine repeats and is promoted to
+`imu_dual_queue_enabled=true`. The comparison runner still provides
+`imu_preintegration` as the explicit legacy single-stream control.
+
+Continuous-time deskew remains default-off. With the promoted dual queue it
+applied to at least 87.5% of `outdoor_hard_01a` rows and passed three repeats,
+but on `outdoor_hard_02a` its median translation RMSE regressed from `0.095 m`
+to `0.146 m` across three repeats. The `imu_dual_queue_deskew` runner mode is
+retained only for reproducible future experiments.
+
+Repeated artifacts are on the external SSD under `runs/`:
+`imu_jitter_tolerance_ab_20260714`, `imu_jitter_corner_ab_20260714`,
+`imu_jitter_outdoor_hard_02a_ab_20260714`,
+`imu_dual_queue_deskew_ab_20260714`, and
+`imu_dual_queue_deskew_outdoor_hard_02a_20260714`.

--- a/experiments/imu_dual_queue/results.json
+++ b/experiments/imu_dual_queue/results.json
@@ -1,0 +1,117 @@
+{
+  "date": "2026-07-14",
+  "imu_accel_scale": 9.80665,
+  "repeat_count_per_fixture": 3,
+  "dual_queue_no_deskew": {
+    "outdoor_hard_01a_0_30": {
+      "coverage_ratio_median": 0.979979,
+      "coverage_ratio_worst": 0.979979,
+      "translation_rmse_m_median": 0.084802,
+      "translation_rmse_m_worst": 0.085000,
+      "rotation_rmse_deg_median": 1.134165,
+      "rotation_rmse_deg_worst": 1.185000,
+      "translation_end_error_m_median": 0.054,
+      "translation_end_error_m_worst": 0.057,
+      "rotation_end_error_deg_median": 0.330,
+      "rotation_end_error_deg_worst": 0.350,
+      "reject_streak_max_worst": 0,
+      "imu_seed_ratio_median": 0.85417,
+      "imu_seed_ratio_worst": 0.84783,
+      "alignment_latency_p95_sec_median": 0.323,
+      "alignment_latency_p95_sec_worst": 0.336
+    },
+    "outdoor_hard_01a_85_112": {
+      "coverage_ratio_median": 0.966688,
+      "coverage_ratio_worst": 0.966688,
+      "translation_rmse_m_median": 0.073120,
+      "translation_rmse_m_worst": 0.081406,
+      "rotation_rmse_deg_median": 0.895,
+      "rotation_rmse_deg_worst": 1.060690,
+      "translation_end_error_m_median": 0.031,
+      "translation_end_error_m_worst": 0.034,
+      "rotation_end_error_deg_median": 0.517,
+      "rotation_end_error_deg_worst": 0.535,
+      "reject_streak_max_worst": 0,
+      "imu_seed_ratio_median": 0.69048,
+      "imu_seed_ratio_worst": 0.675,
+      "alignment_latency_p95_sec_median": 0.442,
+      "alignment_latency_p95_sec_worst": 0.457
+    },
+    "outdoor_hard_02a_0_30": {
+      "coverage_ratio_median": 0.986658,
+      "coverage_ratio_worst": 0.983313,
+      "translation_rmse_m_median": 0.094636,
+      "translation_rmse_m_worst": 0.095766,
+      "rotation_rmse_deg_median": 1.050963,
+      "rotation_rmse_deg_worst": 1.140939,
+      "translation_end_error_m_median": 0.117,
+      "translation_end_error_m_worst": 0.125,
+      "rotation_end_error_deg_median": 1.101,
+      "rotation_end_error_deg_worst": 1.122,
+      "reject_streak_max_worst": 0,
+      "imu_seed_ratio_median": 0.86,
+      "imu_seed_ratio_worst": 0.74510,
+      "alignment_latency_p95_sec_median": 0.323,
+      "alignment_latency_p95_sec_worst": 0.375
+    }
+  },
+  "controls": {
+    "outdoor_hard_01a_0_30_lidar_only": {
+      "coverage_ratio_median": 0.75997,
+      "translation_rmse_m_median": 0.336198,
+      "rotation_rmse_deg_median": 3.340312,
+      "reject_streak_max_median": 8
+    },
+    "outdoor_hard_01a_0_30_legacy_single_stream": {
+      "coverage_ratio_median": 0.763311,
+      "translation_rmse_m_median": 0.365202,
+      "rotation_rmse_deg_median": 3.925431,
+      "reject_streak_max_median": 7
+    },
+    "outdoor_hard_02a_0_30_lidar_only_valid_run": {
+      "coverage_ratio": 0.243340,
+      "translation_rmse_m": 0.338117,
+      "rotation_rmse_deg": 3.813385,
+      "reject_streak_max": 31
+    },
+    "outdoor_hard_02a_0_30_legacy_single_stream": {
+      "coverage_ratio": 0.823322,
+      "translation_rmse_m": 0.652040,
+      "rotation_rmse_deg": 4.264858,
+      "reject_streak_max": 6
+    }
+  },
+  "dual_queue_deskew": {
+    "outdoor_hard_01a_0_30": {
+      "coverage_ratio_median": 0.979979,
+      "translation_rmse_m_median": 0.080,
+      "rotation_rmse_deg_median": 0.974,
+      "reject_streak_max_worst": 0,
+      "imu_seed_ratio_worst": 0.80851,
+      "deskew_applied_ratio_median": 0.87755,
+      "deskew_applied_ratio_worst": 0.875,
+      "alignment_latency_p95_sec_worst": 0.363
+    },
+    "outdoor_hard_02a_0_30": {
+      "coverage_ratio_median": 0.983313,
+      "translation_rmse_m_median": 0.145606,
+      "rotation_rmse_deg_median": 1.168211,
+      "reject_streak_max_worst": 0,
+      "imu_seed_ratio_worst": 0.57447,
+      "deskew_applied_ratio_median": 0.81633,
+      "deskew_applied_ratio_worst": 0.76596,
+      "alignment_latency_p95_sec_worst": 0.478
+    }
+  },
+  "decisions": {
+    "imu_dual_queue": "promote_default_on_after_nine_of_nine_multi_window_multi_sequence_runs_pass",
+    "continuous_time_deskew": "keep_default_off_due_to_repeatable_outdoor_hard_02a_accuracy_regression"
+  },
+  "artifact_roots": [
+    "runs/imu_jitter_tolerance_ab_20260714",
+    "runs/imu_jitter_corner_ab_20260714",
+    "runs/imu_jitter_outdoor_hard_02a_ab_20260714",
+    "runs/imu_dual_queue_deskew_ab_20260714",
+    "runs/imu_dual_queue_deskew_outdoor_hard_02a_20260714"
+  ]
+}

--- a/experiments/imu_scan_time_sync/README.md
+++ b/experiments/imu_scan_time_sync/README.md
@@ -1,0 +1,30 @@
+# IMU / scan time synchronization experiment
+
+Date: 2026-07-14
+
+This experiment tested whether the low continuous-time deskew application rate
+on Koide `outdoor_hard_01a` was caused by IMU samples arriving while NDT was
+registering an older cloud. The controlled window was bag offset 85 s for 27 s.
+
+The candidate buffered transformed IMU samples and integrated only samples at
+or before the cloud timestamp. The diagnostic integration horizon was also
+measured at the cloud timestamp instead of at the newest received IMU sample.
+
+The candidate failed. After recovering across one 0.65 s IMU gap, only 1 of 26
+diagnostic scans applied deskew. The first inaccurate IMU prediction led to
+registration rejection, after which the accepted-pose integration horizon
+correctly exceeded 1 s. Trajectory coverage fell to 6.3% and translation RMSE
+rose to 6.599 m. The implementation was therefore reverted.
+
+The same run also confirmed that increasing application rate alone is unsafe:
+rotation-only IMU pose-history deskew applied to 94.3% of scans but increased
+translation RMSE from 0.141 m to 1.886 m. Offline gyro/reference alignment over
+1,200 scans preferred the documented `header=start` convention (0.0581 rad/s
+fitted residual versus 0.0794 rad/s for `header=end`), so changing the cloud
+timestamp convention is not justified.
+
+Conclusion: keep continuous-time deskew default-off. The next IMU candidate
+must estimate or observe velocity at initialization and pass an open-loop seed
+accuracy gate before it is allowed to affect NDT or deskew.
+
+See [results.json](results.json) for the measured values.

--- a/experiments/imu_scan_time_sync/results.json
+++ b/experiments/imu_scan_time_sync/results.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "date": "2026-07-14",
+  "dataset": "koide/outdoor_hard_01a",
+  "bag_start_offset_sec": 85.0,
+  "bag_duration_sec": 27.0,
+  "runs": {
+    "existing_relative_motion": {
+      "deskew_applied_ratio": 0.533,
+      "translation_rmse_m": 0.14146055045395506,
+      "rotation_rmse_deg": 9.960559645686738,
+      "trajectory_duration_ratio": 0.8703965257715296
+    },
+    "rotation_only_pose_history_start_stamp": {
+      "deskew_applied_ratio": 0.943,
+      "translation_rmse_m": 1.8860262803115062,
+      "rotation_rmse_deg": 17.293493966173173,
+      "trajectory_duration_ratio": 0.9666875203450521
+    },
+    "scan_bounded_imu_buffer": {
+      "deskew_applied_ratio": 0.038,
+      "translation_rmse_m": 6.5985794064951975,
+      "rotation_rmse_deg": 4.2616374941366475,
+      "trajectory_duration_ratio": 0.06296239075837312,
+      "integration_window_too_large_count": 24,
+      "diagnostic_scan_count": 26
+    }
+  },
+  "cloud_stamp_hypothesis": {
+    "scan_count": 1200,
+    "preferred": "start",
+    "start_fitted_rate_rmse_rad_s": 0.05812944924752853,
+    "end_fitted_rate_rmse_rad_s": 0.07938818116306459
+  },
+  "decision": "rejected_and_reverted",
+  "next_gate": "validate initialized velocity or open-loop seed accuracy before runtime coupling"
+}

--- a/experiments/imu_seed_consistency/README.md
+++ b/experiments/imu_seed_consistency/README.md
@@ -1,0 +1,43 @@
+# IMU seed consistency gate
+
+This experiment checks an IMU-predicted pose against the accepted LiDAR pose
+before the prediction is allowed to seed registration. A valid comparison must
+pass both the translation and rotation thresholds for five consecutive accepted
+updates. Missing, non-finite, or failed evidence revokes permission immediately.
+
+## Koide probe (2026-07-14)
+
+Dataset: `outdoor_hard_01a`, first 30 seconds. The run artifacts are stored on
+the external SSD at `generated/imu_seed_gate_probe_20260714`.
+
+```bash
+scripts/run_koide_hard_imu_deskew_smoke.sh \
+  --data-dir /media/sasaki/aiueo/datasets/koide_hard_localization \
+  --output-dir /media/sasaki/aiueo/datasets/koide_hard_localization/generated/imu_seed_gate_probe_20260714 \
+  --duration 30 --ros-domain-id 190 \
+  --mode lidar_only --mode imu_preintegration
+```
+
+The gate thresholds were 0.5 m and 5 degrees with five required consecutive
+passes. The IMU prediction was never selected as a registration seed:
+
+- 32 valid accepted-pose comparisons (37 diagnostic rows carried finite values)
+- translation error: 0.0057 m minimum, 0.9952 m median, 1.3620 m maximum
+- rotation error: 0.0238 degrees minimum, 5.2486 degrees median, 23.5381 degrees maximum
+- maximum consecutive pass count: 4/5
+- IMU seed source: 0/44 alignment rows
+- fallback count: 0
+
+The gated run therefore remained open-loop with respect to registration. Its
+trajectory metrics must not be interpreted as an IMU accuracy gain: the two
+independent NDT runs had different pose counts even though IMU seed use was
+zero, demonstrating material run-to-run/runtime-scheduling variation on this
+fixture.
+
+## Decision
+
+Keep the gate and its diagnostics. Do not enable the state-retaining or
+time-buffered IMU seed prototypes that previously caused large Koide drift.
+Next, fix scan-time-bounded integration and initial velocity/bias observability,
+then repeat this open-loop test. Only allow an IMU seed when multiple windows
+and sequences satisfy the same predeclared thresholds.

--- a/experiments/imu_seed_consistency/results.json
+++ b/experiments/imu_seed_consistency/results.json
@@ -1,0 +1,30 @@
+{
+  "date": "2026-07-14",
+  "dataset": "koide_outdoor_hard_01a",
+  "start_offset_sec": 0.0,
+  "duration_sec": 30.0,
+  "gate": {
+    "max_translation_error_m": 0.5,
+    "max_rotation_error_deg": 5.0,
+    "required_consecutive_passes": 5
+  },
+  "diagnostics": {
+    "alignment_rows": 44,
+    "valid_comparison_count": 32,
+    "finite_diagnostic_rows": 37,
+    "max_consecutive_pass_count": 4,
+    "imu_seed_rows": 0,
+    "fallback_count": 0,
+    "translation_error_m": {
+      "min": 0.005651,
+      "median": 0.995211,
+      "max": 1.361984
+    },
+    "rotation_error_deg": {
+      "min": 0.0238,
+      "median": 5.248615,
+      "max": 23.538059
+    }
+  },
+  "decision": "keep_gate_seed_disabled_for_this_window"
+}

--- a/include/lidar_localization/alignment_diagnostics_policy.hpp
+++ b/include/lidar_localization/alignment_diagnostics_policy.hpp
@@ -101,6 +101,13 @@ struct AlignmentDiagnosticValuesInput
   bool bad_match_active{false};
   bool stale_prediction_active{false};
   bool overload_active{false};
+  bool imu_seed_consistency_gate_enabled{false};
+  bool imu_seed_consistency_seed_allowed{false};
+  std::size_t imu_seed_consistency_valid_comparison_count{0};
+  std::size_t imu_seed_consistency_consecutive_pass_count{0};
+  double imu_seed_consistency_translation_error_m{NAN};
+  double imu_seed_consistency_rotation_error_deg{NAN};
+  bool imu_seed_consistency_sample_passed{false};
 };
 
 inline const char * boolString(bool value)
@@ -273,6 +280,27 @@ inline std::vector<DiagnosticKeyValue> buildAlignmentDiagnosticValues(
     "horizontal_localizability_eigenvalue_ratio",
     std::to_string(input.horizontal_localizability_eigenvalue_ratio));
   append("localizability_guard_active", boolString(input.localizability_guard_active));
+  append(
+    "imu_seed_consistency_gate_enabled",
+    boolString(input.imu_seed_consistency_gate_enabled));
+  append(
+    "imu_seed_consistency_seed_allowed",
+    boolString(input.imu_seed_consistency_seed_allowed));
+  append(
+    "imu_seed_consistency_valid_comparison_count",
+    std::to_string(input.imu_seed_consistency_valid_comparison_count));
+  append(
+    "imu_seed_consistency_consecutive_pass_count",
+    std::to_string(input.imu_seed_consistency_consecutive_pass_count));
+  append(
+    "imu_seed_consistency_translation_error_m",
+    std::to_string(input.imu_seed_consistency_translation_error_m));
+  append(
+    "imu_seed_consistency_rotation_error_deg",
+    std::to_string(input.imu_seed_consistency_rotation_error_deg));
+  append(
+    "imu_seed_consistency_sample_passed",
+    boolString(input.imu_seed_consistency_sample_passed));
   return values;
 }
 

--- a/include/lidar_localization/imu_gtsam_smoother.hpp
+++ b/include/lidar_localization/imu_gtsam_smoother.hpp
@@ -58,22 +58,52 @@ public:
     double vx, double vy, double vz,
     double stamp_sec)
   {
+    initializeState(
+      Eigen::Vector3d(x, y, z),
+      so3::eulerToRotation(roll, pitch, yaw),
+      Eigen::Vector3d(vx, vy, vz),
+      Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero(), stamp_sec);
+  }
+
+  void initializeState(
+    const Eigen::Vector3d & position,
+    const Eigen::Matrix3d & rotation,
+    const Eigen::Vector3d & velocity,
+    const Eigen::Vector3d & gyro_bias,
+    const Eigen::Vector3d & accel_bias,
+    double stamp_sec)
+  {
     PoseEntry entry;
-    entry.position = Eigen::Vector3d(x, y, z);
-    entry.velocity = Eigen::Vector3d(vx, vy, vz);
-    entry.R = so3::eulerToRotation(roll, pitch, yaw);
+    entry.position = position;
+    entry.velocity = velocity;
+    entry.R = rotation;
     entry.has_imu_factor = false;
     entry.has_ndt = false;
     poses_.clear();
     poses_.push_back(entry);
-    gyro_bias_.setZero();
-    accel_bias_.setZero();
+    gyro_bias_ = gyro_bias;
+    accel_bias_ = accel_bias;
     dr_p_ = entry.position;
     dr_v_ = entry.velocity;
     dr_R_ = entry.R;
     last_stamp_ = stamp_sec;
     initialized_ = true;
     // Reset IMU accumulation
+    current_preint_.reset();
+    current_preint_.params = params_.imu_params;
+    current_preint_gyro_bias_ = gyro_bias_;
+    current_preint_accel_bias_ = accel_bias_;
+  }
+
+  /// Discard only the not-yet-corrected IMU interval. Optimized window states,
+  /// velocity, and biases remain intact so the same raw tail can be repropagated.
+  void resetPendingIntegration()
+  {
+    if (!initialized_ || poses_.empty()) return;
+    const auto & latest = poses_.back();
+    dr_p_ = latest.position;
+    dr_v_ = latest.velocity;
+    dr_R_ = latest.R;
     current_preint_.reset();
     current_preint_.params = params_.imu_params;
     current_preint_gyro_bias_ = gyro_bias_;
@@ -88,8 +118,8 @@ public:
     current_preint_.integrate(gyro, accel, gyro_bias_, accel_bias_, dt);
     // Dead-reckoning for init_guess
     Eigen::Vector3d acc_world = dr_R_ * (accel - accel_bias_) + params_.imu_params.gravity;
-    dr_v_ += acc_world * dt;
     dr_p_ += dr_v_ * dt + 0.5 * acc_world * dt * dt;
+    dr_v_ += acc_world * dt;
     Eigen::Vector3d omega = gyro - gyro_bias_;
     dr_R_ = dr_R_ * so3::Exp(omega * dt);
   }
@@ -150,10 +180,53 @@ public:
     return true;
   }
 
+  /// Advance the correction anchor across an accepted LiDAR observation when
+  /// causal IMU coverage is incomplete. No between-factor is invented for the
+  /// gap and the existing window is not re-optimized through a disconnected
+  /// state; optimized velocity and biases are carried into later
+  /// repropagation unchanged.
+  bool updatePoseOnly(
+    double px, double py, double pz,
+    double roll, double pitch, double yaw,
+    double fitness_score, double stamp_sec)
+  {
+    if (!initialized_ || fitness_score > params_.fitness_reject) return false;
+
+    PoseEntry entry;
+    entry.position = Eigen::Vector3d(px, py, pz);
+    entry.velocity = poses_.back().velocity;
+    entry.R = so3::eulerToRotation(roll, pitch, yaw);
+    entry.has_imu_factor = false;
+    entry.has_ndt = true;
+    entry.ndt_position = entry.position;
+    entry.ndt_R = entry.R;
+    entry.ndt_fitness = fitness_score;
+    poses_.push_back(entry);
+    while (static_cast<int>(poses_.size()) > params_.window_size) {
+      poses_.pop_front();
+    }
+
+    dr_p_ = entry.position;
+    dr_v_ = entry.velocity;
+    dr_R_ = entry.R;
+    current_preint_.reset();
+    current_preint_.params = params_.imu_params;
+    current_preint_gyro_bias_ = gyro_bias_;
+    current_preint_accel_bias_ = accel_bias_;
+    last_stamp_ = stamp_sec;
+    return true;
+  }
+
   // Accessors
   double px() const { return poses_.back().position.x(); }
   double py() const { return poses_.back().position.y(); }
   double pz() const { return poses_.back().position.z(); }
+  Eigen::Vector3d velocity() const { return poses_.back().velocity; }
+  Eigen::Vector3d position() const { return poses_.back().position; }
+  Eigen::Matrix3d rotation() const { return poses_.back().R; }
+  Eigen::Vector3d gyroBias() const { return gyro_bias_; }
+  Eigen::Vector3d accelBias() const { return accel_bias_; }
+  std::size_t poseCount() const { return poses_.size(); }
 
   /// Get latest optimized pose as 4x4 matrix
   Eigen::Matrix4f poseMatrix() const
@@ -222,8 +295,9 @@ private:
 
       // --- 1. Anchor prior on first pose ---
       double anchor_w = 1e6;
-      for (int k = 0; k < POSE_DIM; ++k) {
+      for (int k = 0; k < 3; ++k) {
         H(k, k) += anchor_w;
+        H(6 + k, 6 + k) += anchor_w;
       }
 
       // Velocity is only weakly observed when an interval has too little IMU
@@ -376,11 +450,25 @@ private:
 
       // --- 4. Bias prior factor ---
       {
-        double info_bg = 1.0 / (params_.bias_prior_sigma_gyro * params_.bias_prior_sigma_gyro);
-        double info_ba = 1.0 / (params_.bias_prior_sigma_accel * params_.bias_prior_sigma_accel);
+        double window_duration_sec = 0.0;
+        for (int i = 1; i < n; ++i) {
+          if (poses_[i].has_imu_factor) {
+            window_duration_sec += poses_[i].preint.dt_sum;
+          }
+        }
+        const double gyro_bias_variance = imuBiasPriorVariance(
+          params_.bias_prior_sigma_gyro,
+          params_.imu_params.gyro_random_walk,
+          window_duration_sec);
+        const double accel_bias_variance = imuBiasPriorVariance(
+          params_.bias_prior_sigma_accel,
+          params_.imu_params.accel_random_walk,
+          window_duration_sec);
+        double info_bg = 1.0 / gyro_bias_variance;
+        double info_ba = 1.0 / accel_bias_variance;
         for (int k = 0; k < 3; ++k) {
           H(bias_offset + k, bias_offset + k) += info_bg;
-          b(bias_offset + k) += info_bg * gyro_bias_(k);  // prior at current estimate
+          b(bias_offset + k) += info_bg * gyro_bias_(k);
         }
         for (int k = 0; k < 3; ++k) {
           H(bias_offset + 3 + k, bias_offset + 3 + k) += info_ba;

--- a/include/lidar_localization/imu_initialization_policy.hpp
+++ b/include/lidar_localization/imu_initialization_policy.hpp
@@ -1,0 +1,56 @@
+#ifndef LIDAR_LOCALIZATION_IMU_INITIALIZATION_POLICY_HPP_
+#define LIDAR_LOCALIZATION_IMU_INITIALIZATION_POLICY_HPP_
+
+#include <Eigen/Core>
+
+#include <cmath>
+
+namespace lidar_localization
+{
+
+struct ImuInitialVelocityEstimate
+{
+  Eigen::Vector3d velocity{Eigen::Vector3d::Zero()};
+  double interval_sec{0.0};
+  bool usable{false};
+};
+
+inline Eigen::Vector3d scaleImuAcceleration(
+  const Eigen::Vector3d & acceleration, double scale)
+{
+  return acceleration * scale;
+}
+
+inline ImuInitialVelocityEstimate estimateImuInitialVelocity(
+  const Eigen::Matrix4f & previous_pose,
+  double previous_stamp_sec,
+  const Eigen::Matrix4f & current_pose,
+  double current_stamp_sec,
+  double max_interval_sec = 2.0,
+  double max_speed_mps = 50.0)
+{
+  ImuInitialVelocityEstimate estimate;
+  estimate.interval_sec = current_stamp_sec - previous_stamp_sec;
+  if (!previous_pose.allFinite() || !current_pose.allFinite() ||
+    !std::isfinite(previous_stamp_sec) || !std::isfinite(current_stamp_sec) ||
+    !std::isfinite(max_interval_sec) || max_interval_sec <= 0.0 ||
+    !std::isfinite(max_speed_mps) || max_speed_mps <= 0.0 ||
+    estimate.interval_sec <= 0.0 || estimate.interval_sec > max_interval_sec)
+  {
+    return estimate;
+  }
+
+  estimate.velocity =
+    (current_pose.block<3, 1>(0, 3) - previous_pose.block<3, 1>(0, 3)).cast<double>() /
+    estimate.interval_sec;
+  estimate.usable =
+    estimate.velocity.allFinite() && estimate.velocity.norm() <= max_speed_mps;
+  if (!estimate.usable) {
+    estimate.velocity.setZero();
+  }
+  return estimate;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_IMU_INITIALIZATION_POLICY_HPP_

--- a/include/lidar_localization/imu_preintegration.hpp
+++ b/include/lidar_localization/imu_preintegration.hpp
@@ -5,6 +5,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <cmath>
 #include <deque>
 
 struct ImuSample
@@ -22,6 +23,25 @@ struct ImuPreintegrationParams
   double accel_random_walk = 0.001;     // m/s^3/sqrt(Hz)
   Eigen::Vector3d gravity = Eigen::Vector3d(0, 0, -9.81);
 };
+
+/// Marginal variance of a bias after a continuous random walk over duration.
+/// This is also useful to keep a shared-window bias approximation from becoming
+/// overconfident as its window grows: Var[b(t)] = Var[b(0)] + sigma_rw^2 t.
+inline double imuBiasPriorVariance(
+  double initial_sigma, double random_walk_density, double duration_sec)
+{
+  if (!std::isfinite(initial_sigma) || initial_sigma <= 0.0) {
+    return 1.0;
+  }
+  const double initial_variance = initial_sigma * initial_sigma;
+  if (!std::isfinite(random_walk_density) || random_walk_density < 0.0 ||
+    !std::isfinite(duration_sec) || duration_sec <= 0.0)
+  {
+    return initial_variance;
+  }
+  return initial_variance +
+         random_walk_density * random_walk_density * duration_sec;
+}
 
 /// On-manifold IMU preintegration (Forster et al. 2017), pure Eigen
 class ImuPreintegration
@@ -105,8 +125,12 @@ public:
 
     // Continuous noise (per-axis)
     Matrix6d Qc = Matrix6d::Zero();
-    double na2 = params.accel_noise_density * params.accel_noise_density;
-    double ng2 = params.gyro_noise_density * params.gyro_noise_density;
+    // Noise parameters are continuous-time densities (/sqrt(Hz)). The variance
+    // of the average measurement over dt is density^2 / dt. B already contains
+    // the integration powers of dt, so omitting this conversion makes a factor
+    // spuriously more confident as the IMU sampling rate increases.
+    double na2 = params.accel_noise_density * params.accel_noise_density / dt;
+    double ng2 = params.gyro_noise_density * params.gyro_noise_density / dt;
     Qc.block<3, 3>(0, 0) = na2 * Eigen::Matrix3d::Identity();
     Qc.block<3, 3>(3, 3) = ng2 * Eigen::Matrix3d::Identity();
 

--- a/include/lidar_localization/imu_preintegration_diagnostics_policy.hpp
+++ b/include/lidar_localization/imu_preintegration_diagnostics_policy.hpp
@@ -46,6 +46,13 @@ struct ImuPreintegrationDiagnosticsInput
   double integration_window_sec{0.0};
   double stale_sample_age_threshold_sec{0.2};
   double max_integration_window_sec{1.0};
+  bool seed_consistency_gate_enabled{false};
+  bool seed_consistency_seed_allowed{false};
+  std::size_t seed_consistency_valid_comparison_count{0};
+  std::size_t seed_consistency_consecutive_pass_count{0};
+  double seed_consistency_translation_error_m{std::numeric_limits<double>::quiet_NaN()};
+  double seed_consistency_rotation_error_deg{std::numeric_limits<double>::quiet_NaN()};
+  bool seed_consistency_sample_passed{false};
 };
 
 struct ImuPreintegrationDiagnostics
@@ -65,9 +72,21 @@ struct ImuPreintegrationDiagnostics
   double last_dt_sec{std::numeric_limits<double>::quiet_NaN()};
   double last_sample_age_sec{std::numeric_limits<double>::quiet_NaN()};
   double integration_window_sec{0.0};
+  bool seed_consistency_gate_enabled{false};
+  bool seed_consistency_seed_allowed{false};
+  std::size_t seed_consistency_valid_comparison_count{0};
+  std::size_t seed_consistency_consecutive_pass_count{0};
+  double seed_consistency_translation_error_m{std::numeric_limits<double>::quiet_NaN()};
+  double seed_consistency_rotation_error_deg{std::numeric_limits<double>::quiet_NaN()};
+  bool seed_consistency_sample_passed{false};
 };
 
 constexpr double kMaximumImuPreintegrationSampleDtSec = 0.5;
+// ROS timestamps and callback scheduling can put an otherwise complete scan
+// interval a fraction of an IMU tick beyond the nominal one-second guard.
+// This tolerance is tiny relative to the guard and does not permit a genuine
+// missing scan interval (for example 1.1 s) to seed registration.
+constexpr double kImuIntegrationWindowJitterToleranceSec = 0.01;
 
 inline double finiteNonnegativeOrNaN(double value)
 {
@@ -139,7 +158,8 @@ inline bool isImuIntegrationWindowTooLarge(double integration_window_sec, double
   return std::isfinite(integration_window_sec) &&
          std::isfinite(max_window_sec) &&
          max_window_sec > 0.0 &&
-         integration_window_sec > max_window_sec;
+         integration_window_sec >
+         max_window_sec + kImuIntegrationWindowJitterToleranceSec;
 }
 
 inline bool isImuIntegrationWindowTooLarge(
@@ -248,7 +268,14 @@ inline ImuPreintegrationDiagnostics makeImuPreintegrationDiagnostics(
     input.invalid_dt_count,
     input.last_dt_sec,
     input.last_sample_age_sec,
-    input.integration_window_sec};
+    input.integration_window_sec,
+    input.seed_consistency_gate_enabled,
+    input.seed_consistency_seed_allowed,
+    input.seed_consistency_valid_comparison_count,
+    input.seed_consistency_consecutive_pass_count,
+    input.seed_consistency_translation_error_m,
+    input.seed_consistency_rotation_error_deg,
+    input.seed_consistency_sample_passed};
 }
 
 }  // namespace lidar_localization

--- a/include/lidar_localization/imu_queue_policy.hpp
+++ b/include/lidar_localization/imu_queue_policy.hpp
@@ -1,0 +1,225 @@
+#ifndef LIDAR_LOCALIZATION_IMU_QUEUE_POLICY_HPP_
+#define LIDAR_LOCALIZATION_IMU_QUEUE_POLICY_HPP_
+
+#include <Eigen/Core>
+
+#include <cmath>
+#include <cstddef>
+#include <deque>
+#include <optional>
+#include <vector>
+
+namespace lidar_localization
+{
+
+struct TimestampedImuSample
+{
+  double stamp_sec{0.0};
+  Eigen::Vector3d gyro{Eigen::Vector3d::Zero()};
+  Eigen::Vector3d accel{Eigen::Vector3d::Zero()};
+};
+
+struct ImuIntegrationInterval
+{
+  double start_stamp_sec{0.0};
+  double end_stamp_sec{0.0};
+  Eigen::Vector3d gyro{Eigen::Vector3d::Zero()};
+  Eigen::Vector3d accel{Eigen::Vector3d::Zero()};
+
+  double dt() const {return end_stamp_sec - start_stamp_sec;}
+};
+
+struct ImuIntegrationPlan
+{
+  std::vector<ImuIntegrationInterval> intervals;
+  bool input_order_valid{true};
+  bool complete_coverage{false};
+  std::size_t skipped_gap_count{0};
+  double covered_duration_sec{0.0};
+};
+
+inline bool finiteImuSample(const TimestampedImuSample & sample)
+{
+  return std::isfinite(sample.stamp_sec) &&
+         sample.gyro.allFinite() && sample.accel.allFinite();
+}
+
+/// Build causal, zero-order-held IMU intervals over [start, end]. A sample at
+/// or before start is required as the held measurement. Samples after end are
+/// deliberately ignored, so delayed scan callbacks cannot integrate the future.
+inline ImuIntegrationPlan planCausalImuIntervals(
+  double start_stamp_sec,
+  double end_stamp_sec,
+  const std::vector<TimestampedImuSample> & samples,
+  double max_interval_sec)
+{
+  ImuIntegrationPlan plan;
+  if (!std::isfinite(start_stamp_sec) || !std::isfinite(end_stamp_sec) ||
+    end_stamp_sec < start_stamp_sec || !std::isfinite(max_interval_sec) ||
+    max_interval_sec <= 0.0)
+  {
+    plan.input_order_valid = false;
+    return plan;
+  }
+
+  for (std::size_t i = 0; i < samples.size(); ++i) {
+    if (!finiteImuSample(samples[i]) ||
+      (i > 0 && samples[i].stamp_sec <= samples[i - 1].stamp_sec))
+    {
+      plan.input_order_valid = false;
+      return plan;
+    }
+  }
+
+  std::optional<TimestampedImuSample> active;
+  for (const auto & sample : samples) {
+    if (sample.stamp_sec <= start_stamp_sec) {
+      active = sample;
+    } else {
+      break;
+    }
+  }
+
+  double cursor = start_stamp_sec;
+  bool coverage_broken = !active.has_value();
+  for (const auto & sample : samples) {
+    if (sample.stamp_sec <= start_stamp_sec) {
+      continue;
+    }
+    if (sample.stamp_sec > end_stamp_sec) {
+      break;
+    }
+    if (active.has_value()) {
+      const double dt = sample.stamp_sec - cursor;
+      if (dt > 0.0 && dt < max_interval_sec) {
+        plan.intervals.push_back(
+          {cursor, sample.stamp_sec, active->gyro, active->accel});
+        plan.covered_duration_sec += dt;
+      } else if (dt >= max_interval_sec) {
+        ++plan.skipped_gap_count;
+        coverage_broken = true;
+      }
+    } else {
+      coverage_broken = true;
+    }
+    active = sample;
+    cursor = sample.stamp_sec;
+  }
+
+  if (active.has_value() && cursor < end_stamp_sec) {
+    const double dt = end_stamp_sec - cursor;
+    if (dt < max_interval_sec) {
+      plan.intervals.push_back({cursor, end_stamp_sec, active->gyro, active->accel});
+      plan.covered_duration_sec += dt;
+    } else {
+      ++plan.skipped_gap_count;
+      coverage_broken = true;
+    }
+  }
+
+  const double requested_duration = end_stamp_sec - start_stamp_sec;
+  plan.complete_coverage =
+    plan.input_order_valid && !coverage_broken &&
+    std::abs(plan.covered_duration_sec - requested_duration) <= 1e-9;
+  return plan;
+}
+
+struct ImuRepropagationWindow
+{
+  std::optional<TimestampedImuSample> anchor_sample;
+  std::vector<TimestampedImuSample> samples_after_correction;
+};
+
+/// Raw dual queues following the LIO-SAM separation: optimization consumes its
+/// own queue through each LiDAR correction, while prediction retains the same
+/// samples until that correction and can then repropagate the remaining tail.
+class DualImuQueue
+{
+public:
+  bool push(const TimestampedImuSample & sample)
+  {
+    if (!finiteImuSample(sample) ||
+      (last_pushed_stamp_sec_.has_value() &&
+      sample.stamp_sec <= *last_pushed_stamp_sec_))
+    {
+      return false;
+    }
+    optimization_queue_.push_back(sample);
+    prediction_queue_.push_back(sample);
+    last_pushed_stamp_sec_ = sample.stamp_sec;
+    return true;
+  }
+
+  std::vector<TimestampedImuSample> consumeOptimizationThrough(double stamp_sec)
+  {
+    std::vector<TimestampedImuSample> consumed;
+    while (!optimization_queue_.empty() &&
+      optimization_queue_.front().stamp_sec <= stamp_sec)
+    {
+      consumed.push_back(optimization_queue_.front());
+      optimization_queue_.pop_front();
+    }
+    return consumed;
+  }
+
+  std::vector<TimestampedImuSample> optimizationSamplesThrough(double stamp_sec) const
+  {
+    std::vector<TimestampedImuSample> samples;
+    for (const auto & sample : optimization_queue_) {
+      if (sample.stamp_sec > stamp_sec) break;
+      samples.push_back(sample);
+    }
+    return samples;
+  }
+
+  ImuRepropagationWindow preparePredictionRepropagation(double correction_stamp_sec)
+  {
+    ImuRepropagationWindow window;
+    while (!prediction_queue_.empty() &&
+      prediction_queue_.front().stamp_sec <= correction_stamp_sec)
+    {
+      window.anchor_sample = prediction_queue_.front();
+      prediction_queue_.pop_front();
+    }
+    window.samples_after_correction.assign(
+      prediction_queue_.begin(), prediction_queue_.end());
+    return window;
+  }
+
+  std::size_t optimizationSize() const {return optimization_queue_.size();}
+  std::size_t predictionSize() const {return prediction_queue_.size();}
+
+  std::vector<TimestampedImuSample> predictionSamples() const
+  {
+    return {prediction_queue_.begin(), prediction_queue_.end()};
+  }
+
+  std::size_t trimTo(std::size_t max_size)
+  {
+    std::size_t removed = 0;
+    while (optimization_queue_.size() > max_size) {
+      optimization_queue_.pop_front();
+      ++removed;
+    }
+    while (prediction_queue_.size() > max_size) {
+      prediction_queue_.pop_front();
+    }
+    return removed;
+  }
+
+  void clear()
+  {
+    optimization_queue_.clear();
+    prediction_queue_.clear();
+    last_pushed_stamp_sec_.reset();
+  }
+
+private:
+  std::deque<TimestampedImuSample> optimization_queue_;
+  std::deque<TimestampedImuSample> prediction_queue_;
+  std::optional<double> last_pushed_stamp_sec_;
+};
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_IMU_QUEUE_POLICY_HPP_

--- a/include/lidar_localization/imu_seed_consistency_policy.hpp
+++ b/include/lidar_localization/imu_seed_consistency_policy.hpp
@@ -1,0 +1,100 @@
+#ifndef LIDAR_LOCALIZATION_IMU_SEED_CONSISTENCY_POLICY_HPP_
+#define LIDAR_LOCALIZATION_IMU_SEED_CONSISTENCY_POLICY_HPP_
+
+#include <cmath>
+#include <cstddef>
+
+namespace lidar_localization
+{
+
+struct ImuSeedConsistencyParams
+{
+  double max_translation_error_m{0.5};
+  double max_rotation_error_deg{5.0};
+  std::size_t required_consecutive_passes{5};
+};
+
+struct ImuSeedConsistencyState
+{
+  std::size_t valid_comparison_count{0};
+  std::size_t consecutive_pass_count{0};
+  bool seed_allowed{false};
+};
+
+struct ImuSeedConsistencyInput
+{
+  bool lidar_observation_accepted{false};
+  bool imu_prediction_available{false};
+  double translation_error_m{0.0};
+  double rotation_error_deg{0.0};
+};
+
+struct ImuSeedConsistencyUpdate
+{
+  ImuSeedConsistencyState state;
+  bool comparison_valid{false};
+  bool sample_passed{false};
+};
+
+inline bool validImuSeedConsistencyParams(const ImuSeedConsistencyParams & params)
+{
+  return std::isfinite(params.max_translation_error_m) &&
+         params.max_translation_error_m > 0.0 &&
+         std::isfinite(params.max_rotation_error_deg) &&
+         params.max_rotation_error_deg > 0.0 &&
+         params.required_consecutive_passes > 0;
+}
+
+inline ImuSeedConsistencyUpdate updateImuSeedConsistency(
+  const ImuSeedConsistencyState & current,
+  const ImuSeedConsistencyParams & params,
+  const ImuSeedConsistencyInput & input)
+{
+  ImuSeedConsistencyUpdate update;
+  update.state = current;
+  update.comparison_valid =
+    validImuSeedConsistencyParams(params) &&
+    input.lidar_observation_accepted &&
+    input.imu_prediction_available &&
+    std::isfinite(input.translation_error_m) &&
+    input.translation_error_m >= 0.0 &&
+    std::isfinite(input.rotation_error_deg) &&
+    input.rotation_error_deg >= 0.0;
+
+  if (!validImuSeedConsistencyParams(params)) {
+    update.state.consecutive_pass_count = 0;
+    update.state.seed_allowed = false;
+    return update;
+  }
+
+  if (!update.comparison_valid) {
+    // A temporarily unavailable prediction supplies no evidence against a gate
+    // that has already passed its warm-up comparisons. The caller cannot use
+    // the seed while it is unavailable, so retaining the established state is
+    // safe and avoids another full warm-up after a scheduling/scan gap.
+    // Before the gate is established, a missing comparison still breaks the
+    // required consecutive chain. A present but non-finite prediction is a
+    // numerical failure and always fails closed.
+    const bool missing_evidence =
+      input.lidar_observation_accepted && !input.imu_prediction_available;
+    if (!(current.seed_allowed && missing_evidence)) {
+      update.state.consecutive_pass_count = 0;
+      update.state.seed_allowed = false;
+    }
+    return update;
+  }
+
+  ++update.state.valid_comparison_count;
+  update.sample_passed =
+    input.translation_error_m <= params.max_translation_error_m &&
+    input.rotation_error_deg <= params.max_rotation_error_deg;
+  update.state.consecutive_pass_count = update.sample_passed ?
+    current.consecutive_pass_count + 1 : 0;
+  update.state.seed_allowed =
+    update.state.consecutive_pass_count >= params.required_consecutive_passes;
+  return update;
+}
+
+}  // namespace lidar_localization
+
+#endif  // LIDAR_LOCALIZATION_IMU_SEED_CONSISTENCY_POLICY_HPP_

--- a/include/lidar_localization/lidar_localization_component.hpp
+++ b/include/lidar_localization/lidar_localization_component.hpp
@@ -105,6 +105,8 @@ public:
   CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state);
   CallbackReturn on_error(const rclcpp_lifecycle::State & state);
 
+  void declareImuPreintegrationParameters();
+  void loadImuPreintegrationParameters();
   void initializeParameters();
   void initializePubSub();
   void initializeRegistration();

--- a/include/lidar_localization/lidar_localization_component.hpp
+++ b/include/lidar_localization/lidar_localization_component.hpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <utility>
@@ -66,6 +67,9 @@
 #include "lidar_localization/callback_state_coordinator.hpp"
 #include "lidar_localization/imu_preintegration_diagnostics_policy.hpp"
 #include "lidar_localization/imu_preintegration_guard_policy.hpp"
+#include "lidar_localization/imu_initialization_policy.hpp"
+#include "lidar_localization/imu_queue_policy.hpp"
+#include "lidar_localization/imu_seed_consistency_policy.hpp"
 #include "lidar_localization/measurement_gate_policy.hpp"
 #include "lidar_localization/localization_update_policy.hpp"
 #include "lidar_localization/pose_backend_result_policy.hpp"
@@ -192,6 +196,7 @@ public:
   // IMU preintegration smoother
   bool use_imu_preintegration_{false};
   bool imu_preintegration_use_base_frame_transform_{false};
+  double imu_accel_scale_{1.0};
   bool use_continuous_time_deskew_{false};
   std::string continuous_time_deskew_mode_{"relative_motion"};
   std::string continuous_time_cloud_stamp_reference_{"start"};
@@ -200,9 +205,18 @@ public:
   double imu_prediction_correction_guard_translation_m_{2.0};
   double imu_prediction_correction_guard_yaw_deg_{10.0};
   int imu_prediction_correction_guard_warmup_accepts_{5};
+  bool imu_seed_consistency_gate_enabled_{true};
+  bool imu_dual_queue_enabled_{true};
+  lidar_localization::ImuSeedConsistencyParams imu_seed_consistency_params_;
+  lidar_localization::ImuSeedConsistencyState imu_seed_consistency_state_;
   // Read on the per-scan path without taking imu_preintegration_mutex_.
   std::atomic<int> imu_guard_warmup_accepts_remaining_{0};
   ImuGtsamSmoother imu_smoother_;
+  ImuGtsamSmoother imu_prediction_smoother_;
+  lidar_localization::DualImuQueue imu_dual_queue_;
+  std::optional<lidar_localization::TimestampedImuSample> imu_optimization_anchor_sample_;
+  std::optional<lidar_localization::TimestampedImuSample> imu_prediction_anchor_sample_;
+  double latest_dual_queue_integrated_stamp_{0.0};
   double last_imu_stamp_{0.0};
   Eigen::Quaternionf continuous_time_imu_orientation_{Eigen::Quaternionf::Identity()};
   std::deque<lidar_localization::TimestampedPose> continuous_time_imu_pose_history_;
@@ -220,6 +234,13 @@ public:
   double latest_imu_seed_last_dt_sec_{std::numeric_limits<double>::quiet_NaN()};
   double latest_imu_seed_last_sample_age_sec_{std::numeric_limits<double>::quiet_NaN()};
   double latest_imu_seed_integration_window_sec_{0.0};
+  Eigen::Matrix4f latest_imu_open_loop_prediction_{Eigen::Matrix4f::Identity()};
+  bool latest_imu_open_loop_prediction_available_{false};
+  double latest_imu_seed_consistency_translation_error_m_{
+    std::numeric_limits<double>::quiet_NaN()};
+  double latest_imu_seed_consistency_rotation_error_deg_{
+    std::numeric_limits<double>::quiet_NaN()};
+  bool latest_imu_seed_consistency_sample_passed_{false};
   bool latest_continuous_time_deskew_applied_{false};
   std::string latest_continuous_time_deskew_status_{"continuous_time_deskew_disabled"};
   std::size_t latest_continuous_time_deskew_point_count_{0};

--- a/param/hdl_imu_preint.yaml
+++ b/param/hdl_imu_preint.yaml
@@ -40,11 +40,23 @@
     max_twist_prediction_dt: 0.5
     use_twist_ekf: false
     use_gtsam_smoother: false
-    # IMU preintegration smoother
+    # IMU preintegration backend and input units
     use_imu_preintegration: true
     imu_preintegration_use_base_frame_transform: false
+    imu_accel_scale: 1.0
+    imu_dual_queue_enabled: true
+
+    # IMU seed safety gates
     imu_prediction_correction_guard_translation_m: 2.0
     imu_prediction_correction_guard_yaw_deg: 4.0
+    imu_prediction_correction_guard_warmup_accepts: 5
+    imu_seed_consistency_gate_enabled: true
+    imu_seed_consistency_max_translation_error_m: 0.5
+    imu_seed_consistency_max_rotation_error_deg: 5.0
+    imu_seed_consistency_required_consecutive_passes: 5
+
+    # Continuous-time deskew is experimental and default-off
+    use_continuous_time_deskew: false
     enable_reinitialization_request_output: true
     enable_reinitialization_request_latch: true
     reinitialization_trigger_threshold: 0.95
@@ -62,6 +74,8 @@
     gtsam_fitness_scale_factor: 2.0
     gtsam_fitness_reject: 50.0
     gtsam_huber_k: 1.345
+
+    # Preintegration noise and factor model
     imu_gyro_noise_density: 0.01
     imu_accel_noise_density: 0.1
     imu_gyro_random_walk: 0.0001

--- a/param/localization.yaml
+++ b/param/localization.yaml
@@ -28,11 +28,24 @@
       use_twist_prediction: false
       twist_prediction_use_angular_velocity: true
       max_twist_prediction_dt: 0.5
+      # IMU preintegration backend and input units
       use_imu: false
       use_imu_preintegration: true
       imu_preintegration_use_base_frame_transform: false
+      imu_accel_scale: 1.0
+      imu_dual_queue_enabled: true
+
+      # IMU seed safety gates
       imu_prediction_correction_guard_translation_m: 2.0
       imu_prediction_correction_guard_yaw_deg: 4.0
+      imu_prediction_correction_guard_warmup_accepts: 5
+      imu_seed_consistency_gate_enabled: true
+      imu_seed_consistency_max_translation_error_m: 0.5
+      imu_seed_consistency_max_rotation_error_deg: 5.0
+      imu_seed_consistency_required_consecutive_passes: 5
+
+      # Continuous-time deskew is experimental and default-off
+      use_continuous_time_deskew: false
       enable_reinitialization_request_output: true
       enable_reinitialization_request_latch: true
       reinitialization_trigger_threshold: 0.95

--- a/param/mid360_legged.yaml
+++ b/param/mid360_legged.yaml
@@ -39,11 +39,23 @@
     use_twist_ekf: false
     use_gtsam_smoother: false
 
+    # IMU preintegration backend and input units
     use_imu: false
     use_imu_preintegration: true
     imu_preintegration_use_base_frame_transform: true
+    imu_accel_scale: 1.0
+    imu_dual_queue_enabled: true
+
+    # IMU seed safety gates
     imu_prediction_correction_guard_translation_m: 1.0
     imu_prediction_correction_guard_yaw_deg: 6.0
+    imu_prediction_correction_guard_warmup_accepts: 5
+    imu_seed_consistency_gate_enabled: true
+    imu_seed_consistency_max_translation_error_m: 0.5
+    imu_seed_consistency_max_rotation_error_deg: 5.0
+    imu_seed_consistency_required_consecutive_passes: 5
+
+    # Preintegration noise and factor model
     imu_gyro_noise_density: 0.01
     imu_accel_noise_density: 0.1
     imu_gyro_random_walk: 0.0001
@@ -53,6 +65,9 @@
     imu_ndt_sigma_z: 0.1
     imu_ndt_sigma_roll: 0.05
     imu_ndt_sigma_pitch: 0.05
+
+    # Continuous-time deskew is experimental and default-off
+    use_continuous_time_deskew: false
 
     gtsam_ndt_sigma_x: 0.1
     gtsam_ndt_sigma_y: 0.1

--- a/scripts/run_koide_hard_imu_deskew_smoke.sh
+++ b/scripts/run_koide_hard_imu_deskew_smoke.sh
@@ -20,8 +20,10 @@ Options:
                          With GT available, the initial pose is moved to the same offset.
   --duration SEC         Bag playback duration. Default: 20.
   --ros-domain-id ID     ROS_DOMAIN_ID for replay. Default: ROS_DOMAIN_ID env, or 195.
+  --imu-accel-scale X    Acceleration unit scale. Default: 9.80665 (Koide Livox publishes g).
   --mode NAME            Repeat to run a subset: lidar_only, imu_preintegration,
-                         deskew, imu_pose_history, lidar_constant_velocity,
+                         imu_dual_queue, imu_dual_queue_deskew, deskew,
+                         imu_pose_history, lidar_constant_velocity,
                          localizability_guard.
                          registration_localizability.
   --print-only           Write configs/run_plan and print commands without running ROS.
@@ -48,6 +50,7 @@ output_dir=""
 duration="20"
 start_offset="0"
 ros_domain_id="${ROS_DOMAIN_ID:-195}"
+imu_accel_scale="9.80665"
 download=0
 force_download=0
 print_only=0
@@ -82,6 +85,10 @@ while [[ $# -gt 0 ]]; do
     --ros-domain-id)
       shift
       ros_domain_id="$1"
+      ;;
+    --imu-accel-scale)
+      shift
+      imu_accel_scale="$1"
       ;;
     --mode)
       shift
@@ -242,6 +249,7 @@ fi
   --min-imu-active-ratio 0.1 \
   --min-imu-seed-source-ratio 0.1 \
   --min-deskew-applied-ratio 0.1 \
+  --imu-accel-scale "${imu_accel_scale}" \
   --scan-time-range-max-duration-ratio 4.0 \
   --enable-open-loop-strict-score-threshold \
   --open-loop-strict-min-accepted-gap-sec 1.0 \

--- a/scripts/run_lidar_localization_imu_comparison.py
+++ b/scripts/run_lidar_localization_imu_comparison.py
@@ -26,6 +26,7 @@ class ComparisonMode:
     continuous_time_deskew_mode: str = "relative_motion"
     enable_localizability_guard: bool = False
     enable_registration_localizability_diagnostics: bool = False
+    enable_imu_dual_queue: bool = False
 
 
 MODES: Dict[str, ComparisonMode] = {
@@ -34,6 +35,20 @@ MODES: Dict[str, ComparisonMode] = {
         "imu_preintegration",
         "preintegration",
         validate_imu=True,
+    ),
+    "imu_dual_queue": ComparisonMode(
+        "imu_dual_queue",
+        "preintegration",
+        validate_imu=True,
+        enable_imu_dual_queue=True,
+    ),
+    "imu_dual_queue_deskew": ComparisonMode(
+        "imu_dual_queue_deskew",
+        "preintegration",
+        enable_continuous_time_deskew=True,
+        validate_imu=True,
+        require_deskew_applied=True,
+        enable_imu_dual_queue=True,
     ),
     "deskew": ComparisonMode(
         "deskew",
@@ -151,6 +166,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-imu-fallback-count", type=int, default=0)
     parser.add_argument("--min-imu-seed-source-ratio", type=float, default=0.5)
     parser.add_argument("--min-deskew-applied-ratio", type=float, default=0.1)
+    parser.add_argument(
+        "--imu-accel-scale",
+        type=float,
+        default=1.0,
+        help="Multiply incoming acceleration before IMU integration (for example 9.80665 for g units).",
+    )
     parser.add_argument(
         "--launch-arg",
         action="append",
@@ -361,6 +382,8 @@ def config_args_for_mode(
         localizability_min_xy_eigen_ratio=0.05,
         enable_registration_localizability_diagnostics=(
             mode.enable_registration_localizability_diagnostics),
+        enable_imu_dual_queue=mode.enable_imu_dual_queue,
+        imu_accel_scale=args.imu_accel_scale,
         deskew_reference_time_sec=args.deskew_reference_time_sec,
         score_threshold=args.score_threshold,
         enable_open_loop_strict_score_threshold=args.enable_open_loop_strict_score_threshold,
@@ -384,10 +407,10 @@ def write_config(tool_args: argparse.Namespace, output_path: Path) -> None:
     if validation_error is not None:
         raise ValueError(validation_error)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(
-        config_tool.render_ros_params(config_tool.make_params(tool_args)),
-        encoding="utf-8",
-    )
+    params = config_tool.make_params(tool_args)
+    params["imu_dual_queue_enabled"] = tool_args.enable_imu_dual_queue
+    params["imu_accel_scale"] = tool_args.imu_accel_scale
+    output_path.write_text(config_tool.render_ros_params(params), encoding="utf-8")
 
 
 def system_command(tool_args: argparse.Namespace, config_path: Path, extra_launch_args: Sequence[str]) -> str:

--- a/src/lidar_localization_component.cpp
+++ b/src/lidar_localization_component.cpp
@@ -133,35 +133,7 @@ PCLLocalization::PCLLocalization(const rclcpp::NodeOptions & options)
   declare_parameter("gtsam_fitness_scale_factor", 2.0);
   declare_parameter("gtsam_fitness_reject", 50.0);
   declare_parameter("gtsam_huber_k", 1.345);
-  // IMU preintegration parameters
-  declare_parameter("use_imu_preintegration", true);
-  declare_parameter("imu_preintegration_use_base_frame_transform", false);
-  declare_parameter("imu_accel_scale", 1.0);
-  declare_parameter("use_continuous_time_deskew", false);
-  declare_parameter("continuous_time_deskew_mode", "relative_motion");
-  declare_parameter("continuous_time_cloud_stamp_reference", "start");
-  declare_parameter("continuous_time_deskew_reference_time_sec", 0.0);
-  declare_parameter("continuous_time_pose_history_duration_sec", 2.0);
-  declare_parameter("enable_localizability_guard", false);
-  declare_parameter("localizability_min_xy_eigen_ratio", 0.05);
-  declare_parameter("enable_registration_localizability_diagnostics", false);
-  declare_parameter("imu_gyro_noise_density", 0.01);
-  declare_parameter("imu_accel_noise_density", 0.1);
-  declare_parameter("imu_gyro_random_walk", 0.0001);
-  declare_parameter("imu_accel_random_walk", 0.001);
-  declare_parameter("imu_ndt_sigma_z", 0.1);
-  declare_parameter("imu_ndt_sigma_roll", 0.05);
-  declare_parameter("imu_ndt_sigma_pitch", 0.05);
-  declare_parameter("imu_bias_prior_sigma_gyro", 0.01);
-  declare_parameter("imu_bias_prior_sigma_accel", 0.1);
-  declare_parameter("imu_prediction_correction_guard_translation_m", 2.0);
-  declare_parameter("imu_prediction_correction_guard_yaw_deg", 10.0);
-  declare_parameter("imu_prediction_correction_guard_warmup_accepts", 5);
-  declare_parameter("imu_seed_consistency_gate_enabled", true);
-  declare_parameter("imu_dual_queue_enabled", true);
-  declare_parameter("imu_seed_consistency_max_translation_error_m", 0.5);
-  declare_parameter("imu_seed_consistency_max_rotation_error_deg", 5.0);
-  declare_parameter("imu_seed_consistency_required_consecutive_passes", 5);
+  declareImuPreintegrationParameters();
   declare_parameter("enable_debug", false);
   declare_parameter("predict_pose_from_previous_delta", true);
   declare_parameter("enable_local_map_crop", false);
@@ -534,6 +506,155 @@ void PCLLocalization::releaseRuntimeResources(bool leak_target_clouds_for_shutdo
   initialpose_recieved_ = false;
 }
 
+void PCLLocalization::declareImuPreintegrationParameters()
+{
+  // Backend and input units.
+  declare_parameter("use_imu_preintegration", true);
+  declare_parameter("imu_preintegration_use_base_frame_transform", false);
+  declare_parameter("imu_accel_scale", 1.0);
+  declare_parameter("imu_dual_queue_enabled", true);
+
+  // Seed safety and correction guards.
+  declare_parameter("imu_seed_consistency_gate_enabled", true);
+  declare_parameter("imu_seed_consistency_max_translation_error_m", 0.5);
+  declare_parameter("imu_seed_consistency_max_rotation_error_deg", 5.0);
+  declare_parameter("imu_seed_consistency_required_consecutive_passes", 5);
+  declare_parameter("imu_prediction_correction_guard_translation_m", 2.0);
+  declare_parameter("imu_prediction_correction_guard_yaw_deg", 10.0);
+  declare_parameter("imu_prediction_correction_guard_warmup_accepts", 5);
+
+  // Preintegration noise and factor model.
+  declare_parameter("imu_gyro_noise_density", 0.01);
+  declare_parameter("imu_accel_noise_density", 0.1);
+  declare_parameter("imu_gyro_random_walk", 0.0001);
+  declare_parameter("imu_accel_random_walk", 0.001);
+  declare_parameter("imu_ndt_sigma_z", 0.1);
+  declare_parameter("imu_ndt_sigma_roll", 0.05);
+  declare_parameter("imu_ndt_sigma_pitch", 0.05);
+  declare_parameter("imu_bias_prior_sigma_gyro", 0.01);
+  declare_parameter("imu_bias_prior_sigma_accel", 0.1);
+
+  // Experimental deskew and localizability diagnostics.
+  declare_parameter("use_continuous_time_deskew", false);
+  declare_parameter("continuous_time_deskew_mode", "relative_motion");
+  declare_parameter("continuous_time_cloud_stamp_reference", "start");
+  declare_parameter("continuous_time_deskew_reference_time_sec", 0.0);
+  declare_parameter("continuous_time_pose_history_duration_sec", 2.0);
+  declare_parameter("enable_localizability_guard", false);
+  declare_parameter("localizability_min_xy_eigen_ratio", 0.05);
+  declare_parameter("enable_registration_localizability_diagnostics", false);
+}
+
+void PCLLocalization::loadImuPreintegrationParameters()
+{
+  // Backend and input units.
+  get_parameter("use_imu_preintegration", use_imu_preintegration_);
+  get_parameter(
+    "imu_preintegration_use_base_frame_transform",
+    imu_preintegration_use_base_frame_transform_);
+  get_parameter("imu_accel_scale", imu_accel_scale_);
+  get_parameter("imu_dual_queue_enabled", imu_dual_queue_enabled_);
+  if (!std::isfinite(imu_accel_scale_) || imu_accel_scale_ <= 0.0) {
+    RCLCPP_WARN(
+      get_logger(), "Invalid imu_accel_scale %.6f; using 1.0", imu_accel_scale_);
+    imu_accel_scale_ = 1.0;
+  }
+
+  // Seed safety and correction guards.
+  get_parameter("imu_seed_consistency_gate_enabled", imu_seed_consistency_gate_enabled_);
+  get_parameter(
+    "imu_seed_consistency_max_translation_error_m",
+    imu_seed_consistency_params_.max_translation_error_m);
+  get_parameter(
+    "imu_seed_consistency_max_rotation_error_deg",
+    imu_seed_consistency_params_.max_rotation_error_deg);
+  int required_consecutive_passes = 5;
+  get_parameter(
+    "imu_seed_consistency_required_consecutive_passes", required_consecutive_passes);
+  imu_seed_consistency_params_.required_consecutive_passes = static_cast<std::size_t>(
+    std::max(1, required_consecutive_passes));
+  // Experimental deskew and localizability diagnostics.
+  get_parameter("use_continuous_time_deskew", use_continuous_time_deskew_);
+  get_parameter("continuous_time_deskew_mode", continuous_time_deskew_mode_);
+  get_parameter(
+    "continuous_time_cloud_stamp_reference", continuous_time_cloud_stamp_reference_);
+  get_parameter(
+    "continuous_time_deskew_reference_time_sec",
+    continuous_time_deskew_reference_time_sec_);
+  get_parameter(
+    "continuous_time_pose_history_duration_sec",
+    continuous_time_pose_history_duration_sec_);
+  get_parameter("enable_localizability_guard", enable_localizability_guard_);
+  get_parameter(
+    "enable_registration_localizability_diagnostics",
+    enable_registration_localizability_diagnostics_);
+  get_parameter(
+    "localizability_min_xy_eigen_ratio", localizability_min_xy_eigen_ratio_);
+  if (
+    continuous_time_deskew_mode_ != "relative_motion" &&
+    continuous_time_deskew_mode_ != "imu_pose_history" &&
+    continuous_time_deskew_mode_ != "lidar_constant_velocity")
+  {
+    RCLCPP_WARN(
+      get_logger(), "Unsupported continuous_time_deskew_mode '%s'; using relative_motion",
+      continuous_time_deskew_mode_.c_str());
+    continuous_time_deskew_mode_ = "relative_motion";
+  }
+  if (
+    continuous_time_cloud_stamp_reference_ != "start" &&
+    continuous_time_cloud_stamp_reference_ != "end")
+  {
+    RCLCPP_WARN(
+      get_logger(), "Unsupported continuous_time_cloud_stamp_reference '%s'; using start",
+      continuous_time_cloud_stamp_reference_.c_str());
+    continuous_time_cloud_stamp_reference_ = "start";
+  }
+  if (
+    !std::isfinite(continuous_time_pose_history_duration_sec_) ||
+    continuous_time_pose_history_duration_sec_ <= 0.0)
+  {
+    RCLCPP_WARN(
+      get_logger(), "continuous_time_pose_history_duration_sec must be positive; using 2.0");
+    continuous_time_pose_history_duration_sec_ = 2.0;
+  }
+
+  if (!use_imu_preintegration_) {
+    return;
+  }
+
+  get_parameter(
+    "imu_prediction_correction_guard_translation_m",
+    imu_prediction_correction_guard_translation_m_);
+  get_parameter(
+    "imu_prediction_correction_guard_yaw_deg",
+    imu_prediction_correction_guard_yaw_deg_);
+  get_parameter(
+    "imu_prediction_correction_guard_warmup_accepts",
+    imu_prediction_correction_guard_warmup_accepts_);
+
+  // Preintegration noise and factor model.
+  ImuGtsamSmoother::Params imu_params;
+  get_parameter("gtsam_ndt_sigma_x", imu_params.ndt_sigma_x);
+  get_parameter("gtsam_ndt_sigma_y", imu_params.ndt_sigma_y);
+  get_parameter("gtsam_ndt_sigma_yaw", imu_params.ndt_sigma_yaw);
+  get_parameter("imu_ndt_sigma_z", imu_params.ndt_sigma_z);
+  get_parameter("imu_ndt_sigma_roll", imu_params.ndt_sigma_roll);
+  get_parameter("imu_ndt_sigma_pitch", imu_params.ndt_sigma_pitch);
+  get_parameter("gtsam_fitness_nominal", imu_params.fitness_nominal);
+  get_parameter("gtsam_fitness_scale_factor", imu_params.fitness_scale_factor);
+  get_parameter("gtsam_fitness_reject", imu_params.fitness_reject);
+  get_parameter("gtsam_huber_k", imu_params.huber_k);
+  get_parameter("imu_gyro_noise_density", imu_params.imu_params.gyro_noise_density);
+  get_parameter("imu_accel_noise_density", imu_params.imu_params.accel_noise_density);
+  get_parameter("imu_gyro_random_walk", imu_params.imu_params.gyro_random_walk);
+  get_parameter("imu_accel_random_walk", imu_params.imu_params.accel_random_walk);
+  get_parameter("imu_bias_prior_sigma_gyro", imu_params.bias_prior_sigma_gyro);
+  get_parameter("imu_bias_prior_sigma_accel", imu_params.bias_prior_sigma_accel);
+  imu_smoother_.params_ = imu_params;
+  imu_prediction_smoother_.params_ = imu_params;
+  RCLCPP_INFO(get_logger(), "IMU preintegration smoother enabled");
+}
+
 void PCLLocalization::initializeParameters()
 {
   RCLCPP_INFO(get_logger(), "initializeParameters");
@@ -624,105 +745,7 @@ void PCLLocalization::initializeParameters()
     gtsam_smoother_.setParams(gtsam_params);
     gtsam_smoother_.reset();
   }
-  get_parameter("use_imu_preintegration", use_imu_preintegration_);
-  get_parameter(
-    "imu_preintegration_use_base_frame_transform",
-    imu_preintegration_use_base_frame_transform_);
-  get_parameter("imu_accel_scale", imu_accel_scale_);
-  if (!std::isfinite(imu_accel_scale_) || imu_accel_scale_ <= 0.0) {
-    RCLCPP_WARN(
-      get_logger(), "Invalid imu_accel_scale %.6f; using 1.0", imu_accel_scale_);
-    imu_accel_scale_ = 1.0;
-  }
-  get_parameter("imu_seed_consistency_gate_enabled", imu_seed_consistency_gate_enabled_);
-  get_parameter("imu_dual_queue_enabled", imu_dual_queue_enabled_);
-  get_parameter(
-    "imu_seed_consistency_max_translation_error_m",
-    imu_seed_consistency_params_.max_translation_error_m);
-  get_parameter(
-    "imu_seed_consistency_max_rotation_error_deg",
-    imu_seed_consistency_params_.max_rotation_error_deg);
-  int imu_seed_consistency_required_consecutive_passes = 5;
-  get_parameter(
-    "imu_seed_consistency_required_consecutive_passes",
-    imu_seed_consistency_required_consecutive_passes);
-  imu_seed_consistency_params_.required_consecutive_passes = static_cast<std::size_t>(
-    std::max(1, imu_seed_consistency_required_consecutive_passes));
-  get_parameter("use_continuous_time_deskew", use_continuous_time_deskew_);
-  get_parameter("continuous_time_deskew_mode", continuous_time_deskew_mode_);
-  get_parameter(
-    "continuous_time_cloud_stamp_reference", continuous_time_cloud_stamp_reference_);
-  get_parameter(
-    "continuous_time_deskew_reference_time_sec",
-    continuous_time_deskew_reference_time_sec_);
-  get_parameter(
-    "continuous_time_pose_history_duration_sec",
-    continuous_time_pose_history_duration_sec_);
-  get_parameter("enable_localizability_guard", enable_localizability_guard_);
-  get_parameter(
-    "enable_registration_localizability_diagnostics",
-    enable_registration_localizability_diagnostics_);
-  get_parameter(
-    "localizability_min_xy_eigen_ratio", localizability_min_xy_eigen_ratio_);
-  if (
-    continuous_time_deskew_mode_ != "relative_motion" &&
-    continuous_time_deskew_mode_ != "imu_pose_history" &&
-    continuous_time_deskew_mode_ != "lidar_constant_velocity")
-  {
-    RCLCPP_WARN(
-      get_logger(), "Unsupported continuous_time_deskew_mode '%s'; using relative_motion",
-      continuous_time_deskew_mode_.c_str());
-    continuous_time_deskew_mode_ = "relative_motion";
-  }
-  if (
-    continuous_time_cloud_stamp_reference_ != "start" &&
-    continuous_time_cloud_stamp_reference_ != "end")
-  {
-    RCLCPP_WARN(
-      get_logger(), "Unsupported continuous_time_cloud_stamp_reference '%s'; using start",
-      continuous_time_cloud_stamp_reference_.c_str());
-    continuous_time_cloud_stamp_reference_ = "start";
-  }
-  if (
-    !std::isfinite(continuous_time_pose_history_duration_sec_) ||
-    continuous_time_pose_history_duration_sec_ <= 0.0)
-  {
-    RCLCPP_WARN(
-      get_logger(), "continuous_time_pose_history_duration_sec must be positive; using 2.0");
-    continuous_time_pose_history_duration_sec_ = 2.0;
-  }
-  if (use_imu_preintegration_) {
-    ImuGtsamSmoother::Params imu_params;
-    // Reuse GTSAM NDT sigmas for x, y, yaw
-    get_parameter("gtsam_ndt_sigma_x", imu_params.ndt_sigma_x);
-    get_parameter("gtsam_ndt_sigma_y", imu_params.ndt_sigma_y);
-    get_parameter("gtsam_ndt_sigma_yaw", imu_params.ndt_sigma_yaw);
-    get_parameter("imu_ndt_sigma_z", imu_params.ndt_sigma_z);
-    get_parameter("imu_ndt_sigma_roll", imu_params.ndt_sigma_roll);
-    get_parameter("imu_ndt_sigma_pitch", imu_params.ndt_sigma_pitch);
-    get_parameter("gtsam_fitness_nominal", imu_params.fitness_nominal);
-    get_parameter("gtsam_fitness_scale_factor", imu_params.fitness_scale_factor);
-    get_parameter("gtsam_fitness_reject", imu_params.fitness_reject);
-    get_parameter("gtsam_huber_k", imu_params.huber_k);
-    get_parameter("imu_gyro_noise_density", imu_params.imu_params.gyro_noise_density);
-    get_parameter("imu_accel_noise_density", imu_params.imu_params.accel_noise_density);
-    get_parameter("imu_gyro_random_walk", imu_params.imu_params.gyro_random_walk);
-    get_parameter("imu_accel_random_walk", imu_params.imu_params.accel_random_walk);
-    get_parameter("imu_bias_prior_sigma_gyro", imu_params.bias_prior_sigma_gyro);
-    get_parameter("imu_bias_prior_sigma_accel", imu_params.bias_prior_sigma_accel);
-    get_parameter(
-      "imu_prediction_correction_guard_translation_m",
-      imu_prediction_correction_guard_translation_m_);
-    get_parameter(
-      "imu_prediction_correction_guard_yaw_deg",
-      imu_prediction_correction_guard_yaw_deg_);
-    get_parameter(
-      "imu_prediction_correction_guard_warmup_accepts",
-      imu_prediction_correction_guard_warmup_accepts_);
-    imu_smoother_.params_ = imu_params;
-    imu_prediction_smoother_.params_ = imu_params;
-    RCLCPP_INFO(get_logger(), "IMU preintegration smoother enabled");
-  }
+  loadImuPreintegrationParameters();
   get_parameter("enable_debug", enable_debug_);
   get_parameter("viz_downsample", viz_downsample_);
   get_parameter("viz_voxel_leaf_size", viz_voxel_leaf_size_);

--- a/src/lidar_localization_component.cpp
+++ b/src/lidar_localization_component.cpp
@@ -136,6 +136,7 @@ PCLLocalization::PCLLocalization(const rclcpp::NodeOptions & options)
   // IMU preintegration parameters
   declare_parameter("use_imu_preintegration", true);
   declare_parameter("imu_preintegration_use_base_frame_transform", false);
+  declare_parameter("imu_accel_scale", 1.0);
   declare_parameter("use_continuous_time_deskew", false);
   declare_parameter("continuous_time_deskew_mode", "relative_motion");
   declare_parameter("continuous_time_cloud_stamp_reference", "start");
@@ -156,6 +157,11 @@ PCLLocalization::PCLLocalization(const rclcpp::NodeOptions & options)
   declare_parameter("imu_prediction_correction_guard_translation_m", 2.0);
   declare_parameter("imu_prediction_correction_guard_yaw_deg", 10.0);
   declare_parameter("imu_prediction_correction_guard_warmup_accepts", 5);
+  declare_parameter("imu_seed_consistency_gate_enabled", true);
+  declare_parameter("imu_dual_queue_enabled", true);
+  declare_parameter("imu_seed_consistency_max_translation_error_m", 0.5);
+  declare_parameter("imu_seed_consistency_max_rotation_error_deg", 5.0);
+  declare_parameter("imu_seed_consistency_required_consecutive_passes", 5);
   declare_parameter("enable_debug", false);
   declare_parameter("predict_pose_from_previous_delta", true);
   declare_parameter("enable_local_map_crop", false);
@@ -476,6 +482,18 @@ void PCLLocalization::releaseRuntimeResources(bool leak_target_clouds_for_shutdo
     latest_imu_seed_last_dt_sec_ = std::numeric_limits<double>::quiet_NaN();
     latest_imu_seed_last_sample_age_sec_ = std::numeric_limits<double>::quiet_NaN();
     latest_imu_seed_integration_window_sec_ = 0.0;
+    latest_imu_open_loop_prediction_ = Eigen::Matrix4f::Identity();
+    latest_imu_open_loop_prediction_available_ = false;
+    latest_imu_seed_consistency_translation_error_m_ =
+      std::numeric_limits<double>::quiet_NaN();
+    latest_imu_seed_consistency_rotation_error_deg_ =
+      std::numeric_limits<double>::quiet_NaN();
+    latest_imu_seed_consistency_sample_passed_ = false;
+    imu_seed_consistency_state_ = {};
+    imu_dual_queue_.clear();
+    imu_optimization_anchor_sample_.reset();
+    imu_prediction_anchor_sample_.reset();
+    latest_dual_queue_integrated_stamp_ = 0.0;
     resetImuPreintegrationSampleCounters();
   }
   reinitialization_requested_ = false;
@@ -610,6 +628,26 @@ void PCLLocalization::initializeParameters()
   get_parameter(
     "imu_preintegration_use_base_frame_transform",
     imu_preintegration_use_base_frame_transform_);
+  get_parameter("imu_accel_scale", imu_accel_scale_);
+  if (!std::isfinite(imu_accel_scale_) || imu_accel_scale_ <= 0.0) {
+    RCLCPP_WARN(
+      get_logger(), "Invalid imu_accel_scale %.6f; using 1.0", imu_accel_scale_);
+    imu_accel_scale_ = 1.0;
+  }
+  get_parameter("imu_seed_consistency_gate_enabled", imu_seed_consistency_gate_enabled_);
+  get_parameter("imu_dual_queue_enabled", imu_dual_queue_enabled_);
+  get_parameter(
+    "imu_seed_consistency_max_translation_error_m",
+    imu_seed_consistency_params_.max_translation_error_m);
+  get_parameter(
+    "imu_seed_consistency_max_rotation_error_deg",
+    imu_seed_consistency_params_.max_rotation_error_deg);
+  int imu_seed_consistency_required_consecutive_passes = 5;
+  get_parameter(
+    "imu_seed_consistency_required_consecutive_passes",
+    imu_seed_consistency_required_consecutive_passes);
+  imu_seed_consistency_params_.required_consecutive_passes = static_cast<std::size_t>(
+    std::max(1, imu_seed_consistency_required_consecutive_passes));
   get_parameter("use_continuous_time_deskew", use_continuous_time_deskew_);
   get_parameter("continuous_time_deskew_mode", continuous_time_deskew_mode_);
   get_parameter(
@@ -682,6 +720,7 @@ void PCLLocalization::initializeParameters()
       "imu_prediction_correction_guard_warmup_accepts",
       imu_prediction_correction_guard_warmup_accepts_);
     imu_smoother_.params_ = imu_params;
+    imu_prediction_smoother_.params_ = imu_params;
     RCLCPP_INFO(get_logger(), "IMU preintegration smoother enabled");
   }
   get_parameter("enable_debug", enable_debug_);
@@ -894,8 +933,17 @@ void PCLLocalization::initializeParameters()
   RCLCPP_INFO(get_logger(),"use_imu: %d", use_imu_);
   RCLCPP_INFO(get_logger(),"use_imu_preintegration: %d", use_imu_preintegration_);
   RCLCPP_INFO(
+    get_logger(),
+    "imu_seed_consistency_gate: enabled=%d translation=%.3f m rotation=%.3f deg passes=%zu",
+    imu_seed_consistency_gate_enabled_,
+    imu_seed_consistency_params_.max_translation_error_m,
+    imu_seed_consistency_params_.max_rotation_error_deg,
+    imu_seed_consistency_params_.required_consecutive_passes);
+  RCLCPP_INFO(get_logger(), "imu_dual_queue_enabled: %d", imu_dual_queue_enabled_);
+  RCLCPP_INFO(
     get_logger(), "imu_preintegration_use_base_frame_transform: %d",
     imu_preintegration_use_base_frame_transform_);
+  RCLCPP_INFO(get_logger(), "imu_accel_scale: %.8f", imu_accel_scale_);
   RCLCPP_INFO(get_logger(), "use_continuous_time_deskew: %d", use_continuous_time_deskew_);
   RCLCPP_INFO(
     get_logger(), "continuous_time_deskew_mode: %s", continuous_time_deskew_mode_.c_str());
@@ -1311,6 +1359,16 @@ void PCLLocalization::initialPoseReceived(const geometry_msgs::msg::PoseWithCova
         0.0, 0.0, 0.0,  // initial velocity = 0
         stamp_to_sec(msg->header.stamp));
       last_scan_stamp_for_imu_ = stamp_to_sec(msg->header.stamp);
+      imu_seed_consistency_state_ = {};
+      latest_imu_open_loop_prediction_available_ = false;
+      imu_prediction_smoother_.initializeState(
+        imu_smoother_.position(), imu_smoother_.rotation(), imu_smoother_.velocity(),
+        imu_smoother_.gyroBias(), imu_smoother_.accelBias(),
+        last_scan_stamp_for_imu_);
+      imu_dual_queue_.clear();
+      imu_optimization_anchor_sample_.reset();
+      imu_prediction_anchor_sample_.reset();
+      latest_dual_queue_integrated_stamp_ = last_scan_stamp_for_imu_;
       RCLCPP_INFO(get_logger(), "IMU preintegration smoother initialized from initial pose");
     }
   }
@@ -1553,11 +1611,27 @@ void PCLLocalization::imuReceived(const sensor_msgs::msg::Imu::ConstSharedPtr ms
     }
 
     if (collect_preintegration_sample && preintegration_sample_ready) {
+      preintegration_accel = lidar_localization::scaleImuAcceleration(
+        preintegration_accel, imu_accel_scale_);
+    }
+
+    if (collect_preintegration_sample && preintegration_sample_ready) {
       double stamp_sec = stamp_to_sec(msg->header.stamp);
       const double dt = last_imu_stamp_ > 0.0 ? stamp_sec - last_imu_stamp_ : 0.0;
 
-      // Feed to smoother for dead-reckoning
-      if (imu_smoother_.isInitialized() && last_imu_stamp_ > 0.0) {
+      if (imu_dual_queue_enabled_) {
+        if (!imu_dual_queue_.push(
+            lidar_localization::TimestampedImuSample{
+              stamp_sec, preintegration_gyro, preintegration_accel}))
+        {
+          ++imu_preintegration_invalid_dt_count_since_scan_;
+          ++imu_preintegration_skipped_sample_count_since_scan_;
+        } else {
+          imu_preintegration_skipped_sample_count_since_scan_ +=
+            imu_dual_queue_.trimTo(static_cast<std::size_t>(imu_queue_depth_));
+        }
+        // Legacy single-stream integration is retained as the A/B baseline.
+      } else if (imu_smoother_.isInitialized() && last_imu_stamp_ > 0.0) {
         imu_preintegration_last_dt_sec_ = dt;
         if (lidar_localization::isValidImuPreintegrationDt(dt)) {
           imu_smoother_.integrateImu(preintegration_gyro, preintegration_accel, dt);
@@ -2309,14 +2383,72 @@ PCLLocalization::SelectedRegistrationSeed PCLLocalization::selectRegistrationSee
   bool imu_prediction_finite = false;
   {
     std::lock_guard<std::mutex> lock(imu_preintegration_mutex_);
+    bool dual_queue_prediction_ready = false;
+    Eigen::Matrix4f dual_queue_prediction = Eigen::Matrix4f::Identity();
+    if (imu_dual_queue_enabled_ && imu_smoother_.isInitialized()) {
+      std::vector<lidar_localization::TimestampedImuSample> optimization_samples;
+      if (imu_optimization_anchor_sample_.has_value()) {
+        optimization_samples.push_back(*imu_optimization_anchor_sample_);
+      }
+      const auto queued_optimization_samples =
+        imu_dual_queue_.optimizationSamplesThrough(scan_stamp_sec);
+      optimization_samples.insert(
+        optimization_samples.end(),
+        queued_optimization_samples.begin(), queued_optimization_samples.end());
+      const auto optimization_plan = lidar_localization::planCausalImuIntervals(
+        last_scan_stamp_for_imu_, scan_stamp_sec, optimization_samples,
+        lidar_localization::kMaximumImuPreintegrationSampleDtSec);
+      imu_smoother_.resetPendingIntegration();
+      if (optimization_plan.complete_coverage) {
+        for (const auto & interval : optimization_plan.intervals) {
+          imu_smoother_.integrateImu(interval.gyro, interval.accel, interval.dt());
+          ++imu_preintegration_integrated_sample_count_since_scan_;
+          imu_preintegration_last_dt_sec_ = interval.dt();
+        }
+      } else {
+        imu_smoother_.resetPendingIntegration();
+        imu_preintegration_skipped_sample_count_since_scan_ +=
+          optimization_plan.skipped_gap_count;
+      }
+
+      std::vector<lidar_localization::TimestampedImuSample> prediction_samples;
+      if (imu_prediction_anchor_sample_.has_value()) {
+        prediction_samples.push_back(*imu_prediction_anchor_sample_);
+      }
+      const auto queued_prediction_samples = imu_dual_queue_.predictionSamples();
+      prediction_samples.insert(
+        prediction_samples.end(),
+        queued_prediction_samples.begin(), queued_prediction_samples.end());
+      const auto prediction_plan = lidar_localization::planCausalImuIntervals(
+        last_scan_stamp_for_imu_, scan_stamp_sec, prediction_samples,
+        lidar_localization::kMaximumImuPreintegrationSampleDtSec);
+      imu_prediction_smoother_.initializeState(
+        imu_smoother_.position(), imu_smoother_.rotation(), imu_smoother_.velocity(),
+        imu_smoother_.gyroBias(), imu_smoother_.accelBias(),
+        last_scan_stamp_for_imu_);
+      if (prediction_plan.complete_coverage && !prediction_plan.intervals.empty()) {
+        for (const auto & interval : prediction_plan.intervals) {
+          imu_prediction_smoother_.integrateImu(
+            interval.gyro, interval.accel, interval.dt());
+        }
+        dual_queue_prediction = imu_prediction_smoother_.predictedPoseMatrix();
+        dual_queue_prediction_ready = dual_queue_prediction.allFinite();
+        latest_dual_queue_integrated_stamp_ = scan_stamp_sec;
+      }
+    }
     snapshotImuPreintegrationSampleCountersForScan();
 
-    const bool imu_has_new_samples =
+    const bool imu_has_new_samples = imu_dual_queue_enabled_ ?
+      dual_queue_prediction_ready :
       lidar_localization::hasNewImuSamples(last_imu_stamp_, last_scan_stamp_for_imu_);
     latest_imu_seed_has_new_samples_ = imu_has_new_samples;
     latest_imu_seed_last_sample_age_sec_ =
-      lidar_localization::imuLastSampleAgeSec(scan_stamp_sec, last_imu_stamp_);
+      lidar_localization::imuLastSampleAgeSec(
+      scan_stamp_sec,
+      imu_dual_queue_enabled_ ? latest_dual_queue_integrated_stamp_ : last_imu_stamp_);
     latest_imu_seed_integration_window_sec_ =
+      imu_dual_queue_enabled_ ?
+      std::max(0.0, scan_stamp_sec - last_scan_stamp_for_imu_) :
       lidar_localization::imuIntegrationWindowSec(last_imu_stamp_, last_scan_stamp_for_imu_);
     const double max_imu_integration_window_sec =
       lidar_localization::imuMaximumIntegrationWindowSec(scan_period_);
@@ -2339,10 +2471,17 @@ PCLLocalization::SelectedRegistrationSeed PCLLocalization::selectRegistrationSee
       imu_smoother_initialized &&
       imu_has_usable_new_samples;
     if (imu_candidate_ready) {
-      imu_init_guess = imu_smoother_.predictedPoseMatrix();
+      imu_init_guess = imu_dual_queue_enabled_ ?
+        dual_queue_prediction : imu_smoother_.predictedPoseMatrix();
       imu_prediction_finite = imu_init_guess.allFinite();
     }
+    latest_imu_open_loop_prediction_ = imu_init_guess;
+    latest_imu_open_loop_prediction_available_ =
+      imu_candidate_ready && imu_prediction_finite;
     latest_imu_seed_prediction_finite_ = !imu_candidate_ready || imu_prediction_finite;
+    imu_has_usable_new_samples =
+      imu_has_usable_new_samples &&
+      (!imu_seed_consistency_gate_enabled_ || imu_seed_consistency_state_.seed_allowed);
   }
 
   const lidar_localization::RegistrationSeedPolicyDecision seed_decision =
@@ -3173,10 +3312,19 @@ void PCLLocalization::resetImuPreintegrationSmootherToObservation(
   const lidar_localization::RegistrationObservation & observation,
   double stamp_sec)
 {
+  Eigen::Vector3d initial_velocity = Eigen::Vector3d::Zero();
+  if (imu_dual_queue_enabled_ && have_last_accepted_pose_) {
+    const auto estimate = lidar_localization::estimateImuInitialVelocity(
+      last_accepted_pose_matrix_, last_accepted_pose_time_sec_,
+      observation.pose_matrix, stamp_sec);
+    if (estimate.usable) {
+      initial_velocity = estimate.velocity;
+    }
+  }
   imu_smoother_.initialize(
     observation.x, observation.y, observation.z,
     observation.roll, observation.pitch, observation.yaw,
-    0.0, 0.0, 0.0, stamp_sec);
+    initial_velocity.x(), initial_velocity.y(), initial_velocity.z(), stamp_sec);
 }
 
 PCLLocalization::ImuPreintegrationBackendUpdate
@@ -3188,6 +3336,39 @@ PCLLocalization::updateImuPreintegrationBackend(
 {
   std::lock_guard<std::mutex> lock(imu_preintegration_mutex_);
   initializeImuPreintegrationSmootherIfNeeded(observation, stamp_sec);
+
+  if (imu_seed_consistency_gate_enabled_) {
+    const bool prediction_available = latest_imu_open_loop_prediction_available_;
+    const double translation_error_m = prediction_available ?
+      static_cast<double>(
+      (latest_imu_open_loop_prediction_.block<3, 1>(0, 3) -
+      observation.pose_matrix.block<3, 1>(0, 3)).norm()) :
+      std::numeric_limits<double>::quiet_NaN();
+    const double rotation_error_deg = prediction_available ?
+      lidar_localization::rotationDeltaDeg(
+      latest_imu_open_loop_prediction_, observation.pose_matrix) :
+      std::numeric_limits<double>::quiet_NaN();
+    const bool was_allowed = imu_seed_consistency_state_.seed_allowed;
+    const auto consistency_update = lidar_localization::updateImuSeedConsistency(
+      imu_seed_consistency_state_,
+      imu_seed_consistency_params_,
+      lidar_localization::ImuSeedConsistencyInput{
+        true, prediction_available, translation_error_m, rotation_error_deg});
+    imu_seed_consistency_state_ = consistency_update.state;
+    latest_imu_seed_consistency_translation_error_m_ = translation_error_m;
+    latest_imu_seed_consistency_rotation_error_deg_ = rotation_error_deg;
+    latest_imu_seed_consistency_sample_passed_ = consistency_update.sample_passed;
+    if (was_allowed != imu_seed_consistency_state_.seed_allowed) {
+      RCLCPP_WARN(
+        get_logger(),
+        "IMU seed consistency gate %s after %zu consecutive passes "
+        "(translation error %.3f m, rotation error %.3f deg)",
+        imu_seed_consistency_state_.seed_allowed ? "enabled" : "disabled",
+        imu_seed_consistency_state_.consecutive_pass_count,
+        translation_error_m,
+        rotation_error_deg);
+    }
+  }
 
   ImuPreintegrationBackendUpdate update;
   update.pose = observation.pose_matrix;
@@ -3201,12 +3382,32 @@ PCLLocalization::updateImuPreintegrationBackend(
       attempt.correction_translation_m,
       attempt.correction_yaw_deg,
       imu_guard_warmup_accepts_remaining_.load(std::memory_order_acquire)});
+  if (
+    imu_dual_queue_enabled_ &&
+    !update.state.fallback_mode &&
+    !update.state.correction_guard_tripped)
+  {
+    // The consistency gate controls whether prediction may seed NDT, not
+    // whether accepted LiDAR poses may teach the optimization-only smoother.
+    // If causal IMU coverage is incomplete, resetPendingIntegration() has
+    // already removed that factor. A pose-only update then preserves the
+    // optimized velocity and biases instead of resetting them from a noisy
+    // finite difference across the scheduling gap.
+    update.state.should_update_smoother = true;
+  }
 
   if (update.state.should_update_smoother) {
-    update.updated = imu_smoother_.update(
-      observation.x, observation.y, observation.z,
-      observation.roll, observation.pitch, observation.yaw,
-      attempt.fitness_score, stamp_sec);
+    if (imu_dual_queue_enabled_ && !latest_imu_open_loop_prediction_available_) {
+      update.updated = imu_smoother_.updatePoseOnly(
+        observation.x, observation.y, observation.z,
+        observation.roll, observation.pitch, observation.yaw,
+        attempt.fitness_score, stamp_sec);
+    } else {
+      update.updated = imu_smoother_.update(
+        observation.x, observation.y, observation.z,
+        observation.roll, observation.pitch, observation.yaw,
+        attempt.fitness_score, stamp_sec);
+    }
 
     update.pose = imu_smoother_.poseMatrix();
     if (update.pose.allFinite()) {
@@ -3226,7 +3427,12 @@ PCLLocalization::updateImuPreintegrationBackend(
         update.smoother_measurement_rotation_delta_deg});
   }
 
-  if (!update.state.fallback_mode) {
+  if (
+    imu_dual_queue_enabled_ &&
+    (update.state.state_reset || !update.updated))
+  {
+    resetImuPreintegrationSmootherToObservation(observation, stamp_sec);
+  } else if (!imu_dual_queue_enabled_ && !update.state.fallback_mode) {
     resetImuPreintegrationSmootherToObservation(observation, stamp_sec);
   }
   imu_preintegration_fallback_mode_ = update.state.fallback_mode;
@@ -3246,6 +3452,22 @@ PCLLocalization::updateImuPreintegrationBackend(
     }
   }
 
+  if (imu_dual_queue_enabled_) {
+    const auto consumed_optimization =
+      imu_dual_queue_.consumeOptimizationThrough(stamp_sec);
+    if (!consumed_optimization.empty()) {
+      imu_optimization_anchor_sample_ = consumed_optimization.back();
+    }
+    const auto repropagation_window =
+      imu_dual_queue_.preparePredictionRepropagation(stamp_sec);
+    if (repropagation_window.anchor_sample.has_value()) {
+      imu_prediction_anchor_sample_ = repropagation_window.anchor_sample;
+    }
+    imu_prediction_smoother_.initializeState(
+      imu_smoother_.position(), imu_smoother_.rotation(), imu_smoother_.velocity(),
+      imu_smoother_.gyroBias(), imu_smoother_.accelBias(), stamp_sec);
+    latest_dual_queue_integrated_stamp_ = stamp_sec;
+  }
   last_scan_stamp_for_imu_ = stamp_sec;
   return update;
 }
@@ -3767,6 +3989,20 @@ PCLLocalization::prepareAlignmentDiagnosticValuesInput(
   diagnostic_input.imu_last_dt_sec = imu_diagnostics.last_dt_sec;
   diagnostic_input.imu_last_sample_age_sec = imu_diagnostics.last_sample_age_sec;
   diagnostic_input.imu_integration_window_sec = imu_diagnostics.integration_window_sec;
+  diagnostic_input.imu_seed_consistency_gate_enabled =
+    imu_diagnostics.seed_consistency_gate_enabled;
+  diagnostic_input.imu_seed_consistency_seed_allowed =
+    imu_diagnostics.seed_consistency_seed_allowed;
+  diagnostic_input.imu_seed_consistency_valid_comparison_count =
+    imu_diagnostics.seed_consistency_valid_comparison_count;
+  diagnostic_input.imu_seed_consistency_consecutive_pass_count =
+    imu_diagnostics.seed_consistency_consecutive_pass_count;
+  diagnostic_input.imu_seed_consistency_translation_error_m =
+    imu_diagnostics.seed_consistency_translation_error_m;
+  diagnostic_input.imu_seed_consistency_rotation_error_deg =
+    imu_diagnostics.seed_consistency_rotation_error_deg;
+  diagnostic_input.imu_seed_consistency_sample_passed =
+    imu_diagnostics.seed_consistency_sample_passed;
   diagnostic_input.scan_time_status =
     lidar_localization::scanTimeRangeStatusMessage(latest_scan_time_status_);
   diagnostic_input.scan_time_field = latest_scan_time_field_;
@@ -3823,7 +4059,14 @@ PCLLocalization::makeImuPreintegrationDiagnosticsInput(
     latest_imu_seed_last_sample_age_sec_,
     latest_imu_seed_integration_window_sec_,
     lidar_localization::imuStaleSampleAgeThresholdSec(scan_period_),
-    lidar_localization::imuMaximumIntegrationWindowSec(scan_period_)};
+    lidar_localization::imuMaximumIntegrationWindowSec(scan_period_),
+    imu_seed_consistency_gate_enabled_,
+    imu_seed_consistency_state_.seed_allowed,
+    imu_seed_consistency_state_.valid_comparison_count,
+    imu_seed_consistency_state_.consecutive_pass_count,
+    latest_imu_seed_consistency_translation_error_m_,
+    latest_imu_seed_consistency_rotation_error_deg_,
+    latest_imu_seed_consistency_sample_passed_};
 }
 
 void PCLLocalization::appendAlignmentDiagnosticValues(

--- a/test/test_alignment_diagnostics_policy.cpp
+++ b/test/test_alignment_diagnostics_policy.cpp
@@ -133,9 +133,16 @@ void test_build_alignment_diagnostic_values_order_and_strings()
   input.registration_localizability.correspondence_count = 456;
   input.registration_localizability.eigenvalues[0] = 0.125;
   input.registration_localizability.weakest_eigenvector[0] = -0.5;
+  input.imu_seed_consistency_gate_enabled = true;
+  input.imu_seed_consistency_seed_allowed = true;
+  input.imu_seed_consistency_valid_comparison_count = 12;
+  input.imu_seed_consistency_consecutive_pass_count = 6;
+  input.imu_seed_consistency_translation_error_m = 0.2;
+  input.imu_seed_consistency_rotation_error_deg = 1.5;
+  input.imu_seed_consistency_sample_passed = true;
 
   const auto values = ll::buildAlignmentDiagnosticValues(input);
-  assert(values.size() == 88);
+  assert(values.size() == 95);
   assert(values[0].first == "registration_method");
   assert(values[0].second == "NDT");
   assert(values[1].first == "has_converged");
@@ -240,6 +247,20 @@ void test_build_alignment_diagnostic_values_order_and_strings()
   assert(values[86].second.find("0.250") == 0);
   assert(values[87].first == "localizability_guard_active");
   assert(values[87].second == "false");
+  assert(values[88].first == "imu_seed_consistency_gate_enabled");
+  assert(values[88].second == "true");
+  assert(values[89].first == "imu_seed_consistency_seed_allowed");
+  assert(values[89].second == "true");
+  assert(values[90].first == "imu_seed_consistency_valid_comparison_count");
+  assert(values[90].second == "12");
+  assert(values[91].first == "imu_seed_consistency_consecutive_pass_count");
+  assert(values[91].second == "6");
+  assert(values[92].first == "imu_seed_consistency_translation_error_m");
+  assert(values[92].second.find("0.200") == 0);
+  assert(values[93].first == "imu_seed_consistency_rotation_error_deg");
+  assert(values[93].second.find("1.500") == 0);
+  assert(values[94].first == "imu_seed_consistency_sample_passed");
+  assert(values[94].second == "true");
 }
 
 int main()

--- a/test/test_imu_initialization_policy.cpp
+++ b/test/test_imu_initialization_policy.cpp
@@ -1,0 +1,59 @@
+#include "lidar_localization/imu_initialization_policy.hpp"
+
+#include <cassert>
+#include <limits>
+
+namespace ll = lidar_localization;
+
+Eigen::Matrix4f pose(double x, double y, double z)
+{
+  Eigen::Matrix4f value = Eigen::Matrix4f::Identity();
+  value.block<3, 1>(0, 3) = Eigen::Vector3f(x, y, z);
+  return value;
+}
+
+void test_estimates_world_velocity_from_two_accepted_poses()
+{
+  const auto estimate = ll::estimateImuInitialVelocity(
+    pose(1.0, 2.0, 3.0), 10.0,
+    pose(2.0, 1.5, 3.25), 10.5);
+
+  assert(estimate.usable);
+  assert((estimate.velocity - Eigen::Vector3d(2.0, -1.0, 0.5)).norm() < 1e-12);
+  assert(estimate.interval_sec == 0.5);
+}
+
+void test_scales_g_units_to_si_acceleration()
+{
+  const Eigen::Vector3d in_g(0.1, -0.2, 1.0);
+  const Eigen::Vector3d expected(0.980665, -1.96133, 9.80665);
+  assert((ll::scaleImuAcceleration(in_g, 9.80665) - expected).norm() < 1e-12);
+}
+
+void test_rejects_nonpositive_or_excessive_interval()
+{
+  assert(!ll::estimateImuInitialVelocity(
+    pose(0, 0, 0), 1.0, pose(1, 0, 0), 1.0).usable);
+  assert(!ll::estimateImuInitialVelocity(
+    pose(0, 0, 0), 1.0, pose(1, 0, 0), 4.0, 2.0).usable);
+}
+
+void test_rejects_implausible_speed_and_non_finite_pose()
+{
+  assert(!ll::estimateImuInitialVelocity(
+    pose(0, 0, 0), 1.0, pose(100, 0, 0), 2.0, 2.0, 50.0).usable);
+
+  auto invalid = pose(1, 0, 0);
+  invalid(0, 3) = std::numeric_limits<float>::quiet_NaN();
+  assert(!ll::estimateImuInitialVelocity(
+    pose(0, 0, 0), 1.0, invalid, 2.0).usable);
+}
+
+int main()
+{
+  test_estimates_world_velocity_from_two_accepted_poses();
+  test_scales_g_units_to_si_acceleration();
+  test_rejects_nonpositive_or_excessive_interval();
+  test_rejects_implausible_speed_and_non_finite_pose();
+  return 0;
+}

--- a/test/test_imu_preintegration.cpp
+++ b/test/test_imu_preintegration.cpp
@@ -205,6 +205,84 @@ void test_covariance_symmetric_and_grows()
   assert(es.eigenvalues().minCoeff() > -1e-12);
 }
 
+void test_one_step_covariance_matches_continuous_noise_density_units()
+{
+  ImuPreintegration pre;
+  pre.params.accel_noise_density = 0.2;
+  pre.params.gyro_noise_density = 0.03;
+  const double dt = 0.01;
+  pre.integrate(
+    Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero(),
+    Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero(), dt);
+
+  const double accel_variance_density = 0.2 * 0.2;
+  const double gyro_variance_density = 0.03 * 0.03;
+  const double expected_dp_variance =
+    0.25 * accel_variance_density * dt * dt * dt;
+  const double expected_dv_variance = accel_variance_density * dt;
+  const double expected_dtheta_variance = gyro_variance_density * dt;
+  for (int axis = 0; axis < 3; ++axis) {
+    assert(close(pre.covariance(axis, axis), expected_dp_variance, 1e-15));
+    assert(close(pre.covariance(3 + axis, 3 + axis), expected_dv_variance, 1e-15));
+    assert(close(pre.covariance(6 + axis, 6 + axis), expected_dtheta_variance, 1e-15));
+  }
+}
+
+void test_bias_random_walk_increases_prior_variance_analytically()
+{
+  const double initial_sigma = 0.02;
+  const double random_walk = 0.003;
+  const double duration = 4.0;
+  const double expected =
+    initial_sigma * initial_sigma + random_walk * random_walk * duration;
+
+  assert(close(
+    imuBiasPriorVariance(initial_sigma, random_walk, duration), expected, 1e-15));
+  assert(close(
+    imuBiasPriorVariance(initial_sigma, 0.0, duration),
+    initial_sigma * initial_sigma, 1e-15));
+  assert(close(
+    imuBiasPriorVariance(initial_sigma, random_walk, 0.0),
+    initial_sigma * initial_sigma, 1e-15));
+}
+
+ImuGtsamSmoother estimate_constant_gyro_bias(double gyro_random_walk)
+{
+  ImuGtsamSmoother smoother;
+  smoother.params_.imu_params.gravity.setZero();
+  smoother.params_.imu_params.gyro_noise_density = 0.01;
+  smoother.params_.bias_prior_sigma_gyro = 0.001;
+  smoother.params_.imu_params.gyro_random_walk = gyro_random_walk;
+  smoother.initialize(
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0);
+
+  for (int interval = 1; interval <= 5; ++interval) {
+    for (int tick = 0; tick < 20; ++tick) {
+      smoother.integrateImu(
+        Eigen::Vector3d(0.0, 0.0, 0.1), Eigen::Vector3d::Zero(), 0.005);
+    }
+    assert(smoother.update(
+      0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.01, 0.1 * interval));
+  }
+  return smoother;
+}
+
+void test_bias_random_walk_changes_bias_estimate_in_smoother()
+{
+  const auto tightly_anchored = estimate_constant_gyro_bias(0.0);
+  const auto random_walk_aware = estimate_constant_gyro_bias(0.5);
+  const double true_bias = 0.1;
+
+  const double anchored_error =
+    std::abs(tightly_anchored.gyroBias().z() - true_bias);
+  const double random_walk_error =
+    std::abs(random_walk_aware.gyroBias().z() - true_bias);
+  assert(random_walk_error < anchored_error);
+  assert(random_walk_aware.gyroBias().z() > tightly_anchored.gyroBias().z());
+}
+
 void test_smoother_handles_short_and_regular_imu_windows()
 {
   ImuGtsamSmoother smoother;
@@ -222,6 +300,144 @@ void test_smoother_handles_short_and_regular_imu_windows()
   assert(smoother.poseMatrix().allFinite());
 }
 
+void test_dead_reckoning_position_uses_velocity_before_acceleration_update()
+{
+  ImuGtsamSmoother smoother;
+  smoother.params_.imu_params.gravity.setZero();
+  const Eigen::Vector3d initial_position(1.0, -2.0, 0.5);
+  const Eigen::Vector3d initial_velocity(2.0, -1.0, 0.25);
+  const Eigen::Vector3d acceleration(0.5, 1.0, -0.25);
+  const double dt = 0.2;
+  smoother.initialize(
+    initial_position.x(), initial_position.y(), initial_position.z(),
+    0.0, 0.0, 0.0,
+    initial_velocity.x(), initial_velocity.y(), initial_velocity.z(), 0.0);
+
+  smoother.integrateImu(Eigen::Vector3d::Zero(), acceleration, dt);
+
+  const Eigen::Vector3d expected =
+    initial_position + initial_velocity * dt + 0.5 * acceleration * dt * dt;
+  const Eigen::Vector3d predicted =
+    smoother.predictedPoseMatrix().block<3, 1>(0, 3).cast<double>();
+  assert(vclose(predicted, expected, 1e-6));
+}
+
+void test_smoother_keeps_window_and_velocity_across_updates()
+{
+  ImuGtsamSmoother smoother;
+  smoother.params_.imu_params.gravity.setZero();
+  smoother.initialize(
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    1.0, 0.0, 0.0, 0.0);
+
+  for (int interval = 1; interval <= 2; ++interval) {
+    for (int tick = 0; tick < 20; ++tick) {
+      smoother.integrateImu(
+        Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero(), 0.005);
+    }
+    assert(smoother.update(
+      0.1 * interval, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.1, 0.1 * interval));
+  }
+
+  assert(smoother.poseCount() == 3);
+  assert(std::abs(smoother.velocity().x() - 1.0) < 1e-3);
+  assert(std::abs(smoother.velocity().y()) < 1e-6);
+  assert(std::abs(smoother.velocity().z()) < 1e-6);
+}
+
+void test_pose_only_gap_update_preserves_velocity_and_bias()
+{
+  ImuGtsamSmoother smoother;
+  smoother.params_.imu_params.gravity.setZero();
+  const Eigen::Vector3d velocity(1.5, -0.25, 0.1);
+  const Eigen::Vector3d gyro_bias(0.01, -0.02, 0.03);
+  const Eigen::Vector3d accel_bias(0.1, -0.2, 0.05);
+  smoother.initializeState(
+    Eigen::Vector3d::Zero(), Eigen::Matrix3d::Identity(), velocity,
+    gyro_bias, accel_bias, 0.0);
+
+  // An uncovered scan gap contributes no IMU factor, but its accepted LiDAR
+  // pose must not force a zero-velocity/zero-bias reinitialization.
+  smoother.resetPendingIntegration();
+  assert(smoother.updatePoseOnly(
+    1.5, -0.25, 0.1,
+    0.0, 0.0, 0.0, 0.1, 1.0));
+
+  assert(smoother.poseCount() == 2);
+  assert(vclose(smoother.velocity(), velocity, 1e-9));
+  assert(vclose(smoother.gyroBias(), gyro_bias, 1e-9));
+  assert(vclose(smoother.accelBias(), accel_bias, 1e-9));
+}
+
+void test_smoother_estimates_nonzero_initial_velocity_from_pose_updates()
+{
+  ImuGtsamSmoother smoother;
+  smoother.params_.imu_params.gravity.setZero();
+  smoother.initialize(
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0);
+
+  for (int interval = 1; interval <= 3; ++interval) {
+    for (int tick = 0; tick < 20; ++tick) {
+      smoother.integrateImu(
+        Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero(), 0.005);
+    }
+    assert(smoother.update(
+      0.1 * interval, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.1, 0.1 * interval));
+  }
+
+  assert(smoother.poseCount() == 4);
+  assert(std::abs(smoother.velocity().x() - 1.0) < 1e-2);
+  assert(std::abs(smoother.velocity().y()) < 1e-6);
+  assert(std::abs(smoother.velocity().z()) < 1e-6);
+}
+
+void test_smoother_state_transfer_preserves_velocity_and_bias_for_repropagation()
+{
+  ImuGtsamSmoother predictor;
+  predictor.params_.imu_params.gravity.setZero();
+  const Eigen::Vector3d position(1.0, 2.0, 3.0);
+  const Eigen::Vector3d velocity(2.0, -1.0, 0.5);
+  const Eigen::Vector3d gyro_bias(0.0, 0.0, 0.1);
+  const Eigen::Vector3d accel_bias(0.2, 0.0, 0.0);
+  predictor.initializeState(
+    position, Eigen::Matrix3d::Identity(), velocity,
+    gyro_bias, accel_bias, 10.0);
+
+  predictor.integrateImu(gyro_bias, accel_bias, 0.1);
+
+  const Eigen::Vector3d predicted_position =
+    predictor.predictedPoseMatrix().block<3, 1>(0, 3).cast<double>();
+  assert(vclose(predicted_position, position + velocity * 0.1, 1e-6));
+  assert(rot_diff(
+    predictor.predictedPoseMatrix().block<3, 3>(0, 0).cast<double>(),
+    Eigen::Matrix3d::Identity()) < 1e-6);
+  assert(vclose(predictor.gyroBias(), gyro_bias, 1e-12));
+  assert(vclose(predictor.accelBias(), accel_bias, 1e-12));
+}
+
+void test_reset_pending_integration_prevents_duplicate_repropagation()
+{
+  ImuGtsamSmoother predictor;
+  predictor.params_.imu_params.gravity.setZero();
+  predictor.initialize(
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    1.0, 0.0, 0.0, 0.0);
+
+  predictor.integrateImu(
+    Eigen::Vector3d::Zero(), Eigen::Vector3d(1.0, 0.0, 0.0), 0.1);
+  predictor.resetPendingIntegration();
+  predictor.integrateImu(
+    Eigen::Vector3d::Zero(), Eigen::Vector3d(1.0, 0.0, 0.0), 0.1);
+
+  const Eigen::Vector3d predicted_position =
+    predictor.predictedPoseMatrix().block<3, 1>(0, 3).cast<double>();
+  assert(vclose(predicted_position, Eigen::Vector3d(0.105, 0.0, 0.0), 1e-6));
+}
+
+
 }  // namespace
 
 int main()
@@ -233,6 +449,15 @@ int main()
   test_residual_zero_for_consistent_trajectory();
   test_bias_jacobian_matches_finite_difference();
   test_covariance_symmetric_and_grows();
+  test_one_step_covariance_matches_continuous_noise_density_units();
+  test_bias_random_walk_increases_prior_variance_analytically();
+  test_bias_random_walk_changes_bias_estimate_in_smoother();
   test_smoother_handles_short_and_regular_imu_windows();
+  test_dead_reckoning_position_uses_velocity_before_acceleration_update();
+  test_smoother_keeps_window_and_velocity_across_updates();
+  test_pose_only_gap_update_preserves_velocity_and_bias();
+  test_smoother_estimates_nonzero_initial_velocity_from_pose_updates();
+  test_smoother_state_transfer_preserves_velocity_and_bias_for_repropagation();
+  test_reset_pending_integration_prevents_duplicate_repropagation();
   return 0;
 }

--- a/test/test_imu_preintegration_diagnostics_policy.cpp
+++ b/test/test_imu_preintegration_diagnostics_policy.cpp
@@ -181,6 +181,13 @@ void test_prediction_active_and_helpers()
   input.last_dt_sec = 0.005;
   input.last_sample_age_sec = ll::imuLastSampleAgeSec(10.0, 9.9);
   input.integration_window_sec = ll::imuIntegrationWindowSec(9.9, 9.8);
+  input.seed_consistency_gate_enabled = true;
+  input.seed_consistency_seed_allowed = true;
+  input.seed_consistency_valid_comparison_count = 8;
+  input.seed_consistency_consecutive_pass_count = 5;
+  input.seed_consistency_translation_error_m = 0.2;
+  input.seed_consistency_rotation_error_deg = 1.0;
+  input.seed_consistency_sample_passed = true;
 
   const auto diagnostics = ll::makeImuPreintegrationDiagnostics(input);
 
@@ -193,6 +200,13 @@ void test_prediction_active_and_helpers()
   assert(diagnostics.last_dt_sec == 0.005);
   assert(std::abs(diagnostics.last_sample_age_sec - 0.1) < 1e-9);
   assert(std::abs(diagnostics.integration_window_sec - 0.1) < 1e-9);
+  assert(diagnostics.seed_consistency_gate_enabled);
+  assert(diagnostics.seed_consistency_seed_allowed);
+  assert(diagnostics.seed_consistency_valid_comparison_count == 8);
+  assert(diagnostics.seed_consistency_consecutive_pass_count == 5);
+  assert(diagnostics.seed_consistency_translation_error_m == 0.2);
+  assert(diagnostics.seed_consistency_rotation_error_deg == 1.0);
+  assert(diagnostics.seed_consistency_sample_passed);
   assert(ll::imuIntegrationWindowSec(9.9, 10.0) == 0.0);
   assert(std::isnan(ll::imuLastSampleAgeSec(10.0, 0.0)));
   assert(ll::imuStaleSampleAgeThresholdSec(0.05) == 0.2);
@@ -200,7 +214,8 @@ void test_prediction_active_and_helpers()
   assert(ll::imuMaximumIntegrationWindowSec(0.05) == 1.0);
   assert(ll::imuMaximumIntegrationWindowSec(0.2) == 1.0);
   assert(std::abs(ll::imuMaximumIntegrationWindowSec(0.3) - 1.5) < 1e-9);
-  assert(ll::isImuIntegrationWindowTooLarge(1.01, 1.0));
+  assert(!ll::isImuIntegrationWindowTooLarge(1.009, 1.0));
+  assert(ll::isImuIntegrationWindowTooLarge(1.011, 1.0));
   assert(!ll::isImuIntegrationWindowTooLarge(1.0, 1.0));
   assert(ll::isValidImuPreintegrationDt(0.001));
   assert(!ll::isValidImuPreintegrationDt(0.0));

--- a/test/test_imu_queue_policy.cpp
+++ b/test/test_imu_queue_policy.cpp
@@ -1,0 +1,121 @@
+#include "lidar_localization/imu_queue_policy.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <vector>
+
+namespace ll = lidar_localization;
+
+ll::TimestampedImuSample sample(double stamp, double accel_x)
+{
+  return {stamp, Eigen::Vector3d::Zero(), Eigen::Vector3d(accel_x, 0.0, 0.0)};
+}
+
+void test_plan_stops_exactly_at_scan_time_without_future_sample()
+{
+  const std::vector<ll::TimestampedImuSample> samples{
+    sample(0.0, 1.0), sample(0.05, 2.0), sample(0.10, 1000.0)};
+
+  const auto plan = ll::planCausalImuIntervals(0.0, 0.075, samples, 0.06);
+
+  assert(plan.input_order_valid);
+  assert(plan.complete_coverage);
+  assert(plan.intervals.size() == 2);
+  assert(std::abs(plan.intervals[0].dt() - 0.05) < 1e-12);
+  assert(plan.intervals[0].accel.x() == 1.0);
+  assert(std::abs(plan.intervals[1].dt() - 0.025) < 1e-12);
+  assert(plan.intervals[1].accel.x() == 2.0);
+  assert(std::abs(plan.covered_duration_sec - 0.075) < 1e-12);
+}
+
+void test_sample_exactly_on_boundary_updates_only_the_next_interval()
+{
+  const std::vector<ll::TimestampedImuSample> samples{
+    sample(1.0, 1.0), sample(1.1, 2.0), sample(1.2, 3.0)};
+
+  const auto first = ll::planCausalImuIntervals(1.0, 1.1, samples, 0.11);
+  assert(first.complete_coverage);
+  assert(first.intervals.size() == 1);
+  assert(first.intervals[0].accel.x() == 1.0);
+
+  const auto second = ll::planCausalImuIntervals(1.1, 1.2, samples, 0.11);
+  assert(second.complete_coverage);
+  assert(second.intervals.size() == 1);
+  assert(second.intervals[0].accel.x() == 2.0);
+}
+
+void test_missing_anchor_and_large_gap_fail_closed()
+{
+  const auto no_anchor = ll::planCausalImuIntervals(
+    0.0, 0.1, {sample(0.05, 1.0), sample(0.1, 1.0)}, 0.06);
+  assert(!no_anchor.complete_coverage);
+  assert(std::abs(no_anchor.covered_duration_sec - 0.05) < 1e-12);
+
+  const auto gap = ll::planCausalImuIntervals(
+    0.0, 0.2, {sample(0.0, 1.0), sample(0.2, 2.0)}, 0.05);
+  assert(!gap.complete_coverage);
+  assert(gap.skipped_gap_count == 1);
+  assert(gap.intervals.empty());
+}
+
+void test_non_monotonic_or_non_finite_input_is_rejected()
+{
+  const auto duplicate = ll::planCausalImuIntervals(
+    0.0, 0.1, {sample(0.0, 1.0), sample(0.0, 2.0)}, 0.1);
+  assert(!duplicate.input_order_valid);
+  assert(!duplicate.complete_coverage);
+
+  auto invalid = sample(0.1, 1.0);
+  invalid.gyro.x() = std::numeric_limits<double>::quiet_NaN();
+  const auto non_finite = ll::planCausalImuIntervals(
+    0.0, 0.1, {sample(0.0, 1.0), invalid}, 0.1);
+  assert(!non_finite.input_order_valid);
+}
+
+void test_dual_queue_keeps_prediction_tail_for_repropagation()
+{
+  ll::DualImuQueue queue;
+  assert(queue.push(sample(0.0, 1.0)));
+  assert(queue.push(sample(0.05, 2.0)));
+  assert(queue.push(sample(0.10, 3.0)));
+  assert(!queue.push(sample(0.10, 4.0)));
+
+  const auto optimization = queue.consumeOptimizationThrough(0.06);
+  assert(optimization.size() == 2);
+  assert(queue.optimizationSize() == 1);
+  assert(queue.predictionSize() == 3);
+  assert(queue.optimizationSamplesThrough(0.06).size() == 0);
+
+  const auto reprop = queue.preparePredictionRepropagation(0.06);
+  assert(reprop.anchor_sample.has_value());
+  assert(reprop.anchor_sample->stamp_sec == 0.05);
+  assert(reprop.samples_after_correction.size() == 1);
+  assert(reprop.samples_after_correction.front().stamp_sec == 0.10);
+  assert(queue.predictionSize() == 1);
+  assert(queue.predictionSamples().size() == 1);
+
+  std::vector<ll::TimestampedImuSample> causal_samples{*reprop.anchor_sample};
+  causal_samples.insert(
+    causal_samples.end(), reprop.samples_after_correction.begin(),
+    reprop.samples_after_correction.end());
+  const auto plan = ll::planCausalImuIntervals(0.06, 0.10, causal_samples, 0.06);
+  assert(plan.complete_coverage);
+  assert(plan.intervals.size() == 1);
+  assert(plan.intervals[0].accel.x() == 2.0);
+
+  assert(queue.push(sample(0.15, 4.0)));
+  assert(queue.push(sample(0.20, 5.0)));
+  assert(queue.trimTo(1) == 2);
+  assert(queue.optimizationSize() == 1);
+  assert(queue.predictionSize() == 1);
+}
+
+int main()
+{
+  test_plan_stops_exactly_at_scan_time_without_future_sample();
+  test_sample_exactly_on_boundary_updates_only_the_next_interval();
+  test_missing_anchor_and_large_gap_fail_closed();
+  test_non_monotonic_or_non_finite_input_is_rejected();
+  test_dual_queue_keeps_prediction_tail_for_repropagation();
+  return 0;
+}

--- a/test/test_imu_seed_consistency_policy.cpp
+++ b/test/test_imu_seed_consistency_policy.cpp
@@ -1,0 +1,128 @@
+#include "lidar_localization/imu_seed_consistency_policy.hpp"
+
+#include <cassert>
+#include <limits>
+
+namespace ll = lidar_localization;
+
+void test_seed_is_allowed_only_after_required_consecutive_passes()
+{
+  const ll::ImuSeedConsistencyParams params{0.5, 5.0, 3};
+  ll::ImuSeedConsistencyState state;
+
+  for (std::size_t pass = 1; pass <= 3; ++pass) {
+    const auto update = ll::updateImuSeedConsistency(
+      state, params, {true, true, 0.2, 2.0});
+    assert(update.comparison_valid);
+    assert(update.sample_passed);
+    assert(update.state.valid_comparison_count == pass);
+    assert(update.state.consecutive_pass_count == pass);
+    assert(update.state.seed_allowed == (pass == 3));
+    state = update.state;
+  }
+}
+
+void test_failed_comparison_revokes_seed_and_resets_streak()
+{
+  const ll::ImuSeedConsistencyParams params{0.5, 5.0, 2};
+  ll::ImuSeedConsistencyState state{2, 2, true};
+
+  const auto update = ll::updateImuSeedConsistency(
+    state, params, {true, true, 0.6, 2.0});
+
+  assert(update.comparison_valid);
+  assert(!update.sample_passed);
+  assert(update.state.valid_comparison_count == 3);
+  assert(update.state.consecutive_pass_count == 0);
+  assert(!update.state.seed_allowed);
+}
+
+void test_rotation_must_also_pass()
+{
+  const ll::ImuSeedConsistencyParams params{0.5, 5.0, 1};
+  const auto update = ll::updateImuSeedConsistency(
+    {}, params, {true, true, 0.1, 5.1});
+
+  assert(update.comparison_valid);
+  assert(!update.sample_passed);
+  assert(!update.state.seed_allowed);
+}
+
+void test_missing_or_non_finite_evidence_breaks_consecutive_chain()
+{
+  const ll::ImuSeedConsistencyParams params{0.5, 5.0, 2};
+  const ll::ImuSeedConsistencyState one_pass{1, 1, false};
+
+  const auto missing = ll::updateImuSeedConsistency(
+    one_pass, params, {true, false, 0.0, 0.0});
+  assert(!missing.comparison_valid);
+  assert(missing.state.valid_comparison_count == 1);
+  assert(missing.state.consecutive_pass_count == 0);
+  assert(!missing.state.seed_allowed);
+
+  const auto non_finite = ll::updateImuSeedConsistency(
+    one_pass, params,
+    {true, true, std::numeric_limits<double>::quiet_NaN(), 0.0});
+  assert(!non_finite.comparison_valid);
+  assert(non_finite.state.consecutive_pass_count == 0);
+}
+
+void test_established_gate_survives_temporarily_missing_prediction()
+{
+  const ll::ImuSeedConsistencyParams params{0.5, 5.0, 2};
+  const ll::ImuSeedConsistencyState established{8, 2, true};
+
+  const auto missing = ll::updateImuSeedConsistency(
+    established, params, {true, false, 0.0, 0.0});
+
+  assert(!missing.comparison_valid);
+  assert(missing.state.valid_comparison_count == 8);
+  assert(missing.state.consecutive_pass_count == 2);
+  assert(missing.state.seed_allowed);
+
+  const auto resumed = ll::updateImuSeedConsistency(
+    missing.state, params, {true, true, 0.2, 2.0});
+  assert(resumed.comparison_valid);
+  assert(resumed.sample_passed);
+  assert(resumed.state.valid_comparison_count == 9);
+  assert(resumed.state.consecutive_pass_count == 3);
+  assert(resumed.state.seed_allowed);
+}
+
+void test_established_gate_fails_closed_on_non_finite_prediction()
+{
+  const ll::ImuSeedConsistencyParams params{0.5, 5.0, 2};
+  const ll::ImuSeedConsistencyState established{8, 2, true};
+
+  const auto non_finite = ll::updateImuSeedConsistency(
+    established, params,
+    {true, true, std::numeric_limits<double>::quiet_NaN(), 0.0});
+
+  assert(!non_finite.comparison_valid);
+  assert(non_finite.state.consecutive_pass_count == 0);
+  assert(!non_finite.state.seed_allowed);
+}
+
+void test_invalid_parameters_fail_closed()
+{
+  ll::ImuSeedConsistencyParams params;
+  params.required_consecutive_passes = 0;
+  const auto update = ll::updateImuSeedConsistency(
+    {5, 5, true}, params, {true, true, 0.0, 0.0});
+
+  assert(!update.comparison_valid);
+  assert(!update.state.seed_allowed);
+  assert(update.state.consecutive_pass_count == 0);
+}
+
+int main()
+{
+  test_seed_is_allowed_only_after_required_consecutive_passes();
+  test_failed_comparison_revokes_seed_and_resets_streak();
+  test_rotation_must_also_pass();
+  test_missing_or_non_finite_evidence_breaks_consecutive_chain();
+  test_established_gate_survives_temporarily_missing_prediction();
+  test_established_gate_fails_closed_on_non_finite_prediction();
+  test_invalid_parameters_fail_closed();
+  return 0;
+}

--- a/test/test_koide_hard_imu_deskew_smoke_script.py
+++ b/test/test_koide_hard_imu_deskew_smoke_script.py
@@ -53,6 +53,7 @@ class TestKoideHardImuDeskewSmokeScript(unittest.TestCase):
             self.assertIn("use_imu_preintegration: true", config)
             self.assertIn("use_continuous_time_deskew: true", config)
             self.assertIn("initial_pose_x: -86.03759", config)
+            self.assertIn("imu_accel_scale: 9.80665", config)
 
     def test_windowed_print_only_uses_gt_pose_at_start_offset(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/test/test_run_lidar_localization_imu_comparison.py
+++ b/test/test_run_lidar_localization_imu_comparison.py
@@ -100,6 +100,47 @@ class TestRunLidarLocalizationImuComparison(unittest.TestCase):
         self.assertIn("benchmark_eval_trajectory", command)
         self.assertIn("--reference-csv /ref.csv", command)
 
+    def test_dual_queue_mode_and_acceleration_scale_are_written_to_config(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            code = comparison_tool.main([
+                "--bag-path", "/bags/site",
+                "--map-path", "/maps/site.pcd",
+                "--output-dir", tmp_dir,
+                "--mode", "imu_preintegration",
+                "--mode", "imu_dual_queue",
+                "--imu-accel-scale", "9.80665",
+                "--print-only",
+            ])
+
+            self.assertEqual(code, 0)
+            plan = json.loads((Path(tmp_dir) / "run_plan.json").read_text())
+            current_config = Path(plan["runs"][0]["config_path"]).read_text()
+            candidate_config = Path(plan["runs"][1]["config_path"]).read_text()
+            self.assertIn("imu_dual_queue_enabled: false", current_config)
+            self.assertIn("imu_dual_queue_enabled: true", candidate_config)
+            self.assertIn("imu_accel_scale: 9.80665", current_config)
+            self.assertIn("imu_accel_scale: 9.80665", candidate_config)
+
+    def test_dual_queue_deskew_mode_combines_candidate_and_runtime_gate(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            code = comparison_tool.main([
+                "--bag-path", "/bags/site",
+                "--map-path", "/maps/site.pcd",
+                "--output-dir", tmp_dir,
+                "--mode", "imu_dual_queue_deskew",
+                "--print-only",
+            ])
+
+            self.assertEqual(code, 0)
+            plan = json.loads((Path(tmp_dir) / "run_plan.json").read_text())
+            self.assertEqual(plan["runs"][0]["mode"], "imu_dual_queue_deskew")
+            config = Path(plan["runs"][0]["config_path"]).read_text()
+            self.assertIn("imu_dual_queue_enabled: true", config)
+            self.assertIn("use_continuous_time_deskew: true", config)
+            validation = plan["runs"][0]["imu_validation_command"]
+            self.assertIn("--require-imu-seed-source", validation)
+            self.assertIn("--require-deskew-applied", validation)
+
     def test_input_check_reports_missing_files_before_running(self):
         args = comparison_tool.build_arg_parser().parse_args([
             "--bag-path",


### PR DESCRIPTION
## Summary

- correct dead-reckoning ordering, IMU noise discretization, bias random-walk handling, and scan-time boundaries
- add initial velocity estimation, LIO-SAM-style optimization/prediction queues, correction repropagation, consistency gating, and gap-safe pose-only anchoring
- promote the dual queue after repeated Koide multi-window and multi-sequence A/B validation
- keep continuous-time deskew default-off after a repeatable cross-sequence accuracy regression
- add analytical, finite-difference, sequential-update, gap, boundary, runner, and diagnostic tests

## Root cause

The previous path reset velocity, bias, and pending state at accepted LiDAR corrections, used continuous noise densities with incorrect discrete units, and treated tiny scan-boundary jitter as a real integration gap. These issues made the IMU overconfident and created seed/rejection feedback loops.

## Validation

- ROS 2 Jazzy package build passed
- CTest: 76/76 passed
- Koide dual-queue candidate: 9/9 runs passed across three fixtures with worst coverage >= 96.7% and reject streak 0
- deskew remained default-off because outdoor_hard_02a translation RMSE regressed from 0.095 m to 0.146 m median
