### PR TITLE
Make the GLIM coreset odometry profile deterministic

### DIFF
--- a/docs/koide_gif_gallery.md
+++ b/docs/koide_gif_gallery.md
@@ -66,6 +66,16 @@ the failed repeat was dominated by raw-odometry variability. This clears the Z b
 a direct 01b regression, but one-pass-per-bag evidence is not sufficient to enable it by
 default.
 
+The raw-odometry variance was then isolated to parallel ordering in random-grid
+preprocessing and the odometry optimizer. With both coreset-profile thread counts fixed
+to one, two new full 01b replays produced byte-identical 2,218-row `odom_lidar.txt`
+files (SHA-256 `45d49d87932febc06b4ab18b29fc1ba58fc6f6ed043a7157523fe4e75f383642`).
+Both passed at 1.407079 m ATE and 1.957 m final error; RPE was 0.18690/0.18694 m and
+processing p95 was 44.3/47.5 ms. Sparse prior-map VGICP still varied its Z anchor by up
+to 4.3 cm, but the resulting planar ATE difference was below 0.000001 m. The vertical
+bridge remains opt-in until this deterministic profile is replayed on the other bags and
+the non-planar drift is resolved.
+
 #### Outdoor hard 01a
 
 ![Koide outdoor_hard_01a GLIL-style live map-to-odom replay](../images/koide/measured/glil/outdoor_hard_01a_live_map_odom.gif)

--- a/experiments/glim_prior_map_localizer/README.md
+++ b/experiments/glim_prior_map_localizer/README.md
@@ -111,6 +111,13 @@ anchor, whereas baseline raw odometry remained passing at 1.562 m with the Z-bri
 anchor. The variance therefore came primarily from raw GLIM odometry, not the anchor,
 but the Z bridge remains opt-in until repeatability and non-planar drift improve.
 
+The raw 01b variance was reproduced from the first scan and traced to parallel ordering
+in random-grid preprocessing and the odometry optimizer. Setting both thread counts to
+one made two full 302 s raw odometry dumps byte-identical. Both full outputs passed at
+1.407079 m ATE, 1.957 m final error, and 0.187 m median 10 m RPE; processing p95 was
+44.3 ms and 47.5 ms. Prior-map VGICP still produced a small run-to-run Z-anchor
+difference, but it changed planar ATE by less than one micrometre.
+
 The converter composes the canonical raw GLIM poses with the recorded live
 `external_map_odom.txt` history. This evaluates the transform actually published by
 the live policy and avoids introducing a second offline correction model.
@@ -133,8 +140,8 @@ Add `--prior-map-vertical-gain 1.0` for the measured 02a Z-bridge policy.
 
 ## Remaining acceptance work
 
-1. Resolve the remaining non-planar Z drift and the 01b raw-odometry run-to-run variance
-   before making the vertical policy the default.
+1. Replay the deterministic one-thread profile on 01a/02a/02b and resolve the remaining
+   non-planar Z drift before making the vertical policy the default.
 2. Measure seeded and unseeded false-match and kidnapped-pose recovery cases.
 3. Confirm that two-submap recovery reacquires a deliberately displaced pose without
    discontinuity or a false map anchor.

--- a/experiments/glim_prior_map_localizer/results.json
+++ b/experiments/glim_prior_map_localizer/results.json
@@ -98,6 +98,43 @@
       "conclusion": "The failed repeat was dominated by raw GLIM odometry variability; the Z-bridge anchor changed ATE by about 0.02 m."
     }
   },
+  "outdoor_hard_01b_determinism_validation": {
+    "configuration": {
+      "preprocess_num_threads": 1,
+      "odometry_num_threads": 1,
+      "vertical_gain": 1.0
+    },
+    "root_cause": "Parallel ordering in random-grid preprocessing and the odometry optimizer changed the selected points and raw trajectory from the first scan.",
+    "raw_odom_sha256": "45d49d87932febc06b4ab18b29fc1ba58fc6f6ed043a7157523fe4e75f383642",
+    "raw_odom_bitwise_equal": true,
+    "raw_odom_row_count": 2218,
+    "external_map_odom_max_abs_difference": 0.04288318210210029,
+    "runs": [
+      {
+        "id": "run30",
+        "ok": true,
+        "wall_duration_sec": 306.5948609469924,
+        "translation_ate_rmse_m": 1.407079521839094,
+        "translation_end_error_m": 1.957432058163616,
+        "rpe_translation_median_m": 0.18690045253726886,
+        "processing_p95_sec": 0.044286789,
+        "tf_jump_count": 0,
+        "unauthorized_reset_count": 0
+      },
+      {
+        "id": "run31",
+        "ok": true,
+        "wall_duration_sec": 307.0096612229245,
+        "translation_ate_rmse_m": 1.4070793559048809,
+        "translation_end_error_m": 1.957432058163616,
+        "rpe_translation_median_m": 0.18694372463171008,
+        "processing_p95_sec": 0.047511732,
+        "tf_jump_count": 0,
+        "unauthorized_reset_count": 0
+      }
+    ],
+    "decision": "Use the one-thread coreset profile for reproducible measurements; keep vertical gain opt-in pending other-bag and non-planar validation."
+  },
   "runs": [
     {
       "id": "run13",

--- a/param/odometry/glim_koide_outdoor_gicp6500_coreset/config_odometry_cpu.json
+++ b/param/odometry/glim_koide_outdoor_gicp6500_coreset/config_odometry_cpu.json
@@ -25,6 +25,6 @@
     "coreset_reuse_tolerance_rot": 0.0175,
     "validate_imu": true,
     "save_imu_rate_trajectory": true,
-    "num_threads": 2
+    "num_threads": 1
   }
 }

--- a/param/odometry/glim_koide_outdoor_gicp6500_coreset/config_preprocess.json
+++ b/param/odometry/glim_koide_outdoor_gicp6500_coreset/config_preprocess.json
@@ -14,6 +14,6 @@
     "crop_bbox_min": [-1.0, -1.0, -1.0],
     "crop_bbox_max": [1.0, 1.0, 1.0],
     "k_correspondences": 10,
-    "num_threads": 2
+    "num_threads": 1
   }
 }


### PR DESCRIPTION
## What changed

- set random-grid preprocessing to one thread in the measured GLIM coreset profile
- set the CPU odometry optimizer to one thread in the same profile
- record the diagnosis and repeated full 01b validation in the gallery and experiment results

## Root cause

Three prior 01b runs diverged from the first scan. Their first submap point clouds already differed. The fixed `std::mt19937` seed was not sufficient because random-grid preprocessing and odometry optimization both used two threads, allowing parallel ordering to change selected points and floating-point reductions.

A 30-second clipped A/B showed:

- preprocessing at one thread only: residual 6.2 mm raw-odom difference at the end
- preprocessing and odometry at one thread: byte-identical raw odometry

## Full validation

Two independent 302 s 01b replays produced the same 2,218-row `odom_lidar.txt` with SHA-256 `45d49d87932febc06b4ab18b29fc1ba58fc6f6ed043a7157523fe4e75f383642`.

- run30: ATE 1.4070795 m, RPE10 0.186900 m, final 1.957 m, p95 44.3 ms
- run31: ATE 1.4070794 m, RPE10 0.186944 m, final 1.957 m, p95 47.5 ms
- both passed every completion gate with zero TF jumps and zero unauthorized resets

Sparse prior-map VGICP retained a small Z-anchor variation, but planar ATE differed by less than one micrometre.

## Checks

- relevant Python tests: 11 passed
- all changed JSON files parse
- `git diff --check` passed
