### PR TITLE
Organize parameter and script catalogs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,103 +128,123 @@ install(TARGETS
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
-install(PROGRAMS
-  scripts/benchmark_analyze_drift_window
-  scripts/benchmark_compare_runs
+# Keep the installed CLI surface grouped by purpose. The flat scripts directory
+# and command names remain stable for ros2 run and downstream documentation.
+set(LIDAR_LOCALIZATION_CONFIG_SCRIPTS
   scripts/check_lidar_localization_bringup.py
   scripts/check_mid360_legged_bringup.py
-  scripts/compare_nav2_reinit_supervisor_runs.py
-  scripts/convert_boreas_sequence_to_rosbag2.py
   scripts/create_lidar_localization_config.py
+  scripts/run_nav2_demo_smoke
+  scripts/run_nav2_replay_smoke
+  scripts/send_nav2_goal.py)
+
+set(LIDAR_LOCALIZATION_BENCHMARK_SCRIPTS
+  scripts/benchmark_analyze_drift_window
+  scripts/benchmark_bbs_backends.py
+  scripts/benchmark_compare_runs
+  scripts/benchmark_diagnostic_recorder
+  scripts/benchmark_eval_evo_ape
+  scripts/benchmark_eval_trajectory
   scripts/benchmark_extract_pose_reference_from_rosbag2
   scripts/benchmark_from_manifest
   scripts/benchmark_make_graph_dataset
   scripts/benchmark_pose_recorder
-  scripts/benchmark_diagnostic_recorder
+  scripts/benchmark_runner
+  scripts/benchmark_sweep_localizer
   scripts/build_public_demo_report.py
   scripts/build_public_validation_dashboard.py
   scripts/build_relocalization_demo_report.py
-  scripts/benchmark_runner
-  scripts/benchmark_sweep_localizer
-  scripts/benchmark_eval_trajectory
-  scripts/benchmark_eval_evo_ape
+  scripts/compare_nav2_reinit_supervisor_runs.py
+  scripts/compare_registration_relocalization_score_summaries.py
+  scripts/make_localization_comparison_report.py)
+
+set(LIDAR_LOCALIZATION_DATA_SCRIPTS
   scripts/augment_pointcloud_intensity.py
-  scripts/analyze_koide_imu_consistency.py
-  scripts/make_disabled_relocalization_attempts.py
-  scripts/observe_relocalization_reset_execution.py
-  scripts/make_route_grid_relocalization_attempts.py
-  scripts/make_map_grid_relocalization_attempts.py
-  scripts/make_bbs_relocalization_attempts.py
-  scripts/generate_bbs_golden_fixtures.py
-  scripts/benchmark_bbs_backends.py
-  scripts/global_localization_query.py
-  scripts/g2_candidate_registration_rank_policy.py
-  scripts/check_koide_recovery_health.py
-  scripts/check_recovery_pose_gt.py
-  scripts/inject_koide_kidnap_initialpose.py
-  scripts/run_koide_g3_recovery_replay.sh
-  scripts/prepare_hdl_recovery_assets.sh
-  scripts/run_hdl_g3_recovery_replay.sh
-  scripts/global_localization_node.py
-  scripts/reinitialization_supervisor_policy.py
-  scripts/reinitialization_supervisor_node.py
-  scripts/make_registration_relocalization_jobs.py
-  scripts/scaffold_mapless_public_dataset_bundle.py
-  scripts/fetch_official_autoware_istanbul_dataset.sh
-  scripts/fetch_koide_hard_pointcloud_localization_dataset.sh
-  scripts/fetch_official_hdl_localization_sample.sh
   scripts/build_gt_aligned_map_from_reference_csv.py
-  scripts/tum_trajectory_to_pose_reference_csv.py
-  scripts/tum_trajectory_to_pose_reference_csv_for_rosbag2.py
+  scripts/convert_boreas_sequence_to_rosbag2.py
+  scripts/fetch_koide_hard_pointcloud_localization_dataset.sh
+  scripts/fetch_official_autoware_istanbul_dataset.sh
+  scripts/fetch_official_hdl_localization_sample.sh
   scripts/generate_occupancy_map_from_pcd.py
-  scripts/make_localization_comparison_report.py
+  scripts/prepare_hdl_recovery_assets.sh
+  scripts/prepare_koide_hard_relocalization_assets.sh
+  scripts/scaffold_mapless_public_dataset_bundle.py
+  scripts/tum_trajectory_to_pose_reference_csv.py
+  scripts/tum_trajectory_to_pose_reference_csv_for_rosbag2.py)
+
+set(LIDAR_LOCALIZATION_ROS_ADAPTER_SCRIPTS
   scripts/publish_cmd_vel_odom.py
   scripts/publish_identity_odom.py
   scripts/publish_odom_from_localization.py
   scripts/publish_odom_from_twist.py
   scripts/publish_pose_from_odom.py
-  scripts/publish_relocalization_reset_commands.py
-  scripts/prepare_koide_hard_relocalization_assets.sh
-  scripts/republish_initialpose_on_reinit.py
   scripts/relay_localization_inputs_with_current_stamp.py
-  scripts/record_hdl_localization_outputs.py
+  scripts/record_hdl_localization_outputs.py)
+
+set(LIDAR_LOCALIZATION_RECOVERY_SCRIPTS
+  scripts/check_koide_recovery_health.py
+  scripts/check_recovery_pose_gt.py
+  scripts/g2_candidate_registration_rank_policy.py
+  scripts/global_localization_node.py
+  scripts/global_localization_query.py
+  scripts/inject_koide_kidnap_initialpose.py
+  scripts/make_bbs_relocalization_attempts.py
+  scripts/make_disabled_relocalization_attempts.py
+  scripts/make_map_grid_relocalization_attempts.py
+  scripts/make_registration_relocalization_jobs.py
+  scripts/make_relocalization_reset_commands.py
+  scripts/make_route_grid_relocalization_attempts.py
+  scripts/observe_relocalization_reset_execution.py
+  scripts/publish_relocalization_reset_commands.py
+  scripts/reinitialization_supervisor_node.py
+  scripts/reinitialization_supervisor_policy.py
+  scripts/republish_initialpose_on_reinit.py
+  scripts/resolve_registration_relocalization_scans.py
+  scripts/score_relocalization_candidates_with_reference.py
+  scripts/select_relocalization_reset_candidates.py
+  scripts/validate_relocalization_reset_candidate_plan.py
+  scripts/validate_relocalization_reset_commands.py)
+
+set(LIDAR_LOCALIZATION_EXPERIMENT_SCRIPTS
+  scripts/analyze_koide_imu_consistency.py
+  scripts/generate_bbs_golden_fixtures.py
+  scripts/run_autoware_istanbul_60s_predictor_compare.sh
   scripts/run_borderline_gate_experiments.py
   scripts/run_experiment_suite.py
+  scripts/run_hdl_g3_recovery_replay.sh
+  scripts/run_hdl_localization_docker_benchmark.sh
   scripts/run_imu_guard_experiments.py
-  scripts/run_koide_hard_imu_deskew_smoke.sh
   scripts/run_koide_corner_deskew_ab.sh
+  scripts/run_koide_g3_recovery_replay.sh
+  scripts/run_koide_hard_imu_deskew_smoke.sh
   scripts/run_lidar_localization_imu_comparison.py
-  scripts/summarize_koide_deskew_ab.py
-  scripts/summarize_registration_localizability.py
   scripts/run_measurement_acceptance_experiments.py
-  scripts/run_nav2_reinit_supervisor_sweep.sh
   scripts/run_nav2_reinit_supervisor_regression.sh
+  scripts/run_nav2_reinit_supervisor_sweep.sh
   scripts/run_recovery_action_experiments.py
+  scripts/run_registration_ordering_comparison.py
   scripts/run_reinit_trigger_experiments.py
   scripts/run_startup_integrity_experiments.py
   scripts/run_public_demo.sh
-  scripts/run_public_validation_dashboard.sh
-  scripts/run_v1_1_relocalization_smoke.sh
-  scripts/validate_v1_1_claim_language.py
   scripts/run_public_regression_suite.sh
+  scripts/run_public_validation_dashboard.sh
   scripts/run_release_regression_suite.sh
-  scripts/run_nav2_demo_smoke
-  scripts/run_nav2_replay_smoke
-  scripts/send_nav2_goal.py
+  scripts/run_v1_1_relocalization_smoke.sh
+  scripts/summarize_koide_deskew_ab.py
   scripts/summarize_localization_health.py
-  scripts/summarize_relocalization_attempts.py
+  scripts/summarize_registration_localizability.py
   scripts/summarize_registration_relocalization_scores.py
-  scripts/compare_registration_relocalization_score_summaries.py
-  scripts/run_registration_ordering_comparison.py
-  scripts/make_relocalization_reset_commands.py
-  scripts/select_relocalization_reset_candidates.py
-  scripts/validate_relocalization_reset_commands.py
-  scripts/validate_relocalization_reset_candidate_plan.py
+  scripts/summarize_relocalization_attempts.py
   scripts/validate_lidar_localization_imu.py
-  scripts/score_relocalization_candidates_with_reference.py
-  scripts/resolve_registration_relocalization_scans.py
-  scripts/run_autoware_istanbul_60s_predictor_compare.sh
-  scripts/run_hdl_localization_docker_benchmark.sh
+  scripts/validate_v1_1_claim_language.py)
+
+install(PROGRAMS
+  ${LIDAR_LOCALIZATION_CONFIG_SCRIPTS}
+  ${LIDAR_LOCALIZATION_BENCHMARK_SCRIPTS}
+  ${LIDAR_LOCALIZATION_DATA_SCRIPTS}
+  ${LIDAR_LOCALIZATION_ROS_ADAPTER_SCRIPTS}
+  ${LIDAR_LOCALIZATION_RECOVERY_SCRIPTS}
+  ${LIDAR_LOCALIZATION_EXPERIMENT_SCRIPTS}
   DESTINATION lib/${PROJECT_NAME})
 
 install(DIRECTORY

--- a/param/README.md
+++ b/param/README.md
@@ -1,0 +1,68 @@
+# Parameter files
+
+This directory contains runtime presets and reproducible benchmark inputs. Files
+stay at their existing paths for launch-file and downstream compatibility.
+
+## Start here
+
+| File | Use |
+| --- | --- |
+| `localization.yaml` | Generic `lidar_localization.launch.py` starting point |
+| `nav2_ndt_urban.yaml` | Recommended conservative Nav2 localizer preset |
+| `nav2_humble_pointcloud.yaml` | Companion Nav2 stack configuration |
+| `mid360_legged.yaml` | Jetson + Livox MID-360 legged-robot preset |
+| `nav2_replay_safe.yaml` | Single-thread NDT replay/debug fallback |
+
+The localizer and Nav2 configurations are separate. A normal Nav2 launch uses
+both `nav2_ndt_urban.yaml` and `nav2_humble_pointcloud.yaml`.
+
+## Dataset and validation presets
+
+| File | Scope |
+| --- | --- |
+| `boreas_ndt_velodyne.yaml` | Boreas Velodyne 128 |
+| `hdl_imu_preint.yaml` | Official hdl_localization sample with IMU preintegration |
+| `istanbul_gtsam_smoother.yaml` | Autoware Istanbul GTSAM smoother experiment |
+| `koide_indoor_ndt.yaml` | Koide indoor NDT_OMP baseline |
+| `koide_indoor_smallgicp.yaml` | Koide indoor optional SMALL_GICP comparison |
+| `public_istanbul_60s_benchmark.yaml` | Autoware Istanbul public 60 s validation template |
+
+Dataset presets are not universal defaults. Replace placeholder map paths and
+verify frames, topics, initial pose, sensor units, and timing before use.
+
+## Experimental Nav2 derivatives
+
+These files preserve named experiment inputs and are not recommended defaults:
+
+- `nav2_ndt_urban_borderline_only.yaml`
+- `nav2_ndt_urban_recovery_retry_from_last_pose.yaml`
+- `nav2_ndt_urban_recovery_retry_from_last_pose_r3.yaml`
+- `nav2_ndt_urban_recovery_retry_from_last_pose_r3_gap1_seed15.yaml`
+- `nav2_ndt_urban_rejected_seed_update.yaml`
+- `nav2_ndt_urban_rejected_seed_update_r1.yaml`
+
+New one-off comparisons belong under [`benchmark/`](benchmark/) instead of the
+top level. Promote a winner only after repeat validation.
+
+## Editing conventions
+
+Keep existing filenames and parameter names backward compatible. For localizer
+presets, group parameters in this order when practical:
+
+1. registration backend and convergence;
+2. scan filtering and timing;
+3. map and initial pose;
+4. odometry, twist, and IMU prediction;
+5. acceptance and recovery guards;
+6. frames, TF, publishing, and visualization.
+
+Every top-level preset starts with `Preset` and `Status` comments. Explicit
+values should describe an intentional override; inherited node defaults need
+not be copied into every file. Avoid YAML anchors and merge keys because ROS 2
+parameter parser behavior differs across distributions.
+
+## Benchmark inputs
+
+[`benchmark/`](benchmark/) contains immutable comparison inputs, run manifests,
+and result-comparison specifications. See its README before adding a file.
+

--- a/param/benchmark/README.md
+++ b/param/benchmark/README.md
@@ -1,0 +1,41 @@
+# Benchmark parameter inputs
+
+This directory holds reproducible experiment inputs, not recommended runtime
+presets. Keep an input after a run when it is needed to reproduce a documented
+comparison or release boundary.
+
+## File kinds
+
+| Form | Purpose |
+| --- | --- |
+| `*.yaml` with `/**` → `ros__parameters` | Frozen localizer configuration |
+| `*_manifest*.yaml` or `*.example.yaml` | Dataset/run orchestration input |
+| `*_compare.json` | Baseline/candidate comparison specification |
+| `*_sweep.json` | Parameter sweep specification |
+
+The scripts consuming each schema are the source of truth. Most run manifests
+are handled by `benchmark_from_manifest`; comparison specifications are handled
+by `benchmark_compare_runs` or a named experiment script.
+
+## Naming
+
+Use lowercase snake case and encode only information needed to identify the
+fixture:
+
+```text
+<dataset>_<sequence-or-window>_<backend-or-feature>_<purpose>.<yaml|json>
+```
+
+Prefer descriptive feature names over unexplained revision numbers. If a
+revision suffix is required for historical reproduction, explain it in the
+related experiment README or validation log.
+
+## Lifecycle
+
+- Put general runtime presets in the parent directory only after validation.
+- Do not place generated maps, bags, logs, trajectories, or dashboards here.
+- Use `/tmp` or `artifacts/` for generated run outputs.
+- Preserve published comparison inputs; add a successor instead of silently
+  changing the meaning of a historical fixture.
+- Keep private dataset paths out of committed files. Use `*.example.yaml` for
+  templates that require local paths.

--- a/param/boreas_ndt_velodyne.yaml
+++ b/param/boreas_ndt_velodyne.yaml
@@ -1,4 +1,5 @@
-# Boreas Velodyne 128 localizer preset.
+# Preset: Boreas Velodyne 128 localizer.
+# Status: dataset-specific validated preset; not a general default.
 # Tuned for map-split GT-aligned maps and high-rate dense scans.
 # Keep twist prediction enabled; improve throughput and post-reject recovery.
 

--- a/param/hdl_imu_preint.yaml
+++ b/param/hdl_imu_preint.yaml
@@ -1,3 +1,6 @@
+# Preset: official hdl_localization sample with IMU preintegration.
+# Status: public-validation preset; replace map_path before use.
+
 /**:
   ros__parameters:
     registration_method: NDT_OMP

--- a/param/istanbul_gtsam_smoother.yaml
+++ b/param/istanbul_gtsam_smoother.yaml
@@ -1,3 +1,6 @@
+# Preset: Autoware Istanbul with the experimental GTSAM twist smoother.
+# Status: dataset-specific experiment; not a recommended runtime default.
+
 /**:
   ros__parameters:
     registration_method: NDT_OMP

--- a/param/koide_indoor_ndt.yaml
+++ b/param/koide_indoor_ndt.yaml
@@ -1,3 +1,6 @@
+# Preset: Koide indoor sequence using NDT_OMP.
+# Status: dataset-specific baseline with IMU preintegration disabled.
+
 /**:
   ros__parameters:
     registration_method: NDT_OMP

--- a/param/koide_indoor_smallgicp.yaml
+++ b/param/koide_indoor_smallgicp.yaml
@@ -1,3 +1,6 @@
+# Preset: Koide indoor sequence using the optional SMALL_GICP backend.
+# Status: dataset-specific backend comparison; requires small_gicp support.
+
 /**:
   ros__parameters:
     # SMALL_GICP with NDT initializer for indoor depth camera data.

--- a/param/localization.yaml
+++ b/param/localization.yaml
@@ -1,3 +1,6 @@
+# Preset: generic lidar_localization launch default.
+# Status: general starting point; override map path, initial pose, and sensor topics.
+
 /**:
     ros__parameters:
       registration_method: "NDT_OMP"

--- a/param/mid360_legged.yaml
+++ b/param/mid360_legged.yaml
@@ -1,4 +1,5 @@
-# Jetson + Livox MID-360 preset for quadruped/biped robots.
+# Preset: Jetson + Livox MID-360 for quadruped/biped robots.
+# Status: hardware-specific runtime preset.
 # Runtime launch should override map_path and measured sensor extrinsics.
 /**:
   ros__parameters:

--- a/param/nav2_humble_pointcloud.yaml
+++ b/param/nav2_humble_pointcloud.yaml
@@ -1,3 +1,6 @@
+# Preset: Nav2 companion configuration using PointCloud2 obstacles.
+# Status: Humble/Jazzy-compatible navigation preset; not a localizer parameter file.
+
 bt_navigator:
   ros__parameters:
     use_sim_time: false

--- a/param/nav2_ndt_urban.yaml
+++ b/param/nav2_ndt_urban.yaml
@@ -1,3 +1,6 @@
+# Preset: conservative urban NDT_OMP localizer for Nav2.
+# Status: recommended Nav2 localizer starting point.
+
 /**:
   ros__parameters:
     registration_method: NDT_OMP

--- a/param/nav2_ndt_urban_borderline_only.yaml
+++ b/param/nav2_ndt_urban_borderline_only.yaml
@@ -1,3 +1,6 @@
+# Preset: Nav2 urban borderline-seed gate isolation.
+# Status: experiment-only derivative of nav2_ndt_urban.yaml.
+
 /**:
   ros__parameters:
     registration_method: NDT_OMP

--- a/param/nav2_ndt_urban_recovery_retry_from_last_pose.yaml
+++ b/param/nav2_ndt_urban_recovery_retry_from_last_pose.yaml
@@ -1,3 +1,6 @@
+# Preset: Nav2 urban aggressive last-pose recovery retry.
+# Status: experiment-only derivative; retained for benchmark reproduction.
+
 /**:
   ros__parameters:
     registration_method: NDT_OMP

--- a/param/nav2_ndt_urban_recovery_retry_from_last_pose_r3.yaml
+++ b/param/nav2_ndt_urban_recovery_retry_from_last_pose_r3.yaml
@@ -1,3 +1,6 @@
+# Preset: Nav2 urban last-pose retry after three rejections.
+# Status: experiment-only derivative; did not hold up on 120 s repeats.
+
 /**:
   ros__parameters:
     registration_method: NDT_OMP

--- a/param/nav2_ndt_urban_recovery_retry_from_last_pose_r3_gap1_seed15.yaml
+++ b/param/nav2_ndt_urban_recovery_retry_from_last_pose_r3_gap1_seed15.yaml
@@ -1,3 +1,6 @@
+# Preset: Nav2 urban bounded last-pose recovery retry.
+# Status: experiment-only derivative used by public benchmark comparisons.
+
 /**:
   ros__parameters:
     registration_method: NDT_OMP

--- a/param/nav2_ndt_urban_rejected_seed_update.yaml
+++ b/param/nav2_ndt_urban_rejected_seed_update.yaml
@@ -1,3 +1,6 @@
+# Preset: Nav2 urban immediate rejected-seed update.
+# Status: experiment-only derivative retained for comparison.
+
 /**:
   ros__parameters:
     registration_method: NDT_OMP

--- a/param/nav2_ndt_urban_rejected_seed_update_r1.yaml
+++ b/param/nav2_ndt_urban_rejected_seed_update_r1.yaml
@@ -1,3 +1,6 @@
+# Preset: Nav2 urban rejected-seed update after one rejection.
+# Status: experiment-only derivative retained for comparison.
+
 /**:
   ros__parameters:
     registration_method: NDT_OMP

--- a/param/nav2_replay_safe.yaml
+++ b/param/nav2_replay_safe.yaml
@@ -1,3 +1,6 @@
+# Preset: conservative single-thread NDT replay baseline for Nav2.
+# Status: replay/debug fallback; prefer nav2_ndt_urban.yaml for normal use.
+
 /**:
   ros__parameters:
     registration_method: NDT

--- a/param/public_istanbul_60s_benchmark.yaml
+++ b/param/public_istanbul_60s_benchmark.yaml
@@ -1,3 +1,6 @@
+# Preset: Autoware Istanbul 60 s public benchmark template.
+# Status: reproducible validation input; not a general runtime default.
+
 /**:
   ros__parameters:
     registration_method: NDT_OMP

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,78 @@
+# Script catalog
+
+The script directory is intentionally flat. Existing filenames are public CLI
+and documentation contracts, and installed scripts must remain discoverable by
+`ros2 run lidar_localization_ros2 <name>`. Use the categories below instead of
+moving files into subdirectories.
+
+## Common workflows
+
+| Task | Entry point |
+| --- | --- |
+| Generate a site preset | `create_lidar_localization_config.py` |
+| Check generic bringup | `check_lidar_localization_bringup.py` |
+| Check MID-360 bringup | `check_mid360_legged_bringup.py` |
+| Run public demo | `run_public_demo.sh` |
+| Run public regression | `run_public_regression_suite.sh` |
+| Run release regression | `run_release_regression_suite.sh` |
+| Run manifest benchmark | `benchmark_from_manifest` |
+| Compare benchmark runs | `benchmark_compare_runs` |
+
+## Categories
+
+- `benchmark_*`: benchmark execution, recording, conversion, scoring, and
+  comparison primitives.
+- `fetch_*`, `convert_*`, `generate_*`, `build_*`, `prepare_*`, `scaffold_*`:
+  dataset, map, manifest, and report preparation.
+- `run_*`: end-to-end demos, experiments, replays, smoke tests, and regression
+  suites. Dataset-specific runners should state their data prerequisites in
+  `--help` output or their companion documentation.
+- `analyze_*`, `diagnose_*`, `summarize_*`, `compare_*`, `validate_*`,
+  `check_*`: offline analysis and acceptance checks.
+- `publish_*`, `relay_*`, `republish_*`, `record_*`, `send_*`, `inject_*`:
+  small ROS graph adapters used by launches and experiments.
+- `make_*`, `select_*`, `score_*`, `resolve_*`, `observe_*`: global
+  localization and relocalization planning stages.
+- `global_localization_*`, `reinitialization_supervisor_*`: runtime G2/G3
+  localization and recovery components.
+- `render_*`: GIF and gallery rendering.
+- `setup_local_env.sh`, `bootstrap_colcon_workspace.sh`: local developer
+  environment setup; source or run these from the repository checkout.
+
+## Installed versus development-only
+
+The grouped lists in `CMakeLists.txt` are the installation source of truth.
+Installed entries are callable from the package prefix. Scripts omitted from
+those lists are repository-development tools and may rely on checkout-relative
+paths.
+
+Current development-only helpers are:
+
+- environment: `setup_local_env.sh`, `bootstrap_colcon_workspace.sh`;
+- Koide acquisition/rendering: `fetch_all_koide_sequences.sh`,
+  `render_koide_dataset_gallery.sh`, `render_koide_localization_gif.py`,
+  `prepare_koide_localization_gif_benchmarks.py`;
+- focused research/reporting: `analyze_pose_covariance_calibration.py`,
+  `diagnose_local_map_crop_coverage.py`, `demo_pose_arbitration.py`,
+  `render_global_localization_demo_gif.py`,
+  `summarize_koide_phase1_backend_comparison.py`;
+- legacy/direct regression wrappers: `run_hdl_g3_recovery_regression.sh`,
+  `run_koide_g3_recovery_regression.sh`,
+  `run_koide_phase1_backend_comparison.sh`,
+  `run_koide_phase1_regression.sh`;
+- lower-level benchmark utilities: `benchmark_convert_traj_refined`,
+  `benchmark_drift_correlation_report`.
+
+`scripts/lidar_localization_mid360/` is the small shared Python package used by
+MID-360 configuration and validation commands. Pure policy modules may be
+installed beside executable scripts because runtime nodes import them from the
+same directory.
+
+## Adding a script
+
+1. Choose an existing action prefix and a narrow, descriptive name.
+2. Add a shebang and executable bit for a command; omit command-line behavior
+   for a pure import module.
+3. Add user-facing commands to the appropriate grouped CMake list.
+4. Add a focused test for argument, output, or cleanup contracts.
+5. Keep generated outputs outside the repository by default.

--- a/test/test_package_install_contract.py
+++ b/test/test_package_install_contract.py
@@ -25,8 +25,20 @@ ROS_RUN_SCRIPTS = {
 BOOTSTRAP_SCRIPT = "scripts/bootstrap_colcon_workspace.sh"
 
 
+def cmake_script_groups(text: str) -> dict[str, list[str]]:
+    groups = {}
+    pattern = re.compile(
+        r"set\((?P<name>LIDAR_LOCALIZATION_[A-Z_]+_SCRIPTS)\s+(?P<body>.*?)\)",
+        re.DOTALL,
+    )
+    for match in pattern.finditer(text):
+        groups[match.group("name")] = re.findall(r"scripts/[^\s)]+", match.group("body"))
+    return groups
+
+
 def cmake_install_programs() -> set[str]:
     text = (REPO_ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+    groups = cmake_script_groups(text)
     match = re.search(
         r"install\(PROGRAMS(?P<body>.*?)DESTINATION\s+lib/\$\{PROJECT_NAME\}\)",
         text,
@@ -34,11 +46,12 @@ def cmake_install_programs() -> set[str]:
     )
     if match is None:
         raise AssertionError("install(PROGRAMS ... DESTINATION lib/${PROJECT_NAME}) not found")
-    programs = set()
-    for line in match.group("body").splitlines():
-        stripped = line.strip()
-        if stripped and not stripped.startswith("#"):
-            programs.add(stripped)
+    body = match.group("body")
+    programs = set(re.findall(r"scripts/[^\s)]+", body))
+    for variable in re.findall(r"\$\{([A-Z_]+)\}", body):
+        if variable not in groups:
+            raise AssertionError(f"unknown install(PROGRAMS) variable: {variable}")
+        programs.update(groups[variable])
     return programs
 
 
@@ -58,6 +71,18 @@ class TestPackageInstallContract(unittest.TestCase):
 
                 self.assertTrue(path.exists())
                 self.assertTrue(os.access(path, os.X_OK), f"{relative_path} is not executable")
+
+    def test_grouped_install_scripts_exist_and_are_unique(self):
+        cmake_text = (REPO_ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+        groups = cmake_script_groups(cmake_text)
+        grouped_scripts = [script for values in groups.values() for script in values]
+
+        self.assertTrue(groups, "no grouped script lists found")
+        self.assertEqual(len(grouped_scripts), len(set(grouped_scripts)))
+        self.assertEqual(cmake_install_programs(), set(grouped_scripts))
+        for relative_path in sorted(grouped_scripts):
+            with self.subTest(relative_path=relative_path):
+                self.assertTrue((REPO_ROOT / relative_path).is_file())
 
     def test_lidar_localization_mid360_helper_package_is_installed_as_directory(self):
         cmake_text = (REPO_ROOT / "CMakeLists.txt").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

- add catalogs and editing conventions for runtime and benchmark parameters
- label every top-level parameter preset with its role and stability
- document the complete script taxonomy and development-only helpers
- group the 96 installed commands by purpose without changing the CLI surface
- extend the package install contract test for grouped CMake script lists

## Why

The flat parameter and script directories had grown difficult to navigate. This
keeps every existing path and command compatible while making recommended,
dataset-specific, experimental, installed, and development-only entries clear.

## Validation

- parsed 100 YAML and 35 JSON files with duplicate-key checks
- confirmed all top-level parameter values are unchanged
- verified all 96 installed script paths and Python/shell syntax
- built `lidar_localization_ros2` successfully
- passed 76/76 CTest tests
