### PR TITLE
Add experimental GLIM prior-map localization extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,24 @@ install(DIRECTORY
 if(BUILD_TESTING)
   find_package(Threads REQUIRED)
   link_libraries(Eigen3::Eigen)
+  add_executable(test_glim_prior_map_factor_policy
+    test/test_glim_prior_map_factor_policy.cpp)
+  target_include_directories(test_glim_prior_map_factor_policy PRIVATE
+    experiments/glim_prior_map_localizer/include)
+  add_test(
+    NAME glim_prior_map_factor_policy
+    COMMAND test_glim_prior_map_factor_policy
+  )
+
+  add_executable(test_glim_prior_map_ply_loader
+    test/test_glim_prior_map_ply_loader.cpp)
+  target_include_directories(test_glim_prior_map_ply_loader PRIVATE
+    experiments/glim_prior_map_localizer/include)
+  add_test(
+    NAME glim_prior_map_ply_loader
+    COMMAND test_glim_prior_map_ply_loader
+  )
+
   add_executable(test_registration_seed_policy
     test/test_registration_seed_policy.cpp)
   target_include_directories(test_registration_seed_policy PRIVATE

--- a/experiments/glim_prior_map_localizer/CMakeLists.txt
+++ b/experiments/glim_prior_map_localizer/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.16)
+project(glim_prior_map_localizer LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(glim REQUIRED)
+find_package(GTSAM REQUIRED)
+find_package(TBB REQUIRED)
+find_package(robin REQUIRED)
+find_package(kiss_matcher REQUIRED)
+find_package(spdlog REQUIRED)
+
+add_library(glim_prior_map_localizer SHARED
+  src/prior_map_localizer.cpp
+  src/vgicp_refiner.cpp)
+target_include_directories(glim_prior_map_localizer PRIVATE
+  include
+  ${GTSAM_INCLUDE_DIRS})
+target_link_libraries(glim_prior_map_localizer PRIVATE
+  glim::glim
+  kiss_matcher::kiss_matcher_core
+  robin::robin
+  spdlog::spdlog
+  ${GTSAM_LIBRARIES})
+
+add_executable(glim_prior_map_offline_match
+  src/offline_match.cpp
+  src/vgicp_refiner.cpp)
+target_include_directories(glim_prior_map_offline_match PRIVATE
+  include)
+target_link_libraries(glim_prior_map_offline_match PRIVATE
+  glim::glim
+  kiss_matcher::kiss_matcher_core
+  robin::robin)
+
+install(TARGETS glim_prior_map_localizer glim_prior_map_offline_match
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/experiments/glim_prior_map_localizer/Dockerfile
+++ b/experiments/glim_prior_map_localizer/Dockerfile
@@ -1,0 +1,23 @@
+FROM lidarloc/glim-ros2:jazzy-v1.2.2-coreset
+
+ARG KISS_MATCHER_REVISION=669fe866b1c612daa3702292571c25dc1bc61c86
+
+RUN git clone https://github.com/MIT-SPARK/KISS-Matcher.git /tmp/KISS-Matcher \
+    && cd /tmp/KISS-Matcher \
+    && git checkout "${KISS_MATCHER_REVISION}" \
+    && make cppinstall PARALLEL=2 \
+      CMAKE_EXTRA_ARGS=-DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    && rm -rf /tmp/KISS-Matcher
+
+COPY . /tmp/glim_prior_map_localizer
+RUN . /opt/ros/jazzy/setup.sh \
+    && . /root/ros2_ws/install/setup.sh \
+    && cmake -S /tmp/glim_prior_map_localizer \
+      -B /tmp/glim_prior_map_localizer/build \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && cmake --build /tmp/glim_prior_map_localizer/build -j2 \
+    && cmake --install /tmp/glim_prior_map_localizer/build \
+    && rm -rf /tmp/glim_prior_map_localizer
+
+ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}

--- a/experiments/glim_prior_map_localizer/README.md
+++ b/experiments/glim_prior_map_localizer/README.md
@@ -1,0 +1,125 @@
+# GLIM prior-map localizer experiment
+
+This experiment makes prior-map localization part of GLIM's global factor
+graph. It is intended to replace continuously running NDT, not GLIM odometry.
+
+## Design
+
+The extension keeps GLIM as the continuous LiDAR/IMU odometry front end. At a
+sparse submap interval it crops the prior PLY map around GLIM's prediction and
+uses that prediction to initialize GLIM's own CPU VGICP implementation. Normal
+tracking does not run KISS-Matcher. KISS is used only to acquire an unknown
+frame or as a fallback after direct VGICP loses lock. Accepted registrations
+are inserted as fixed-map `IntegratedVGICPFactor`s, matching GLIM's native
+global-mapping formulation rather than converting a coarse match into an
+arbitrarily strong pose prior.
+
+When an approximate startup pose is supplied, the extension transforms GLIM's
+X(0) initial value into the map frame before its first iSAM2 update. GLIM's own
+gauge-fixing damping factor then anchors the correct frame from the beginning;
+later map factors are bounded refinements, not an ill-conditioned 80+ metre
+late graph shift.
+
+The policy has two modes:
+
+- Tracking: accept a well-supported pose only when its full 3D correction from
+  GLIM's prediction is bounded.
+- Recovery: a large correction is not accepted until registrations from two
+  independent GLIM submaps produce consistent map-from-GLIM-world anchors.
+  In a seeded tracking crop this supports reattachment after local lock loss;
+  unseeded recovery still requires explicit full-map mode.
+
+Full-map KISS alone is not yet accepted as a production kidnap-recovery path;
+the measured unseeded replay found a repeatable structural ambiguity, so this
+remains an experimental opt-in.
+
+No ground truth is used at runtime. Ground truth or a previously saved GLIM
+pose may be used only by the offline evaluator. Tracking uses a local prior-map
+crop and runs at submap rate, not scan rate. Full-map KISS search is
+experimental and disabled by default; an unseeded saved-submap search took
+29.55 seconds and repeated a structurally ambiguous match.
+
+The extension uses GLIM's documented global-mapping callbacks rather than
+patching GLIM itself. Relevant primary sources:
+
+- [GLIM paper](https://arxiv.org/abs/2407.10344)
+- [GLIM extension API](https://github.com/koide3/glim/blob/master/docs/extend.md)
+- [KISS-Matcher paper](https://arxiv.org/abs/2409.15615)
+- [KISS-Matcher implementation](https://github.com/MIT-SPARK/KISS-Matcher)
+
+## Build and offline check
+
+    docker build -t lidarloc/glim-ros2:jazzy-v1.2.2-prior-map \
+      experiments/glim_prior_map_localizer
+
+    docker run --rm \
+      -v /path/to/glim_dump:/dump:ro \
+      -v /path/to/map.ply:/map.ply:ro \
+      lidarloc/glim-ros2:jazzy-v1.2.2-prior-map \
+      /usr/local/bin/glim_prior_map_offline_match /dump/000050 /map.ply 0.5
+
+The offline output is one JSON object containing KISS validity/inliers, VGICP
+overlap/error, runtime, the refined matrix, and its difference from the pose
+stored in the GLIM dump. Add `direct` after the crop radius to initialize VGICP
+from the stored GLIM pose instead of the KISS pose. The stored-pose error is an
+evaluation diagnostic, not a runtime gate.
+
+## Runtime configuration
+
+Add libglim_prior_map_localizer.so to extension_modules in GLIM's
+config_ros.json, mount the prior map, and set GLIM_PRIOR_MAP_PATH.
+
+Important environment variables and defaults:
+
+| Variable | Default | Meaning |
+| --- | ---: | --- |
+| GLIM_PRIOR_MAP_PATH | required | ASCII or little-endian binary PLY prior map |
+| GLIM_PRIOR_MAP_VOXEL_SIZE_M | 0.75 | KISS-Matcher resolution |
+| GLIM_PRIOR_MAP_MIN_INLIERS | 10 | minimum KISS inliers when coarse fallback is used |
+| GLIM_PRIOR_MAP_BOOTSTRAP_CROP_RADIUS_M | 60.0 | pre-alignment search radius |
+| GLIM_PRIOR_MAP_BOOTSTRAP_CENTER_X/Y/Z | unset | approximate initial map position |
+| GLIM_PRIOR_MAP_BOOTSTRAP_YAW_DEG | unset | approximate initial map yaw |
+| GLIM_PRIOR_MAP_MAX_BOOTSTRAP_TRANSLATION_M | 10.0 | seeded-candidate correction bound |
+| GLIM_PRIOR_MAP_TRACKING_CROP_RADIUS_M | 35.0 | local tracking-map radius |
+| GLIM_PRIOR_MAP_BOOTSTRAP_SUBMAP_STRIDE | 2 | pre-alignment match interval |
+| GLIM_PRIOR_MAP_TRACKING_SUBMAP_STRIDE | 10 | post-alignment match interval |
+| GLIM_PRIOR_MAP_FULL_GLOBAL_SEARCH | false | experimental full-map mode |
+| GLIM_PRIOR_MAP_MAX_LOCAL_TRANSLATION_M | 1.5 | single-submap tracking correction bound |
+| GLIM_PRIOR_MAP_MAX_LOCAL_YAW_DEG | 10.0 | full 3D rotation bound (legacy name) |
+| GLIM_PRIOR_MAP_ALLOW_GLOBAL_RELOCALIZATION | true | enable two-submap recovery |
+| GLIM_PRIOR_MAP_MAX_GLOBAL_DISAGREEMENT_M | 2.0 | recovery-anchor agreement |
+| GLIM_PRIOR_MAP_MAX_GLOBAL_DISAGREEMENT_YAW_DEG | 10.0 | 3D rotation agreement |
+| GLIM_PRIOR_MAP_VGICP_VOXEL_RESOLUTION_M | 1.0 | prior-map VGICP voxel size |
+| GLIM_PRIOR_MAP_VGICP_MAX_ITERATIONS | 10 | refinement iterations |
+| GLIM_PRIOR_MAP_VGICP_MIN_INLIER_FRACTION | 0.50 | minimum overlap (same as GLIM pose-graph default) |
+| GLIM_PRIOR_MAP_VGICP_MAX_NORMALIZED_ERROR | 5.0 | maximum VGICP error per inlier |
+| GLIM_PRIOR_MAP_VGICP_MAX_COARSE_DELTA_M | 2.0 | maximum KISS-to-VGICP translation change |
+| GLIM_PRIOR_MAP_VGICP_MAX_COARSE_DELTA_DEG | 5.0 | maximum KISS-to-VGICP rotation change |
+
+## Measured status
+
+On `outdoor_hard_01a` (380 s), the direct-VGICP plus two-submap consensus
+replay achieved 99.21% coverage, 2.196 m translation ATE, 4.434 m end error,
+0.313 m median 10 m translation RPE, 46.9 ms processing p95, and no TF jumps.
+It improves the earlier coarse-KISS pose-prior prototype (3.379 m ATE, 7.668 m
+end error) and demonstrated a real consensus reattachment at submaps 30/40,
+followed by normal tracking through submap 80.
+
+It is not yet a production win: the GLIM coreset baseline remains better at
+1.696 m ATE and 0.182 m RPE. The remaining issue is that global-map factors
+alter the corrected trajectory even though GLIM's local odometry is already
+more accurate. The next design gate is therefore a separately smoothed
+`map -> odom` correction output that never deforms GLIM odometry. Do not use
+this experiment to replace the validated localizer yet.
+
+## Acceptance gates
+
+Before enabling this in measured replays:
+
+1. Compile and unit-test the factor acceptance policy.
+2. Measure registration success, error, and wall time on saved submaps from all
+   four Koide sequences, including false-match and kidnapped-pose cases.
+3. Run a 60-second GLIM-only replay and verify factor insertion and TF
+   continuity.
+4. Run all full sequences, compare ATE/recovery with the current hybrid, and
+   measure whole-process CPU. Do not remove NDT until these gates pass.

--- a/experiments/glim_prior_map_localizer/include/glim_prior_map_localizer/ply_loader.hpp
+++ b/experiments/glim_prior_map_localizer/include/glim_prior_map_localizer/ply_loader.hpp
@@ -1,0 +1,194 @@
+#pragma once
+
+#include <cstddef>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+
+namespace glim_prior_map_localizer
+{
+namespace detail
+{
+
+struct PlyProperty
+{
+  std::string type;
+  std::string name;
+  std::size_t offset{0};
+  std::size_t size{0};
+};
+
+inline std::size_t plyScalarSize(const std::string & type)
+{
+  if (type == "char" || type == "uchar" || type == "int8" || type == "uint8") {
+    return 1;
+  }
+  if (type == "short" || type == "ushort" || type == "int16" || type == "uint16") {
+    return 2;
+  }
+  if (type == "int" || type == "uint" || type == "int32" || type == "uint32" ||
+    type == "float" || type == "float32")
+  {
+    return 4;
+  }
+  if (type == "double" || type == "float64") {
+    return 8;
+  }
+  throw std::runtime_error("unsupported PLY scalar type: " + type);
+}
+
+template<typename T>
+inline double copiedScalar(const char * data)
+{
+  T value;
+  std::memcpy(&value, data, sizeof(value));
+  return static_cast<double>(value);
+}
+
+inline double binaryPlyScalar(const char * data, const std::string & type)
+{
+  if (type == "char" || type == "int8") {
+    return copiedScalar<signed char>(data);
+  }
+  if (type == "uchar" || type == "uint8") {
+    return copiedScalar<unsigned char>(data);
+  }
+  if (type == "short" || type == "int16") {
+    return copiedScalar<short>(data);
+  }
+  if (type == "ushort" || type == "uint16") {
+    return copiedScalar<unsigned short>(data);
+  }
+  if (type == "int" || type == "int32") {
+    return copiedScalar<int>(data);
+  }
+  if (type == "uint" || type == "uint32") {
+    return copiedScalar<unsigned int>(data);
+  }
+  if (type == "float" || type == "float32") {
+    return copiedScalar<float>(data);
+  }
+  if (type == "double" || type == "float64") {
+    return copiedScalar<double>(data);
+  }
+  throw std::runtime_error("unsupported PLY scalar type: " + type);
+}
+
+}  // namespace detail
+
+inline std::vector<Eigen::Vector3f> loadPlyXyz(const std::string & path)
+{
+  std::ifstream stream(path, std::ios::binary);
+  if (!stream) {
+    throw std::runtime_error("failed to open prior-map PLY: " + path);
+  }
+
+  std::string line;
+  std::getline(stream, line);
+  if (line != "ply") {
+    throw std::runtime_error("not a PLY file: " + path);
+  }
+
+  bool ascii = false;
+  bool binary_little_endian = false;
+  bool reading_vertices = false;
+  std::size_t vertex_count = 0;
+  std::size_t stride = 0;
+  std::vector<detail::PlyProperty> properties;
+  while (std::getline(stream, line)) {
+    std::istringstream fields(line);
+    std::string keyword;
+    fields >> keyword;
+    if (keyword == "format") {
+      std::string format;
+      fields >> format;
+      ascii = format == "ascii";
+      binary_little_endian = format == "binary_little_endian";
+    } else if (keyword == "element") {
+      std::string element;
+      std::size_t count = 0;
+      fields >> element >> count;
+      reading_vertices = element == "vertex";
+      if (reading_vertices) {
+        vertex_count = count;
+      }
+    } else if (keyword == "property" && reading_vertices) {
+      detail::PlyProperty property;
+      fields >> property.type;
+      if (property.type == "list") {
+        throw std::runtime_error("list property in PLY vertex element is unsupported");
+      }
+      fields >> property.name;
+      property.offset = stride;
+      property.size = detail::plyScalarSize(property.type);
+      stride += property.size;
+      properties.push_back(property);
+    } else if (keyword == "end_header") {
+      break;
+    }
+  }
+  if ((!ascii && !binary_little_endian) || vertex_count == 0 || properties.empty()) {
+    throw std::runtime_error("unsupported or empty PLY header: " + path);
+  }
+
+  int xyz_indices[3] = {-1, -1, -1};
+  for (std::size_t index = 0; index < properties.size(); ++index) {
+    xyz_indices[0] = properties[index].name == "x" ? static_cast<int>(index) : xyz_indices[0];
+    xyz_indices[1] = properties[index].name == "y" ? static_cast<int>(index) : xyz_indices[1];
+    xyz_indices[2] = properties[index].name == "z" ? static_cast<int>(index) : xyz_indices[2];
+  }
+  if (xyz_indices[0] < 0 || xyz_indices[1] < 0 || xyz_indices[2] < 0) {
+    throw std::runtime_error("PLY vertex element must contain x, y, and z");
+  }
+
+  std::vector<Eigen::Vector3f> points;
+  points.reserve(vertex_count);
+  if (ascii) {
+    for (std::size_t row = 0; row < vertex_count && std::getline(stream, line); ++row) {
+      std::istringstream values(line);
+      std::vector<double> record(properties.size());
+      for (double & value : record) {
+        if (!(values >> value)) {
+          throw std::runtime_error("truncated ASCII PLY vertex data");
+        }
+      }
+      Eigen::Vector3f point(
+        static_cast<float>(record[xyz_indices[0]]),
+        static_cast<float>(record[xyz_indices[1]]),
+        static_cast<float>(record[xyz_indices[2]]));
+      if (point.allFinite()) {
+        points.push_back(point);
+      }
+    }
+  } else {
+    std::vector<char> record(stride);
+    for (std::size_t row = 0; row < vertex_count; ++row) {
+      stream.read(record.data(), static_cast<std::streamsize>(record.size()));
+      if (!stream) {
+        throw std::runtime_error("truncated binary PLY vertex data");
+      }
+      const auto value = [&](int index) {
+          const auto & property = properties[static_cast<std::size_t>(index)];
+          return detail::binaryPlyScalar(record.data() + property.offset, property.type);
+        };
+      Eigen::Vector3f point(
+        static_cast<float>(value(xyz_indices[0])),
+        static_cast<float>(value(xyz_indices[1])),
+        static_cast<float>(value(xyz_indices[2])));
+      if (point.allFinite()) {
+        points.push_back(point);
+      }
+    }
+  }
+  if (points.empty()) {
+    throw std::runtime_error("prior-map PLY has no finite XYZ points: " + path);
+  }
+  return points;
+}
+
+}  // namespace glim_prior_map_localizer

--- a/experiments/glim_prior_map_localizer/include/glim_prior_map_localizer/prior_map_factor_policy.hpp
+++ b/experiments/glim_prior_map_localizer/include/glim_prior_map_localizer/prior_map_factor_policy.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <string>
+
+namespace glim_prior_map_localizer
+{
+
+struct PriorMapFactorGateParams
+{
+  std::size_t min_final_inliers{20};
+  double max_local_correction_translation_m{5.0};
+  double max_local_correction_rotation_deg{10.0};
+  bool allow_global_relocalization{true};
+  double max_global_anchor_translation_disagreement_m{2.0};
+  double max_global_anchor_rotation_disagreement_deg{10.0};
+};
+
+struct PriorMapFactorGateInput
+{
+  bool solution_valid{false};
+  bool transform_finite{false};
+  std::size_t final_inliers{0};
+  double local_correction_translation_m{0.0};
+  double local_correction_rotation_deg{0.0};
+  bool previous_global_anchor_available{false};
+  double global_anchor_translation_disagreement_m{0.0};
+  double global_anchor_rotation_disagreement_deg{0.0};
+};
+
+struct PriorMapFactorGateDecision
+{
+  bool accepted{false};
+  bool accepted_as_global_relocalization{false};
+  std::string reason{"solution_invalid"};
+};
+
+inline PriorMapFactorGateDecision decidePriorMapFactor(
+  const PriorMapFactorGateParams & params,
+  const PriorMapFactorGateInput & input)
+{
+  if (!input.solution_valid) {
+    return {false, false, "solution_invalid"};
+  }
+  if (!input.transform_finite) {
+    return {false, false, "transform_non_finite"};
+  }
+  if (input.final_inliers < params.min_final_inliers) {
+    return {false, false, "insufficient_final_inliers"};
+  }
+
+  const bool local_consistent =
+    std::isfinite(input.local_correction_translation_m) &&
+    std::isfinite(input.local_correction_rotation_deg) &&
+    input.local_correction_translation_m <=
+    params.max_local_correction_translation_m &&
+    std::abs(input.local_correction_rotation_deg) <=
+    params.max_local_correction_rotation_deg;
+  if (local_consistent) {
+    return {true, false, "local_correction_consistent"};
+  }
+
+  if (!params.allow_global_relocalization) {
+    return {false, false, "local_correction_exceeded"};
+  }
+  if (!input.previous_global_anchor_available) {
+    return {false, false, "global_consensus_pending"};
+  }
+
+  const bool global_consistent =
+    std::isfinite(input.global_anchor_translation_disagreement_m) &&
+    std::isfinite(input.global_anchor_rotation_disagreement_deg) &&
+    input.global_anchor_translation_disagreement_m <=
+    params.max_global_anchor_translation_disagreement_m &&
+    std::abs(input.global_anchor_rotation_disagreement_deg) <=
+    params.max_global_anchor_rotation_disagreement_deg;
+  if (!global_consistent) {
+    return {false, false, "global_consensus_rejected"};
+  }
+  return {true, true, "global_consensus_accepted"};
+}
+
+}  // namespace glim_prior_map_localizer

--- a/experiments/glim_prior_map_localizer/include/glim_prior_map_localizer/vgicp_refiner.hpp
+++ b/experiments/glim_prior_map_localizer/include/glim_prior_map_localizer/vgicp_refiner.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace gtsam_points
+{
+class GaussianVoxelMapCPU;
+struct PointCloud;
+}
+
+namespace glim_prior_map_localizer
+{
+
+struct VgicpRefinementResult
+{
+  bool valid{false};
+  Eigen::Isometry3d pose{Eigen::Isometry3d::Identity()};
+  double inlier_fraction{0.0};
+  int num_inliers{0};
+  double normalized_error{0.0};
+  std::shared_ptr<const gtsam_points::GaussianVoxelMapCPU> target_voxels;
+};
+
+VgicpRefinementResult refineWithVgicp(
+  const std::vector<Eigen::Vector3f> & target_points,
+  const std::shared_ptr<const gtsam_points::PointCloud> & source,
+  const Eigen::Isometry3d & initial_pose,
+  double voxel_resolution_m,
+  int max_iterations);
+
+}  // namespace glim_prior_map_localizer

--- a/experiments/glim_prior_map_localizer/src/offline_match.cpp
+++ b/experiments/glim_prior_map_localizer/src/offline_match.cpp
@@ -1,0 +1,132 @@
+#include "glim_prior_map_localizer/ply_loader.hpp"
+#include "glim_prior_map_localizer/vgicp_refiner.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <glim/mapping/sub_map.hpp>
+#include <kiss_matcher/KISSMatcher.hpp>
+
+namespace
+{
+
+std::vector<Eigen::Vector3f> loadSubmapPoints(const glim::SubMap & submap)
+{
+  std::vector<Eigen::Vector3f> points;
+  points.reserve(submap.frame->size());
+  for (std::size_t index = 0; index < submap.frame->size(); ++index) {
+    const auto point = submap.frame->points[index].head<3>().cast<float>();
+    if (point.allFinite()) {
+      points.push_back(point);
+    }
+  }
+  return points;
+}
+
+double rotationDegrees(const Eigen::Matrix3d & rotation)
+{
+  constexpr double radians_to_degrees = 57.295779513082320876;
+  const double cosine = std::clamp((rotation.trace() - 1.0) * 0.5, -1.0, 1.0);
+  return std::acos(cosine) * radians_to_degrees;
+}
+
+std::vector<Eigen::Vector3f> cropMap(
+  const std::vector<Eigen::Vector3f> & map,
+  const Eigen::Vector3d & center,
+  double radius_m)
+{
+  if (radius_m <= 0.0) {
+    return map;
+  }
+  std::vector<Eigen::Vector3f> cropped;
+  const float squared_radius = static_cast<float>(radius_m * radius_m);
+  const Eigen::Vector3f center_f = center.cast<float>();
+  for (const auto & point : map) {
+    if ((point - center_f).squaredNorm() <= squared_radius) {
+      cropped.push_back(point);
+    }
+  }
+  return cropped;
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+try
+{
+  if (argc < 3 || argc > 6) {
+    std::cerr << "usage: " << argv[0]
+              << " SUBMAP_DIRECTORY PRIOR_MAP.ply [VOXEL_M] [CROP_RADIUS_M] [direct]\n";
+    return 2;
+  }
+  const float voxel_size = argc == 4 ? std::stof(argv[3]) : 0.5F;
+  const auto submap = glim::SubMap::load(argv[1]);
+  if (!submap || !submap->frame) {
+    throw std::runtime_error("failed to load GLIM submap: " + std::string(argv[1]));
+  }
+  const auto source = loadSubmapPoints(*submap);
+  const double crop_radius_m = argc >= 5 ? std::stod(argv[4]) : 0.0;
+  const bool direct_tracking = argc == 6 && std::string(argv[5]) == "direct";
+  const auto full_map = glim_prior_map_localizer::loadPlyXyz(argv[2]);
+  const auto target = cropMap(full_map, submap->T_world_origin.translation(), crop_radius_m);
+
+  kiss_matcher::KISSMatcherConfig config(voxel_size);
+  config.use_quatro_ = true;
+  config.use_ratio_test_ = true;
+  config.num_max_corr_ = 5000;
+  kiss_matcher::KISSMatcher matcher(config);
+
+  const auto start = std::chrono::steady_clock::now();
+  const auto solution = matcher.estimate(source, target);
+  const auto elapsed = std::chrono::duration<double>(
+    std::chrono::steady_clock::now() - start).count();
+
+  Eigen::Isometry3d estimate = Eigen::Isometry3d::Identity();
+  estimate.linear() = solution.rotation;
+  estimate.translation() = solution.translation;
+  const auto refinement = glim_prior_map_localizer::refineWithVgicp(
+    target, submap->frame,
+    direct_tracking ? submap->T_world_origin : estimate, 1.0, 10);
+  const Eigen::Isometry3d refined = refinement.valid ? refinement.pose : estimate;
+  const Eigen::Isometry3d error = refined * submap->T_world_origin.inverse();
+
+  std::cout << std::boolalpha << std::fixed << std::setprecision(6)
+            << "{\"valid\":" << solution.valid
+            << ",\"submap_id\":" << submap->id
+            << ",\"source_points\":" << source.size()
+            << ",\"target_points\":" << target.size()
+            << ",\"final_inliers\":" << matcher.getNumFinalInliers()
+            << ",\"refinement_valid\":" << refinement.valid
+            << ",\"refinement_inliers\":" << refinement.num_inliers
+            << ",\"refinement_inlier_fraction\":" << refinement.inlier_fraction
+            << ",\"refinement_normalized_error\":" << refinement.normalized_error
+            << ",\"elapsed_s\":" << elapsed
+            << ",\"recorded_pose_translation_error_m\":" << error.translation().norm()
+            << ",\"recorded_pose_rotation_error_deg\":" << rotationDegrees(error.linear())
+            << ",\"matrix\":[";
+  for (int row = 0; row < 4; ++row) {
+    for (int column = 0; column < 4; ++column) {
+      if (row != 0 || column != 0) {
+        std::cout << ',';
+      }
+      std::cout << refined.matrix()(row, column);
+    }
+  }
+  std::cout << "]}\n";
+  return solution.valid ? 0 : 1;
+}
+catch (const std::exception & error)
+{
+  std::cerr << error.what() << '\n';
+  return 2;
+}
+#include "glim_prior_map_localizer/ply_loader.hpp"

--- a/experiments/glim_prior_map_localizer/src/prior_map_localizer.cpp
+++ b/experiments/glim_prior_map_localizer/src/prior_map_localizer.cpp
@@ -1,0 +1,462 @@
+#include "glim_prior_map_localizer/prior_map_factor_policy.hpp"
+#include "glim_prior_map_localizer/ply_loader.hpp"
+#include "glim_prior_map_localizer/vgicp_refiner.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam_points/factors/integrated_vgicp_factor.hpp>
+#include <gtsam_points/optimizers/isam2_ext.hpp>
+#include <gtsam_points/types/gaussian_voxelmap_cpu.hpp>
+
+#include <glim/mapping/callbacks.hpp>
+#include <glim/mapping/sub_map.hpp>
+#include <glim/util/extension_module.hpp>
+#include <glim/util/logging.hpp>
+
+#include <kiss_matcher/KISSMatcher.hpp>
+#include <spdlog/spdlog.h>
+
+namespace glim_prior_map_localizer
+{
+namespace
+{
+
+double environmentDouble(const char * name, double fallback)
+{
+  const char * raw = std::getenv(name);
+  return raw == nullptr ? fallback : std::stod(raw);
+}
+
+std::size_t environmentSize(const char * name, std::size_t fallback)
+{
+  const char * raw = std::getenv(name);
+  return raw == nullptr ? fallback : static_cast<std::size_t>(std::stoul(raw));
+}
+
+bool environmentBool(const char * name, bool fallback)
+{
+  const char * raw = std::getenv(name);
+  if (raw == nullptr) {
+    return fallback;
+  }
+  const std::string value(raw);
+  if (value == "1" || value == "true" || value == "on") {
+    return true;
+  }
+  if (value == "0" || value == "false" || value == "off") {
+    return false;
+  }
+  throw std::invalid_argument(std::string(name) + " must be true or false");
+}
+
+double rotationDegrees(const Eigen::Isometry3d & transform)
+{
+  constexpr double radians_to_degrees = 57.295779513082320876;
+  const double cosine = std::clamp(
+    (transform.linear().trace() - 1.0) * 0.5, -1.0, 1.0);
+  return std::acos(cosine) * radians_to_degrees;
+}
+
+bool finiteTransform(const Eigen::Isometry3d & transform)
+{
+  return transform.matrix().allFinite() &&
+         std::abs(transform.linear().determinant() - 1.0) < 1.0e-2;
+}
+
+std::vector<Eigen::Vector3f> loadPriorMap(const std::string & path)
+{
+  return loadPlyXyz(path);
+}
+
+std::vector<Eigen::Vector3f> submapPoints(const glim::SubMap & submap)
+{
+  std::vector<Eigen::Vector3f> points;
+  points.reserve(submap.frame->size());
+  for (std::size_t index = 0; index < submap.frame->size(); ++index) {
+    const auto point = submap.frame->points[index].head<3>().cast<float>();
+    if (point.allFinite()) {
+      points.push_back(point);
+    }
+  }
+  return points;
+}
+
+std::vector<Eigen::Vector3f> cropMap(
+  const std::vector<Eigen::Vector3f> & map,
+  const Eigen::Vector3d & center,
+  double radius_m)
+{
+  std::vector<Eigen::Vector3f> cropped;
+  const float squared_radius = static_cast<float>(radius_m * radius_m);
+  const Eigen::Vector3f center_f = center.cast<float>();
+  for (const auto & point : map) {
+    if ((point - center_f).squaredNorm() <= squared_radius) {
+      cropped.push_back(point);
+    }
+  }
+  return cropped;
+}
+
+}  // namespace
+
+class PriorMapLocalizer : public glim::ExtensionModule
+{
+public:
+  PriorMapLocalizer()
+  : logger_(glim::create_module_logger("prior_map_localizer")),
+    prior_map_(loadPriorMap(requiredMapPath())),
+    matcher_(matcherConfig())
+  {
+    gate_params_.min_final_inliers = environmentSize("GLIM_PRIOR_MAP_MIN_INLIERS", 10);
+    gate_params_.max_local_correction_translation_m =
+      environmentDouble("GLIM_PRIOR_MAP_MAX_LOCAL_TRANSLATION_M", 1.5);
+    gate_params_.max_local_correction_rotation_deg =
+      environmentDouble("GLIM_PRIOR_MAP_MAX_LOCAL_YAW_DEG", 10.0);
+    gate_params_.allow_global_relocalization =
+      environmentBool("GLIM_PRIOR_MAP_ALLOW_GLOBAL_RELOCALIZATION", true);
+    gate_params_.max_global_anchor_translation_disagreement_m =
+      environmentDouble("GLIM_PRIOR_MAP_MAX_GLOBAL_DISAGREEMENT_M", 2.0);
+    gate_params_.max_global_anchor_rotation_disagreement_deg =
+      environmentDouble("GLIM_PRIOR_MAP_MAX_GLOBAL_DISAGREEMENT_YAW_DEG", 10.0);
+    vgicp_voxel_resolution_m_ =
+      environmentDouble("GLIM_PRIOR_MAP_VGICP_VOXEL_RESOLUTION_M", 1.0);
+    vgicp_max_iterations_ = static_cast<int>(
+      environmentSize("GLIM_PRIOR_MAP_VGICP_MAX_ITERATIONS", 10));
+    vgicp_min_inlier_fraction_ =
+      environmentDouble("GLIM_PRIOR_MAP_VGICP_MIN_INLIER_FRACTION", 0.50);
+    vgicp_max_normalized_error_ =
+      environmentDouble("GLIM_PRIOR_MAP_VGICP_MAX_NORMALIZED_ERROR", 5.0);
+    vgicp_max_coarse_delta_translation_m_ =
+      environmentDouble("GLIM_PRIOR_MAP_VGICP_MAX_COARSE_DELTA_M", 2.0);
+    vgicp_max_coarse_delta_rotation_deg_ =
+      environmentDouble("GLIM_PRIOR_MAP_VGICP_MAX_COARSE_DELTA_DEG", 5.0);
+    tracking_crop_radius_m_ =
+      environmentDouble("GLIM_PRIOR_MAP_TRACKING_CROP_RADIUS_M", 35.0);
+    bootstrap_crop_radius_m_ =
+      environmentDouble("GLIM_PRIOR_MAP_BOOTSTRAP_CROP_RADIUS_M", 60.0);
+    bootstrap_submap_stride_ = std::max<std::size_t>(
+      1, environmentSize("GLIM_PRIOR_MAP_BOOTSTRAP_SUBMAP_STRIDE", 2));
+    tracking_submap_stride_ = std::max<std::size_t>(
+      1, environmentSize("GLIM_PRIOR_MAP_TRACKING_SUBMAP_STRIDE", 10));
+    full_global_search_ =
+      environmentBool("GLIM_PRIOR_MAP_FULL_GLOBAL_SEARCH", false);
+    const char * bootstrap_x = std::getenv("GLIM_PRIOR_MAP_BOOTSTRAP_CENTER_X");
+    const char * bootstrap_y = std::getenv("GLIM_PRIOR_MAP_BOOTSTRAP_CENTER_Y");
+    const char * bootstrap_z = std::getenv("GLIM_PRIOR_MAP_BOOTSTRAP_CENTER_Z");
+    const char * bootstrap_yaw = std::getenv("GLIM_PRIOR_MAP_BOOTSTRAP_YAW_DEG");
+    const int bootstrap_values =
+      (bootstrap_x != nullptr) + (bootstrap_y != nullptr) + (bootstrap_z != nullptr) +
+      (bootstrap_yaw != nullptr);
+    if (bootstrap_values != 0 && bootstrap_values != 4) {
+      throw std::invalid_argument(
+              "GLIM_PRIOR_MAP_BOOTSTRAP_CENTER_X/Y/Z and BOOTSTRAP_YAW_DEG are all required");
+    }
+    if (bootstrap_values == 4) {
+      bootstrap_anchor_.translation() = Eigen::Vector3d(
+        std::stod(bootstrap_x), std::stod(bootstrap_y), std::stod(bootstrap_z));
+      constexpr double degrees_to_radians = 0.01745329251994329577;
+      bootstrap_anchor_.linear() = Eigen::AngleAxisd(
+        std::stod(bootstrap_yaw) * degrees_to_radians, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+      bootstrap_anchor_available_ = true;
+    }
+
+    using std::placeholders::_1;
+    using std::placeholders::_2;
+    using std::placeholders::_3;
+    glim::GlobalMappingCallbacks::on_insert_submap.add(
+      std::bind(&PriorMapLocalizer::onSubmap, this, _1));
+    glim::GlobalMappingCallbacks::on_smoother_update.add(
+      std::bind(&PriorMapLocalizer::onSmootherUpdate, this, _1, _2, _3));
+    logger_->info(
+      "loaded prior map with {} points; mode={} crop={:.1f}/{:.1f}m stride={}/{} seeded={}",
+      prior_map_.size(), full_global_search_ ? "full-global" : "tracking-crop",
+      bootstrap_crop_radius_m_, tracking_crop_radius_m_, bootstrap_submap_stride_,
+      tracking_submap_stride_,
+      bootstrap_anchor_available_);
+  }
+
+private:
+  struct PendingFactor
+  {
+    int submap_id;
+    Eigen::Isometry3d map_from_submap;
+    bool global_relocalization;
+    gtsam_points::GaussianVoxelMapCPU::ConstPtr target_voxels;
+    gtsam_points::PointCloud::ConstPtr source;
+  };
+
+  static std::string requiredMapPath()
+  {
+    const char * path = std::getenv("GLIM_PRIOR_MAP_PATH");
+    if (path == nullptr || std::string(path).empty()) {
+      throw std::runtime_error("GLIM_PRIOR_MAP_PATH is required");
+    }
+    return path;
+  }
+
+  static kiss_matcher::KISSMatcherConfig matcherConfig()
+  {
+    kiss_matcher::KISSMatcherConfig config(
+      static_cast<float>(environmentDouble("GLIM_PRIOR_MAP_VOXEL_SIZE_M", 0.75)));
+    config.use_quatro_ = environmentBool("GLIM_PRIOR_MAP_USE_QUATRO", true);
+    config.use_ratio_test_ = environmentBool("GLIM_PRIOR_MAP_USE_RATIO_TEST", true);
+    config.num_max_corr_ = static_cast<int>(
+      environmentSize("GLIM_PRIOR_MAP_MAX_CORRESPONDENCES", 5000));
+    return config;
+  }
+
+  void onSubmap(const glim::SubMap::ConstPtr & submap)
+  {
+    const std::size_t active_stride = map_frame_initialized_ ?
+      tracking_submap_stride_ : bootstrap_submap_stride_;
+    if (static_cast<std::size_t>(submap->id) % active_stride != 0) {
+      return;
+    }
+    const auto source = submapPoints(*submap);
+    if (source.empty()) {
+      logger_->warn("submap {} has no finite points", submap->id);
+      return;
+    }
+
+    const Eigen::Isometry3d predicted = submap->T_world_origin;
+    const Eigen::Isometry3d predicted_in_map =
+      (!graph_frame_seeded_ && bootstrap_anchor_available_) ?
+      bootstrap_anchor_ * predicted : predicted;
+    Eigen::Vector3d predicted_map_center = predicted_in_map.translation();
+    if (previous_global_anchor_available_) {
+      predicted_map_center = previous_global_anchor_ * predicted.translation();
+    }
+    const double crop_radius_m = map_frame_initialized_ ?
+      tracking_crop_radius_m_ : bootstrap_crop_radius_m_;
+    const auto cropped_map = full_global_search_ ?
+      std::vector<Eigen::Vector3f>{} :
+      cropMap(prior_map_, predicted_map_center, crop_radius_m);
+    const auto & target = full_global_search_ ? prior_map_ : cropped_map;
+    if (target.empty()) {
+      logger_->warn("submap {} has no prior-map points in its tracking crop", submap->id);
+      return;
+    }
+
+    // During normal tracking GLIM already provides the best VGICP initial
+    // value. KISS is reserved for acquiring an unknown/global frame; running
+    // it on every submap adds CPU and can move a good prediction into a
+    // repeated-structure basin.
+    bool use_coarse_global_candidate =
+      !graph_frame_seeded_ || full_global_search_;
+    Eigen::Isometry3d candidate = predicted_in_map;
+    bool coarse_valid = true;
+    std::size_t coarse_inliers = gate_params_.min_final_inliers;
+    if (use_coarse_global_candidate) {
+      matcher_.reset();
+      const auto solution = matcher_.estimate(source, target);
+      candidate.linear() = solution.rotation;
+      candidate.translation() = solution.translation;
+      coarse_valid = solution.valid && finiteTransform(candidate);
+      coarse_inliers = matcher_.getNumFinalInliers();
+      if (!coarse_valid || coarse_inliers < gate_params_.min_final_inliers) {
+        logger_->info(
+          "submap={} source={} target={} KISS_valid={} KISS_inliers={} "
+          "decision=coarse_rejected",
+          submap->id, source.size(), target.size(), solution.valid,
+          coarse_inliers);
+        return;
+      }
+    }
+
+    auto refinement = refineWithVgicp(
+      target, submap->frame, candidate, vgicp_voxel_resolution_m_,
+      vgicp_max_iterations_);
+    auto refinement_delta = refinement.pose * candidate.inverse();
+    const auto refinementAccepted = [&]() {
+        return refinement.valid &&
+          refinement.inlier_fraction >= vgicp_min_inlier_fraction_ &&
+          refinement.normalized_error <= vgicp_max_normalized_error_ &&
+          (!use_coarse_global_candidate ||
+          (refinement_delta.translation().norm() <=
+          vgicp_max_coarse_delta_translation_m_ &&
+          rotationDegrees(refinement_delta) <=
+          vgicp_max_coarse_delta_rotation_deg_));
+      };
+    bool refinement_accepted = refinementAccepted();
+    if (!refinement_accepted && !use_coarse_global_candidate) {
+      logger_->info(
+        "submap={} direct VGICP rejected; trying crop-local KISS fallback",
+        submap->id);
+      matcher_.reset();
+      const auto solution = matcher_.estimate(source, target);
+      coarse_valid = solution.valid;
+      coarse_inliers = matcher_.getNumFinalInliers();
+      if (solution.valid) {
+        candidate.linear() = solution.rotation;
+        candidate.translation() = solution.translation;
+        coarse_valid = finiteTransform(candidate);
+      }
+      if (!coarse_valid || coarse_inliers < gate_params_.min_final_inliers) {
+        logger_->info(
+          "submap={} source={} target={} KISS_valid={} KISS_inliers={} "
+          "decision=fallback_coarse_rejected",
+          submap->id, source.size(), target.size(), solution.valid,
+          coarse_inliers);
+        return;
+      }
+      use_coarse_global_candidate = true;
+      refinement = refineWithVgicp(
+        target, submap->frame, candidate, vgicp_voxel_resolution_m_,
+        vgicp_max_iterations_);
+      refinement_delta = refinement.pose * candidate.inverse();
+      refinement_accepted = refinementAccepted();
+    }
+    if (!refinement_accepted) {
+      logger_->info(
+        "submap={} KISS_inliers={} VGICP_valid={} VGICP_inliers={} "
+        "VGICP_overlap={:.3f} VGICP_error={:.3f} delta={:.3f}m/{:.2f}deg "
+        "decision=refinement_rejected",
+        submap->id, coarse_inliers, refinement.valid,
+        refinement.num_inliers, refinement.inlier_fraction,
+        refinement.normalized_error, refinement_delta.translation().norm(),
+        rotationDegrees(refinement_delta));
+      return;
+    }
+    candidate = refinement.pose;
+
+    // Compare in the map frame. Before the graph is anchored, predicted_in_map
+    // applies the approximate startup pose; afterwards GLIM's world is map.
+    const Eigen::Isometry3d local_correction = candidate * predicted_in_map.inverse();
+    const Eigen::Isometry3d global_anchor = candidate * predicted.inverse();
+    const Eigen::Isometry3d anchor_disagreement =
+      previous_global_anchor_available_ ?
+      previous_global_anchor_.inverse() * global_anchor :
+      Eigen::Isometry3d::Identity();
+
+    auto active_gate_params = gate_params_;
+    if (!map_frame_initialized_ && bootstrap_anchor_available_) {
+      active_gate_params.allow_global_relocalization = false;
+      active_gate_params.max_local_correction_translation_m =
+        environmentDouble("GLIM_PRIOR_MAP_MAX_BOOTSTRAP_TRANSLATION_M", 10.0);
+    } else {
+      // In a seeded map frame, a large crop-local correction is accepted only
+      // after two independent submaps agree on the same map-from-GLIM-world
+      // anchor. Unseeded acquisition still requires explicit full-map mode.
+      active_gate_params.allow_global_relocalization =
+        gate_params_.allow_global_relocalization &&
+        (graph_frame_seeded_ || full_global_search_);
+    }
+    const PriorMapFactorGateDecision decision = decidePriorMapFactor(
+      active_gate_params,
+      PriorMapFactorGateInput{
+        coarse_valid,
+        finiteTransform(candidate),
+        coarse_inliers,
+        local_correction.translation().norm(),
+        rotationDegrees(local_correction),
+        previous_global_anchor_available_,
+        anchor_disagreement.translation().norm(),
+        rotationDegrees(anchor_disagreement)});
+
+    if (!decision.accepted &&
+      decision.reason.find("global_") == 0)
+    {
+      previous_global_anchor_ = global_anchor;
+      previous_global_anchor_available_ = finiteTransform(global_anchor);
+    }
+
+    logger_->info(
+      "submap={} source={} target={} inliers={} candidate=({:.3f},{:.3f},{:.3f}) "
+      "VGICP_inliers={} overlap={:.3f} error={:.3f} "
+      "correction={:.3f}m/{:.2f}deg decision={}",
+      submap->id, source.size(), target.size(), coarse_inliers,
+      candidate.translation().x(), candidate.translation().y(), candidate.translation().z(),
+      refinement.num_inliers, refinement.inlier_fraction,
+      refinement.normalized_error,
+      local_correction.translation().norm(), rotationDegrees(local_correction),
+      decision.reason);
+    if (!decision.accepted) {
+      return;
+    }
+
+    pending_factors_.push_back(
+      PendingFactor{
+        submap->id, candidate,
+        decision.accepted_as_global_relocalization || !graph_frame_seeded_,
+        refinement.target_voxels, submap->frame});
+    map_frame_initialized_ = true;
+    previous_global_anchor_available_ = false;
+  }
+
+  void onSmootherUpdate(
+    gtsam_points::ISAM2Ext &,
+    gtsam::NonlinearFactorGraph & new_factors,
+    gtsam::Values & new_values)
+  {
+    using gtsam::symbol_shorthand::X;
+    if (!graph_frame_seeded_ && bootstrap_anchor_available_ && new_values.exists(X(0))) {
+      const auto glim_world_from_submap = new_values.at<gtsam::Pose3>(X(0));
+      const Eigen::Isometry3d map_from_submap =
+        bootstrap_anchor_ * Eigen::Isometry3d(glim_world_from_submap.matrix());
+      new_values.update(X(0), gtsam::Pose3(map_from_submap.matrix()));
+      graph_frame_seeded_ = true;
+      logger_->info("seeded GLIM X(0) in the prior-map frame");
+    }
+    for (const auto & pending : pending_factors_) {
+      if (pending.global_relocalization && new_values.exists(X(pending.submap_id))) {
+        // The current submap has not entered iSAM2 yet. Seed its linearization
+        // at the consensus-validated map pose so an 80+ metre frame change is
+        // not linearized as one enormous increment from the GLIM-world pose.
+        new_values.update(
+          X(pending.submap_id), gtsam::Pose3(pending.map_from_submap.matrix()));
+      }
+      new_factors.emplace_shared<gtsam_points::IntegratedVGICPFactor>(
+        gtsam::Pose3::Identity(), X(pending.submap_id),
+        pending.target_voxels, pending.source);
+      logger_->info(
+        "injected {} prior-map VGICP factor on submap {}",
+        pending.global_relocalization ? "global-relocalization" : "local-tracking",
+        pending.submap_id);
+    }
+    pending_factors_.clear();
+  }
+
+  std::shared_ptr<spdlog::logger> logger_;
+  std::vector<Eigen::Vector3f> prior_map_;
+  kiss_matcher::KISSMatcher matcher_;
+  PriorMapFactorGateParams gate_params_;
+  double vgicp_voxel_resolution_m_{1.0};
+  int vgicp_max_iterations_{10};
+  double vgicp_min_inlier_fraction_{0.50};
+  double vgicp_max_normalized_error_{5.0};
+  double vgicp_max_coarse_delta_translation_m_{2.0};
+  double vgicp_max_coarse_delta_rotation_deg_{5.0};
+  double tracking_crop_radius_m_{35.0};
+  double bootstrap_crop_radius_m_{60.0};
+  std::size_t bootstrap_submap_stride_{2};
+  std::size_t tracking_submap_stride_{10};
+  bool full_global_search_{false};
+  bool map_frame_initialized_{false};
+  bool graph_frame_seeded_{false};
+  bool bootstrap_anchor_available_{false};
+  Eigen::Isometry3d bootstrap_anchor_{Eigen::Isometry3d::Identity()};
+  bool previous_global_anchor_available_{false};
+  Eigen::Isometry3d previous_global_anchor_{Eigen::Isometry3d::Identity()};
+  std::vector<PendingFactor> pending_factors_;
+};
+
+}  // namespace glim_prior_map_localizer
+
+extern "C" glim::ExtensionModule * create_extension_module()
+{
+  return new glim_prior_map_localizer::PriorMapLocalizer();
+}

--- a/experiments/glim_prior_map_localizer/src/vgicp_refiner.cpp
+++ b/experiments/glim_prior_map_localizer/src/vgicp_refiner.cpp
@@ -1,0 +1,83 @@
+#include "glim_prior_map_localizer/vgicp_refiner.hpp"
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam_points/factors/integrated_vgicp_factor.hpp>
+#include <gtsam_points/optimizers/levenberg_marquardt_ext.hpp>
+#include <gtsam_points/types/gaussian_voxelmap_cpu.hpp>
+#include <gtsam_points/types/point_cloud_cpu.hpp>
+
+namespace glim_prior_map_localizer
+{
+
+VgicpRefinementResult refineWithVgicp(
+  const std::vector<Eigen::Vector3f> & target_points,
+  const std::shared_ptr<const gtsam_points::PointCloud> & source,
+  const Eigen::Isometry3d & initial_pose,
+  double voxel_resolution_m,
+  int max_iterations)
+{
+  VgicpRefinementResult result;
+  result.pose = initial_pose;
+  if (target_points.empty() || !source || source->size() == 0 ||
+    !source->has_covs() || !initial_pose.matrix().allFinite() ||
+    !(voxel_resolution_m > 0.0) || max_iterations < 1)
+  {
+    return result;
+  }
+
+  std::vector<Eigen::Vector4d> target_points_homogeneous;
+  target_points_homogeneous.reserve(target_points.size());
+  for (const auto & point : target_points) {
+    target_points_homogeneous.emplace_back(
+      point.x(), point.y(), point.z(), 1.0);
+  }
+  auto target = std::make_shared<gtsam_points::PointCloudCPU>(
+    target_points_homogeneous);
+  // GaussianVoxelMapCPU consumes each input point covariance while building
+  // voxel distributions. A raw prior-map PLY has no covariance channel, so
+  // give each sample a small isotropic measurement covariance; the voxel's
+  // spatial distribution still supplies the dominant surface geometry.
+  std::vector<Eigen::Matrix4d> target_covariances(
+    target_points_homogeneous.size(), Eigen::Matrix4d::Zero());
+  for (auto & covariance : target_covariances) {
+    covariance.diagonal().head<3>().setConstant(1.0e-2);
+  }
+  target->add_covs(target_covariances);
+  auto target_voxels = std::make_shared<gtsam_points::GaussianVoxelMapCPU>(
+    voxel_resolution_m);
+  target_voxels->insert(*target);
+  result.target_voxels = target_voxels;
+
+  constexpr gtsam::Key source_key = 0;
+  auto factor = gtsam::make_shared<gtsam_points::IntegratedVGICPFactor>(
+    gtsam::Pose3::Identity(), source_key, target_voxels, source);
+  gtsam::NonlinearFactorGraph graph;
+  graph.add(factor);
+  gtsam::Values values;
+  values.insert(source_key, gtsam::Pose3(initial_pose.matrix()));
+
+  gtsam_points::LevenbergMarquardtExtParams params;
+  params.setMaxIterations(max_iterations);
+  const auto optimized =
+    gtsam_points::LevenbergMarquardtOptimizerExt(graph, values, params).optimize();
+  const gtsam::Pose3 refined = optimized.at<gtsam::Pose3>(source_key);
+  const double error = factor->error(optimized);
+  result.pose = Eigen::Isometry3d(refined.matrix());
+  result.num_inliers = factor->num_inliers();
+  result.inlier_fraction = factor->inlier_fraction();
+  result.normalized_error = result.num_inliers > 0 ?
+    error / static_cast<double>(result.num_inliers) :
+    std::numeric_limits<double>::infinity();
+  result.valid = result.pose.matrix().allFinite() &&
+    std::isfinite(result.inlier_fraction) &&
+    std::isfinite(result.normalized_error) && result.num_inliers > 0;
+  return result;
+}
+
+}  // namespace glim_prior_map_localizer

--- a/scripts/run_koide_glim_odometry_benchmark.py
+++ b/scripts/run_koide_glim_odometry_benchmark.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -31,6 +32,22 @@ def main() -> int:
         help="Expected covered duration forwarded to the completion checker "
         "(reference start to bag end; default keeps the outdoor_hard_01a gate).")
     parser.add_argument("--image", default=os.environ.get("GLIM_IMAGE", DEFAULT_IMAGE))
+    parser.add_argument(
+        "--config",
+        help="GLIM config directory (default: param/odometry/glim_koide_outdoor_gicp6500).",
+    )
+    parser.add_argument(
+        "--prior-map",
+        help="Enable libglim_prior_map_localizer.so with this PLY prior map.",
+    )
+    parser.add_argument(
+        "--prior-map-bootstrap-center", type=float, nargs=3, metavar=("X", "Y", "Z"),
+        help="Known approximate initial position in the prior-map frame; crop seed only.",
+    )
+    parser.add_argument(
+        "--prior-map-bootstrap-yaw-deg", type=float,
+        help="Known approximate initial yaw in the prior-map frame; requires bootstrap center.",
+    )
     parser.add_argument("--ros-domain-id", type=int, default=91)
     parser.add_argument(
         "--allow-image-mismatch", action="store_true",
@@ -41,7 +58,9 @@ def main() -> int:
     bag = Path(args.bag).resolve()
     reference = Path(args.reference).resolve()
     output = Path(args.output).resolve()
-    config = repo / "param/odometry/glim_koide_outdoor_gicp6500"
+    config = Path(args.config).resolve() if args.config else (
+        repo / "param/odometry/glim_koide_outdoor_gicp6500"
+    )
     if not (bag / "metadata.yaml").is_file():
         parser.error(f"not a rosbag2 directory: {bag}")
     if not reference.is_file():
@@ -49,6 +68,27 @@ def main() -> int:
     if output.exists() and any(output.iterdir()):
         parser.error(f"output directory must be empty: {output}")
     output.mkdir(parents=True, exist_ok=True)
+
+    prior_map = Path(args.prior_map).resolve() if args.prior_map else None
+    if prior_map is not None:
+        if prior_map.suffix.lower() != ".ply" or not prior_map.is_file():
+            parser.error(f"prior map must be an existing PLY file: {prior_map}")
+        generated_config = output / "glim_config"
+        shutil.copytree(config, generated_config)
+        config_ros_path = generated_config / "config_ros.json"
+        config_ros = json.loads(config_ros_path.read_text(encoding="utf-8"))
+        modules = config_ros["glim_ros"].setdefault("extension_modules", [])
+        if "libglim_prior_map_localizer.so" not in modules:
+            modules.append("libglim_prior_map_localizer.so")
+        config_ros_path.write_text(
+            json.dumps(config_ros, indent=2) + "\n", encoding="utf-8")
+        config = generated_config
+    elif (args.prior_map_bootstrap_center is not None or
+          args.prior_map_bootstrap_yaw_deg is not None):
+        parser.error("--prior-map-bootstrap-center requires --prior-map")
+    if ((args.prior_map_bootstrap_center is None) !=
+            (args.prior_map_bootstrap_yaw_deg is None)):
+        parser.error("bootstrap center and bootstrap yaw must be provided together")
 
     image_id = subprocess.check_output(
         ["docker", "image", "inspect", args.image, "--format", "{{.Id}}"], text=True
@@ -66,12 +106,27 @@ def main() -> int:
         "-v", f"{bag.parent}:/data:ro",
         "-v", f"{config}:/glim/config:ro",
         "-v", f"{output}:/tmp",
+    ]
+    if prior_map is not None:
+        docker_command.extend([
+            "-e", "GLIM_PRIOR_MAP_PATH=/prior_map.ply",
+            "-v", f"{prior_map}:/prior_map.ply:ro",
+        ])
+        if args.prior_map_bootstrap_center is not None:
+            for axis, value in zip("XYZ", args.prior_map_bootstrap_center):
+                docker_command.extend([
+                    "-e", f"GLIM_PRIOR_MAP_BOOTSTRAP_CENTER_{axis}={value}",
+                ])
+            docker_command.extend([
+                "-e", f"GLIM_PRIOR_MAP_BOOTSTRAP_YAW_DEG={args.prior_map_bootstrap_yaw_deg}",
+            ])
+    docker_command.extend([
         args.image,
         "bash", "-lc",
         ". /opt/ros/jazzy/setup.bash && . /root/ros2_ws/install/setup.bash && "
         f"ros2 run glim_ros glim_rosbag {container_bag} --ros-args "
         "-p config_path:=/glim/config -p auto_quit:=true",
-    ]
+    ])
     started = time.monotonic()
     with (output / "glim.log").open("w", encoding="utf-8") as log:
         process = subprocess.run(
@@ -87,6 +142,8 @@ def main() -> int:
         "wall_duration_sec": wall_duration,
         "image": args.image,
         "image_id": image_id,
+        "prior_map": str(prior_map) if prior_map is not None else None,
+        "config": str(config),
     }
     (output / "summary.json").write_text(
         json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/test/test_glim_prior_map_factor_policy.cpp
+++ b/test/test_glim_prior_map_factor_policy.cpp
@@ -1,0 +1,87 @@
+#include "glim_prior_map_localizer/prior_map_factor_policy.hpp"
+
+#include <cassert>
+#include <limits>
+
+namespace gp = glim_prior_map_localizer;
+
+void test_rejects_invalid_and_non_finite_solutions()
+{
+  const gp::PriorMapFactorGateParams params;
+  auto input = gp::PriorMapFactorGateInput{};
+  auto decision = gp::decidePriorMapFactor(params, input);
+  assert(!decision.accepted);
+  assert(decision.reason == "solution_invalid");
+
+  input.solution_valid = true;
+  input.transform_finite = false;
+  decision = gp::decidePriorMapFactor(params, input);
+  assert(!decision.accepted);
+  assert(decision.reason == "transform_non_finite");
+}
+
+void test_rejects_weak_correspondence_support()
+{
+  const gp::PriorMapFactorGateParams params;
+  gp::PriorMapFactorGateInput input;
+  input.solution_valid = true;
+  input.transform_finite = true;
+  input.final_inliers = params.min_final_inliers - 1;
+
+  const auto decision = gp::decidePriorMapFactor(params, input);
+  assert(!decision.accepted);
+  assert(decision.reason == "insufficient_final_inliers");
+}
+
+void test_accepts_a_bounded_local_map_correction()
+{
+  const gp::PriorMapFactorGateParams params;
+  gp::PriorMapFactorGateInput input;
+  input.solution_valid = true;
+  input.transform_finite = true;
+  input.final_inliers = 50;
+  input.local_correction_translation_m = 1.2;
+  input.local_correction_rotation_deg = 4.0;
+
+  const auto decision = gp::decidePriorMapFactor(params, input);
+  assert(decision.accepted);
+  assert(!decision.accepted_as_global_relocalization);
+  assert(decision.reason == "local_correction_consistent");
+}
+
+void test_global_relocalization_requires_two_consistent_anchors()
+{
+  const gp::PriorMapFactorGateParams params;
+  gp::PriorMapFactorGateInput input;
+  input.solution_valid = true;
+  input.transform_finite = true;
+  input.final_inliers = 50;
+  input.local_correction_translation_m = 30.0;
+  input.local_correction_rotation_deg = 90.0;
+
+  auto decision = gp::decidePriorMapFactor(params, input);
+  assert(!decision.accepted);
+  assert(decision.reason == "global_consensus_pending");
+
+  input.previous_global_anchor_available = true;
+  input.global_anchor_translation_disagreement_m = 0.8;
+  input.global_anchor_rotation_disagreement_deg = 3.0;
+  decision = gp::decidePriorMapFactor(params, input);
+  assert(decision.accepted);
+  assert(decision.accepted_as_global_relocalization);
+  assert(decision.reason == "global_consensus_accepted");
+
+  input.global_anchor_translation_disagreement_m = 4.0;
+  decision = gp::decidePriorMapFactor(params, input);
+  assert(!decision.accepted);
+  assert(decision.reason == "global_consensus_rejected");
+}
+
+int main()
+{
+  test_rejects_invalid_and_non_finite_solutions();
+  test_rejects_weak_correspondence_support();
+  test_accepts_a_bounded_local_map_correction();
+  test_global_relocalization_requires_two_consistent_anchors();
+  return 0;
+}

--- a/test/test_glim_prior_map_ply_loader.cpp
+++ b/test/test_glim_prior_map_ply_loader.cpp
@@ -1,0 +1,39 @@
+#include "glim_prior_map_localizer/ply_loader.hpp"
+
+#include <cassert>
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+#include <unistd.h>
+
+void test_loads_ascii_xyz_with_extra_scalar()
+{
+  const std::string path =
+    "/tmp/glim_prior_map_loader_" + std::to_string(getpid()) + ".ply";
+  {
+    std::ofstream stream(path);
+    stream << "ply\n"
+           << "format ascii 1.0\n"
+           << "element vertex 2\n"
+           << "property uchar intensity\n"
+           << "property float z\n"
+           << "property float x\n"
+           << "property double y\n"
+           << "end_header\n"
+           << "7 3.0 1.0 2.0\n"
+           << "8 6.0 4.0 5.0\n";
+  }
+
+  const auto points = glim_prior_map_localizer::loadPlyXyz(path);
+  assert(points.size() == 2);
+  assert(points[0].isApprox(Eigen::Vector3f(1.0F, 2.0F, 3.0F)));
+  assert(points[1].isApprox(Eigen::Vector3f(4.0F, 5.0F, 6.0F)));
+  std::remove(path.c_str());
+}
+
+int main()
+{
+  test_loads_ascii_xyz_with_extra_scalar();
+  return 0;
+}


### PR DESCRIPTION
## What changed

- add an out-of-tree GLIM prior-map localization extension
- use predicted-pose VGICP for sparse normal tracking
- reserve KISS-Matcher for unknown-frame acquisition and lock-loss fallback
- require two-submap map-frame consensus before accepting large recovery corrections
- add PLY loading and factor-gate unit tests
- extend the Koide GLIM benchmark runner with prior-map and startup-pose options

## Why

Continuously running GLIM and NDT duplicates registration work. This experiment evaluates a lighter architecture where GLIM remains the continuous LiDAR/IMU odometry front end and prior-map registration runs only at submap rate.

## Measured impact

The 380 s `outdoor_hard_01a` run achieved:

- 99.21% coverage
- 2.196 m translation ATE
- 4.434 m end error
- 0.313 m median 10 m translation RPE
- 46.9 ms processing p95
- zero TF jumps

It demonstrated a two-submap consensus reattachment at submaps 30/40 and then tracked through submap 80.

This is intentionally experimental: the GLIM coreset baseline remains better at 1.696 m ATE and 0.182 m RPE. The README records that limitation and identifies separately smoothed `map -> odom` correction as the next design gate.

## Validation

- Docker image build succeeds
- factor-policy test passes with `-Wall -Wextra -Werror`
- PLY-loader test passes with `-Wall -Wextra -Werror`
- benchmark runner passes `py_compile`
- `git diff --check` passes
- full 380 s measured replay completed without TF jumps or queue growth
