### PR TITLE
Document smoothed map odom remeasurement

### DIFF
--- a/experiments/glim_prior_map_localizer/README.md
+++ b/experiments/glim_prior_map_localizer/README.md
@@ -112,6 +112,21 @@ more accurate. The next design gate is therefore a separately smoothed
 `map -> odom` correction output that never deforms GLIM odometry. Do not use
 this experiment to replace the validated localizer yet.
 
+A post-merge offline reconstruction tested that separation on the same run11
+dump. It left GLIM's raw orientation unchanged, held the startup map-to-odom
+yaw fixed, applied 20% of each accepted translation-anchor update, and used a
+2 s first-order transition. The reconstructed trajectory passed every current
+01a odometry gate: 1.998 m translation ATE, 4.596 m end error, 0.169 m median
+10 m translation RPE, and 1.644 degrees rotation ATE. With zero map correction,
+the same run's raw odometry measured 1.853 m ATE, 4.726 m end error, and 0.155 m
+RPE; the low-gain correction therefore improved the end error while preserving
+the local-odometry gates.
+
+These are offline replay-reconstruction results, not evidence of a live ROS TF
+publisher. The next implementation must reproduce the same fixed-yaw,
+low-gain, time-smoothed policy online and re-run the full bag before production
+use.
+
 ## Acceptance gates
 
 Before enabling this in measured replays:


### PR DESCRIPTION
## Summary

Document the post-merge offline `map -> odom` separation sweep performed on the run11 dump.

The best measured policy keeps GLIM orientation untouched, holds startup map-to-odom yaw fixed, applies translation anchor updates at gain 0.2, and smooths them with a 2 s time constant.

## Results

- translation ATE: 1.998 m
- end error: 4.596 m
- median 10 m translation RPE: 0.169 m
- rotation ATE: 1.644 degrees
- all current 01a odometry gates pass

The README explicitly distinguishes this offline replay reconstruction from a live ROS TF implementation.

## Validation

- compared gains 0, 0.05, 0.1, 0.2, 0.3, and 0.5 on the same raw run11 trajectory
- compared smoothing time constants 2, 5, 10, 20, 40, and 80 seconds
- re-ran the existing completion checker for each generated trajectory
- `git diff --check` passes
