### PR TITLE
docs: restore Koide gallery link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 <img src="./images/path.png" alt="LiDAR localization path over pointcloud map" width="720">
 
+<p><a href="./docs/koide_gif_gallery.md">Explore the complete Koide indoor/outdoor GIF gallery →</a></p>
+
 </div>
 
 ## Features


### PR DESCRIPTION
## Summary

- restore the Koide indoor/outdoor GIF gallery link below the README hero image
- keep the rest of the shortened README unchanged

## Validation

- `git diff --check`
- verified `docs/koide_gif_gallery.md` exists