### PR TITLE
Document the GLIL Z-bridge four-bag regression

### DIFF
--- a/docs/koide_gif_gallery.md
+++ b/docs/koide_gif_gallery.md
@@ -44,6 +44,28 @@ A separate non-planar check of repeat 2 improved from the earlier 10.4--10.7 m r
 9.21 m ATE but still failed, so full 3D drift and kidnapped-pose recovery remain open.
 Ground truth is only the dashed evaluation overlay.
 
+#### Four-bag Z-bridge regression
+
+Vertical gain 1.0 was subsequently replayed across all four outdoor-hard bags with the
+same image and unchanged gates. It passed at least once on every bag, but remains opt-in
+because one of two 01b repeats exceeded the ATE limit.
+
+| Bag | Repeat | Translation ATE | Final error | Median 10 m RPE | Processing p95 | Gate |
+|---|---:|---:|---:|---:|---:|---|
+| `outdoor_hard_01a` | 1 | 1.106 m | 2.738 m | 0.160 m | 60.3 ms | Pass |
+| `outdoor_hard_01b` | 1 | 2.219 m | 2.412 m | 0.183 m | 78.3 ms | ATE fail |
+| `outdoor_hard_01b` | 2 | 1.867 m | 2.022 m | 0.192 m | 94.1 ms | Pass |
+| `outdoor_hard_02a` | 1 | 1.926 m | 2.854 m | 0.181 m | 38.5 ms | Pass |
+| `outdoor_hard_02a` | 2 | 1.795 m | 2.827 m | 0.181 m | 30.4 ms | Pass |
+| `outdoor_hard_02b` | 1 | 1.097 m | 1.538 m | 0.175 m | 81.4 ms | Pass |
+
+Cross-composing the 01b artifacts isolated the failure: repeat-1 raw GLIM odometry with
+the baseline map anchor still produced 2.210 m ATE, while baseline raw odometry with the
+repeat-1 Z-bridge anchor produced 1.562 m. The anchor changed ATE by only about 0.02 m;
+the failed repeat was dominated by raw-odometry variability. This clears the Z bridge of
+a direct 01b regression, but one-pass-per-bag evidence is not sufficient to enable it by
+default.
+
 #### Outdoor hard 01a
 
 ![Koide outdoor_hard_01a GLIL-style live map-to-odom replay](../images/koide/measured/glil/outdoor_hard_01a_live_map_odom.gif)

--- a/experiments/glim_prior_map_localizer/README.md
+++ b/experiments/glim_prior_map_localizer/README.md
@@ -103,6 +103,14 @@ runs passed, but repeat 2 still measured 9.21 m non-planar 3D ATE and 14.29 m fi
 error. Full 3D drift and kidnapped-pose recovery therefore remain unverified. The
 authoritative recorded values are in [`results.json`](results.json).
 
+A follow-up four-bag regression used vertical gain 1.0 everywhere. 01a passed at
+1.106 m ATE, 02b passed at 1.097 m, and the two previously recorded 02a repeats passed
+at 1.926 m and 1.795 m. 01b passed one repeat at 1.867 m and failed one at 2.219 m.
+Cross-composition showed that failed repeat remained at 2.210 m with the baseline map
+anchor, whereas baseline raw odometry remained passing at 1.562 m with the Z-bridge
+anchor. The variance therefore came primarily from raw GLIM odometry, not the anchor,
+but the Z bridge remains opt-in until repeatability and non-planar drift improve.
+
 The converter composes the canonical raw GLIM poses with the recorded live
 `external_map_odom.txt` history. This evaluates the transform actually published by
 the live policy and avoids introducing a second offline correction model.
@@ -125,8 +133,8 @@ Add `--prior-map-vertical-gain 1.0` for the measured 02a Z-bridge policy.
 
 ## Remaining acceptance work
 
-1. Resolve the remaining non-planar Z drift and validate the vertical policy across all
-   four outdoor-hard bags before making it the default.
+1. Resolve the remaining non-planar Z drift and the 01b raw-odometry run-to-run variance
+   before making the vertical policy the default.
 2. Measure seeded and unseeded false-match and kidnapped-pose recovery cases.
 3. Confirm that two-submap recovery reacquires a deliberately displaced pose without
    discontinuity or a false map anchor.

--- a/experiments/glim_prior_map_localizer/results.json
+++ b/experiments/glim_prior_map_localizer/results.json
@@ -28,6 +28,76 @@
     "outdoor_hard_02a_passes": 2,
     "outdoor_hard_02a_repeats": 4
   },
