### PR TITLE
Prepare v1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## Unreleased
 
+## 1.2.0 - 2026-07-22
+
+Tightly coupled GLIL, exact point-cloud downsampling, and guarded kidnapped-pose
+recovery. Release boundary: PR #128 merged at `04bc8c7`; Humble and Jazzy CI passed,
+the Python suite reported 314 tests plus 140 subtests passed, and the pinned GLIL
+container passed its embedded CTest suite.
+
+### Tightly Coupled GLIL
+
+- Combined IMU preintegration, exact-coreset scan-to-scan GICP, and exact-coreset
+  scan-to-prior-map GICP in one GLIM fixed-lag factor graph, following the estimator
+  structure of Koide et al. ICRA 2024 and deferred exact downsampling of Koide et al.
+  ICRA 2025.
+- Added continuous `odom -> base_link` output through map loss and one bounded
+  `map -> odom` authority; map-factor loss, rejected candidates, and recovery never
+  reset raw odometry or introduce a second TF parent.
+- Added verified map-state epochs, time-aligned 32-candidate BBS/GLIL re-ranking, and
+  three-frame full-resolution consensus for kidnapped-pose recovery.
+- Recovery loss now checks both overlap fraction and the absolute map-factor inlier
+  floor, closing the misleading 12/12-style sparse-overlap case while ignoring empty
+  transport frames.
+- Published reproducible 01a/01b/02a/02b and outdoor-kidnap A/B runners, measurements,
+  and six GLIL-only replay GIFs in `docs/koide_gif_gallery.md`.
+
+### Validation Boundary
+
+- Full 01a, 01b, and 02a runs passed accuracy, continuity, real-time playback, queue,
+  and TF/reset gates. The final 02b run passed accuracy and TF gates; its CPU-contended
+  playback result is explicitly labeled rather than claimed as clean throughput.
+- Outdoor kidnap A and B both ended `recovered_true`, at 0.074 m and 0.041 m final
+  error respectively, with zero TF jumps, zero unauthorized resets, and drained final
+  queues.
+- The tightly coupled GLIL path is the measured main configuration; NDT is not launched
+  alongside it. Legacy split prior-map localization remains available for comparison.
+
 ### Added
 
 - `failure_category` key on `/alignment_status` distinguishing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(lidar_localization_ros2 VERSION 1.0.0)
+project(lidar_localization_ros2 VERSION 1.2.0)
 
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>lidar_localization_ros2</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>ROS 2 LiDAR localization with Nav2 integration, replay helpers, and benchmarking tools.</description>
   <maintainer email="rsasaki0109@gmail.com">ryohei sasaki</maintainer>
   <license>BSD2.0</license>


### PR DESCRIPTION
## What changed

- bump `package.xml` from 1.1.0 to 1.2.0
- align the CMake project version with the ROS package version
- close the accumulated Unreleased changelog as 1.2.0
- record the tightly coupled GLIL, exact-coreset, recovery, measurement, and CPU-contention claim boundary

## Why

PR #128 completed the two-paper tightly coupled GLIL milestone and published the final measured gallery. This release records that stable boundary before starting the next CPU-robustness and indoor-localization work.

## Validation

- `package.xml` parses successfully with `xmllint`
- package and CMake versions both resolve to `1.2.0`
- `git diff --check` passes
- PR #128 already passed Humble and Jazzy CI