+  "four_bag_vertical_gain_validation": {
+    "image_id": "sha256:a37681c646540d5ebab3037108495e8d6e2574dc53ad9b720278515d2582f821",
+    "vertical_gain": 1.0,
+    "default_enabled": false,
+    "decision": "Keep opt-in: every bag passed at least once, but outdoor_hard_01b passed only one of two repeats and non-planar drift remains unresolved.",
+    "runs": [
+      {
+        "id": "run22",
+        "sequence": "outdoor_hard_01a",
+        "ok": true,
+        "translation_ate_rmse_m": 1.1059563868093492,
+        "translation_end_error_m": 2.7380426690111515,
+        "rpe_translation_median_m": 0.15974521089054913,
+        "processing_p95_sec": 0.060261482
+      },
+      {
+        "id": "run23_repeat01",
+        "sequence": "outdoor_hard_01b",
+        "ok": false,
+        "failed_gates": [
+          "translation_ate"
+        ],
+        "translation_ate_rmse_m": 2.2192020897060774,
+        "translation_end_error_m": 2.4117412672055027,
+        "rpe_translation_median_m": 0.18280792674184734,
+        "processing_p95_sec": 0.078321586
+      },
+      {
+        "id": "run25_repeat02",
+        "sequence": "outdoor_hard_01b",
+        "ok": true,
+        "translation_ate_rmse_m": 1.8666354199732293,
+        "translation_end_error_m": 2.0215093971060494,
+        "rpe_translation_median_m": 0.1921255401376088,
+        "processing_p95_sec": 0.094137254
+      },
+      {
+        "id": "run20_repeat01",
+        "sequence": "outdoor_hard_02a",
+        "ok": true,
+        "translation_ate_rmse_m": 1.9261487862027733,
+        "translation_end_error_m": 2.853730416097297,
+        "rpe_translation_median_m": 0.1806983865230643,
+        "processing_p95_sec": 0.038549368
+      },
+      {
+        "id": "run21_repeat02",
+        "sequence": "outdoor_hard_02a",
+        "ok": true,
+        "translation_ate_rmse_m": 1.7946390730291173,
+        "translation_end_error_m": 2.8269908244298674,
+        "rpe_translation_median_m": 0.18096794788754772,
+        "processing_p95_sec": 0.030422028999999996
+      },
+      {
+        "id": "run24",
+        "sequence": "outdoor_hard_02b",
+        "ok": true,
+        "translation_ate_rmse_m": 1.0974642709448172,
+        "translation_end_error_m": 1.5378621361495903,
+        "rpe_translation_median_m": 0.17482914373973615,
+        "processing_p95_sec": 0.081358522
+      }
+    ],
+    "outdoor_hard_01b_cross_composition": {
+      "repeat01_raw_odom_with_baseline_anchor_ate_m": 2.2098280569472197,
+      "baseline_raw_odom_with_repeat01_anchor_ate_m": 1.562110968048621,
+      "conclusion": "The failed repeat was dominated by raw GLIM odometry variability; the Z-bridge anchor changed ATE by about 0.02 m."
+    }
+  },
   "runs": [
     {
       "id": "run13",


### PR DESCRIPTION
## What changed

- record full vertical-gain 1.0 regressions for all four outdoor-hard bags
- retain both 01b repeats, including the ATE-only failure
- document cross-composition of raw GLIM odometry and map-to-odom histories
- keep the Z bridge opt-in rather than enabling it by default

## Results

- 01a: PASS, ATE 1.106 m
- 01b repeat 1: ATE-only failure, 2.219 m
- 01b repeat 2: PASS, 1.867 m
- 02a repeats: PASS, 1.926 m and 1.795 m
- 02b: PASS, 1.097 m
- all runs retained continuity and runtime gates

Cross-composition showed repeat-1 01b raw odometry still measured 2.210 m with the baseline anchor, while baseline raw odometry measured 1.562 m with the Z-bridge anchor. The failed repeat was therefore dominated by raw-odometry variability; nevertheless, repeatability and non-planar drift are insufficient for default enablement.

## Validation

- four new full-bag replays plus the two existing 02a repeats
- relevant Python tests: 11 passed
- standalone C++ map-to-odom policy test passed with `-Wall -Wextra -Werror`
- JSON parse and `git diff --check` passed
