### PR TITLE
feat: add guarded localization quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- Added `quickstart.py` and `quickstart.launch.py` for one-command configuration,
+  sensor-topic discovery, localization, RViz, and actionable bringup output.
+- Added map-content-bound pose persistence and guarded startup initialization. A saved
+  pose must pass pre-publication NDT scoring, while a BBS_2D candidate requires active
+  3D NDT scoring and distinct-scan consensus. Stale, weak, ambiguous, inconsistent, or
+  exhausted candidates fall back to RViz without publishing an identity pose.
+
 ## 1.2.0 - 2026-07-22
 
 Tightly coupled GLIL, exact point-cloud downsampling, and guarded kidnapped-pose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,9 +134,12 @@ set(LIDAR_LOCALIZATION_CONFIG_SCRIPTS
   scripts/check_lidar_localization_bringup.py
   scripts/check_mid360_legged_bringup.py
   scripts/create_lidar_localization_config.py
+  scripts/quickstart.py
+  scripts/quickstart_model.py
   scripts/run_nav2_demo_smoke
   scripts/run_nav2_replay_smoke
-  scripts/send_nav2_goal.py)
+  scripts/send_nav2_goal.py
+  scripts/startup_initialization_node.py)
 
 set(LIDAR_LOCALIZATION_BENCHMARK_SCRIPTS
   scripts/benchmark_analyze_drift_window
@@ -838,6 +841,18 @@ if(BUILD_TESTING)
   add_test(
     NAME create_lidar_localization_config
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_create_lidar_localization_config.py
+  )
+  add_test(
+    NAME quickstart_model
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_quickstart_model.py
+  )
+  add_test(
+    NAME quickstart_cli
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_quickstart_cli.py
+  )
+  add_test(
+    NAME quickstart_ros_integration
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_quickstart_ros_integration.py
   )
   add_test(
     NAME imu_runtime_validation_model

--- a/README.md
+++ b/README.md
@@ -45,18 +45,27 @@ For manual builds and no-sudo setup, see [local build](docs/local_build.md).
 
 ## Quick Start
 
-Create a configuration for your map:
+Start localization and RViz with one command:
 
 ```bash
-ros2 run lidar_localization_ros2 create_lidar_localization_config.py \
+ros2 run lidar_localization_ros2 quickstart.py \
   --profile standalone \
-  --map-path /absolute/path/to/map.pcd \
-  --output /tmp/lidar_localization.yaml
+  --map /absolute/path/to/map.pcd
 ```
 
-The command prints the matching launch and bringup-check commands. Add
-`--use-sim-time` for rosbag replay or `--initial-pose X Y Z QX QY QZ QW` when the
-map pose is known.
+Quickstart detects unambiguous sensor topics, generates a reusable configuration,
+restores only a pose saved against the same map, and verifies tracking. Add an occupancy
+map to enable guarded global initialization with 3D NDT scoring:
+
+```bash
+ros2 run lidar_localization_ros2 quickstart.py \
+  --profile mid360 \
+  --map /absolute/path/to/map.pcd \
+  --occupancy-map /absolute/path/to/map.yaml
+```
+
+If no safe candidate is available, it asks for **2D Pose Estimate** in RViz; it never
+guesses the origin. See [quickstart and automatic initialization](docs/quickstart.md).
 
 Common launches:
 
@@ -119,6 +128,7 @@ commands, see [benchmarking](docs/benchmarking.md).
 - [MID-360 bringup](docs/mid360_legged_jetson.md)
 - [IMU estimation](docs/imu_estimation.md) and [pose covariance](docs/pose_covariance.md)
 - [Global localization](docs/global_localization.md)
+- [Quickstart and automatic initialization](docs/quickstart.md)
 - [Koide demo gallery](docs/koide_gif_gallery.md)
 - [Release notes](CHANGELOG.md)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,129 @@
+# Quickstart and Automatic Initialization
+
+`quickstart.py` is the user-facing entry point for first bringup. It generates a normal
+package parameter file and launches the existing localizer; the localization algorithm
+and topic/frame contracts are unchanged.
+
+## Start
+
+With a known pose, pass it explicitly:
+
+```bash
+ros2 run lidar_localization_ros2 quickstart.py \
+  --profile standalone \
+  --map /absolute/path/to/map.pcd \
+  --initial-pose X Y Z QX QY QZ QW
+```
+
+Without a known pose, enable map-wide search by supplying the 2D occupancy map used by
+the existing G2 BBS_2D engine:
+
+```bash
+ros2 run lidar_localization_ros2 quickstart.py \
+  --profile mid360 \
+  --map /absolute/path/to/map.pcd \
+  --occupancy-map /absolute/path/to/map.yaml
+```
+
+Use `--dry-run` to generate the configuration and inspect both the launch and bringup
+check commands without starting ROS nodes. A five-second topic/TF check runs after
+launch by default; disable it with `--no-bringup-check`. Use `--no-rviz` on a headless
+robot and `--use-sim-time` for rosbag replay.
+
+When exactly one live `sensor_msgs/msg/PointCloud2` or `sensor_msgs/msg/Imu` topic is
+visible, quickstart selects it. If several exist, it keeps the selected profile's safe
+default and prints `ambiguous`; specify `--cloud-topic` or `--imu-topic` rather than
+guessing. Frame defaults also come from the profile and can be overridden with
+`--lidar-frame`, `--imu-frame`, `--base-frame`, `--odom-frame`, and `--global-frame`.
+
+## Initialization order
+
+The startup manager uses this fixed order:
+
+1. an explicit `--initial-pose`, when supplied;
+2. the last verified pose saved for the exact same pointcloud map contents;
+3. guarded BBS_2D global search when `--occupancy-map` is supplied;
+4. an operator pose from RViz **2D Pose Estimate**.
+
+There is no implicit `(0, 0, 0)` fallback. An explicit pose disables both saved-pose
+publication and global search for that start; the startup manager monitors localizer
+diagnostics without publishing the explicit pose a second time.
+
+The saved state defaults to
+`~/.local/state/lidar_localization_ros2/<map-name>.json`. Its map identity is the full
+SHA-256 and byte size of the `.pcd` or `.ply`; renaming an unchanged map is safe, while
+changing any map content rejects the old pose. Before publication, the current scan must
+also converge from the stored pose under the NDT score gate. If the optional scorer is
+unavailable, quickstart skips automatic restore instead of trusting the pose. Writes are
+atomic. A pose is saved only after fresh diagnostics report stable tracking and acceptable
+fitness for the configured number of consecutive samples. `--no-restore-saved-pose`
+disables restore without disabling future verified saves, and
+`--saved-pose-max-age-sec` can impose an age limit.
+
+## Global-search safety gates
+
+Global initialization reuses `global_localization_node.py`; it does not duplicate the
+BBS implementation. The startup-only state machine is separate from the G3 lost-tracking
+supervisor because cold start has no previously trusted tracking episode.
+
+A candidate is published only when:
+
+- G2 confirms that 3D NDT registration scoring is active (required by default);
+- the G2 score is at least `--min-candidate-score`;
+- the score lead over candidate 2 is at least `--min-score-margin`;
+- `candidate_age_sec` is present and no greater than `--max-candidate-age-sec`;
+- at least `--global-consensus-samples` results from distinct scan timestamps agree
+  within the configured translation and yaw bounds;
+- the localizer subsequently reports acceptable fitness and stable tracking for
+  `--verification-samples` fresh diagnostic messages.
+
+Failed saved poses fall through to global search. Weak, ambiguous, stale, inconsistent,
+timed-out, or unverified global candidates consume a bounded query attempt; after
+`--max-global-attempts`, the node publishes nothing and requests RViz input. Status is
+available as JSON on `/startup_initialization/status`.
+
+The compiled G2 backend and 3D scoring are enabled by default. If scorer loading or
+scoring fails, quickstart rejects the 2D-only result instead of weakening the policy.
+Use `--global-seed-z` for maps whose sensor height is not near zero. HDL-style maps may
+need `--refine-global-candidates`; refinement remains opt-in because repeated geometry
+can make several BBS hypotheses converge to the same local optimum. Keep the robot
+stationary during cold-start search: the candidate age and query timeout defaults are
+30 seconds, and an over-time in-flight query falls back directly to the operator instead
+of issuing duplicate work. Quickstart uses 256 scan points, 10-degree yaw sampling,
+eight candidates, and 3 m BBS non-maximum suppression to keep the guarded query bounded;
+all are available as `--global-*` overrides for measured site tuning. The
+`--no-require-global-registration-scoring` escape hatch is intended only for replay
+experiments, not unattended startup.
+
+The occupancy grid must represent the same physical map as the 3D map. The package does
+not infer this relationship and cannot make a mismatched pair safe. Create a grid with
+`generate_occupancy_map_from_pcd.py` when its route-crop behavior fits the site, then
+inspect the result before use.
+
+## Profiles
+
+| Profile | Default cloud | Default IMU | Pose output | TF expectation |
+| --- | --- | --- | --- | --- |
+| `standalone` | `/velodyne_points` | `/imu` | `/pcl_pose` | localizer publishes `map -> base_link` |
+| `nav2` | `/velodyne_points` | `/imu/data` | `/localization/pose_with_covariance` | external `odom -> base_link` required |
+| `mid360` | `/livox/points` | `/livox/imu` | `/localization/pose_with_covariance` | external `odom -> base_link` required |
+
+Do not enable quickstart's static TF publishers when `robot_state_publisher`, the sensor
+driver, or a bag already owns the same edge. Use `--no-publish-lidar-tf` and leave IMU TF
+publication off as appropriate.
+
+## Troubleshooting
+
+- `no_safe_automatic_source`: no matching saved pose and no occupancy map; use RViz or
+  restart with `--occupancy-map`.
+- `map_mismatch`: the stored pose belongs to different map contents and was ignored.
+- `ambiguous_candidate_retry`: similar places are not distinguishable at the configured
+  margin; do not loosen the margin without replay evidence.
+- `global_attempts_exhausted`: automatic publication stopped; set the pose in RViz.
+- no detected sensor topic: start the driver or bag first, or pass the topic explicitly.
+
+Run the printed `check_lidar_localization_bringup.py` command when data or pose output is
+missing. See [frame contract](frame_contract.md), [troubleshooting](troubleshooting.md),
+[global localization](global_localization.md), and the
+[Phase 4 validation record](quickstart_validation.md) for lower-level details and the
+measured dataset boundary.

--- a/docs/quickstart_validation.md
+++ b/docs/quickstart_validation.md
@@ -1,0 +1,58 @@
+# Quickstart Validation Record
+
+This page records the Phase 4 validation boundary for the guarded quickstart feature.
+It distinguishes tests that ran from datasets that were inspected but could not run.
+
+## Automated coverage
+
+On ROS 2 Jazzy, the package was built with `colcon build --symlink-install` and the full
+package CTest suite passed. The focused quickstart coverage includes:
+
+- ROS-free map identity, atomic pose persistence, malformed/expired state, topic
+  discovery, startup policy, global-query timeout, and distinct-scan consensus tests;
+- CLI generation and invalid-input tests, including the saved-pose-only command;
+- launch argument and installed-file contract tests;
+- a real rclpy graph with a fake G2 service, two scan timestamps, `/initialpose`,
+  tracking diagnostics, state transitions, and verified pose persistence.
+
+## Koide real-bag validation
+
+Run date: 2026-07-22. The mounted public Koide assets contained the 380.39 s
+`outdoor_hard_01a` ROS 2 bag, `map_outdoor_hard.ply`, and its generated BBS occupancy
+map. They are external validation data and are not shipped in this repository.
+
+Cold-start replay used the installed `quickstart.py`, the standalone profile,
+`/livox/points`, simulation time, `--global-seed-z -11.04`, no RViz, and 0.1x bag
+playback to approximate the documented stationary initialization condition.
+
+Observed result:
+
+- the compiled G2 backend and `g2_ndt_score` loaded successfully;
+- guarded queries completed in 10.865 s, 12.344 s, and 11.228 s;
+- the accepted 3D-ranked candidate was near `(-86.56, -8.41, -11.04, -80 deg)`;
+- distinct-scan consensus published `/initialpose`, fresh localizer diagnostics reached
+  `global_pose_verified`, and the startup state reached `active`;
+- the atomic state record contained the exact map SHA-256 and a verified pose near
+  `(-86.10, -8.86, -11.01)`.
+
+A second launch omitted the occupancy map and reused that state record. The current scan
+passed pre-publication NDT verification at fitness `3.326`, then the localizer reached
+`saved_pose_verified` and `active`. This exercises both automatic startup sources on
+real sensor messages.
+
+An earlier 1.0x moving replay intentionally failed consensus and published no pose. That
+is the expected boundary: cold-start global search requires a stationary robot, and a
+weak, ambiguous, stale, inconsistent, or over-time result falls back to RViz.
+
+## Dataset availability boundary
+
+The mounted filesystem was searched for ROS bags and matching pointcloud maps:
+
+| Dataset | Available assets | Phase 4 result |
+| --- | --- | --- |
+| Koide | bag, matching 3D map, occupancy map | cold start and saved restore passed |
+| HDL | 120 per-frame `cloud.pcd` snapshots only; no HDL bag or matching map | replay skipped: incomplete input pair |
+| Istanbul | no Istanbul bag or pointcloud map | replay skipped: dataset absent |
+
+The HDL and Istanbul rows are not pass claims. Re-run their normal package replay tools
+and the same quickstart workflow when a matching bag/map pair is mounted.

--- a/launch/quickstart.launch.py
+++ b/launch/quickstart.launch.py
@@ -1,0 +1,224 @@
+"""User-facing localization bringup with guarded startup initialization."""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction, TimerAction)
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+
+def _localization_include(context):
+    package_share = get_package_share_directory("lidar_localization_ros2")
+    profile = LaunchConfiguration("profile").perform(context)
+    launch_by_profile = {
+        "standalone": "lidar_localization.launch.py",
+        "nav2": "nav2_lidar_localization.launch.py",
+        "mid360": "mid360_legged_localization.launch.py",
+    }
+    if profile not in launch_by_profile:
+        raise ValueError(f"unsupported quickstart profile: {profile}")
+    arguments = {
+        "localization_param_dir": LaunchConfiguration("localization_param_dir"),
+        "cloud_topic": LaunchConfiguration("cloud_topic"),
+        "imu_topic": LaunchConfiguration("imu_topic"),
+        "global_frame_id": LaunchConfiguration("global_frame_id"),
+        "odom_frame_id": LaunchConfiguration("odom_frame_id"),
+        "base_frame_id": LaunchConfiguration("base_frame_id"),
+        "lidar_frame_id": LaunchConfiguration("lidar_frame_id"),
+        "imu_frame_id": LaunchConfiguration("imu_frame_id"),
+        "use_sim_time": LaunchConfiguration("use_sim_time"),
+        "publish_lidar_tf": LaunchConfiguration("publish_lidar_tf"),
+        "publish_imu_tf": LaunchConfiguration("publish_imu_tf"),
+    }
+    if profile == "mid360":
+        arguments["map_path"] = LaunchConfiguration("map_path")
+    return [IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(package_share, "launch", launch_by_profile[profile])),
+        launch_arguments=arguments.items(),
+    )]
+
+
+def _bringup_check(context):
+    profile = LaunchConfiguration("profile").perform(context)
+    arguments = [
+        "--profile", profile,
+        "--duration-sec", "5.0",
+        "--cloud-topic", LaunchConfiguration("cloud_topic"),
+        "--imu-topic", LaunchConfiguration("imu_topic"),
+        "--lidar-frame", LaunchConfiguration("lidar_frame_id"),
+        "--imu-frame", LaunchConfiguration("imu_frame_id"),
+        "--global-frame", LaunchConfiguration("global_frame_id"),
+        "--odom-frame", LaunchConfiguration("odom_frame_id"),
+        "--base-frame", LaunchConfiguration("base_frame_id"),
+    ]
+    if profile in {"nav2", "mid360"}:
+        arguments.append("--require-odom-base-tf")
+    if profile == "nav2":
+        arguments.append("--require-map-odom-tf")
+    if profile == "mid360":
+        arguments.extend(["--require-imu", "--require-imu-base-tf"])
+    return [TimerAction(
+        period=3.0,
+        actions=[Node(
+            package="lidar_localization_ros2",
+            executable="check_lidar_localization_bringup.py",
+            name="quickstart_bringup_check",
+            arguments=arguments,
+            condition=IfCondition(LaunchConfiguration("run_bringup_check")),
+            output="screen",
+        )],
+    )]
+
+
+def generate_launch_description():
+    package_share = get_package_share_directory("lidar_localization_ros2")
+    declarations = [
+        DeclareLaunchArgument("profile", default_value="standalone"),
+        DeclareLaunchArgument("localization_param_dir"),
+        DeclareLaunchArgument("map_path"),
+        DeclareLaunchArgument("occupancy_yaml", default_value=""),
+        DeclareLaunchArgument("pose_state_path"),
+        DeclareLaunchArgument("cloud_topic", default_value="/velodyne_points"),
+        DeclareLaunchArgument("imu_topic", default_value="/imu"),
+        DeclareLaunchArgument("pose_topic", default_value="/pcl_pose"),
+        DeclareLaunchArgument("global_frame_id", default_value="map"),
+        DeclareLaunchArgument("odom_frame_id", default_value="odom"),
+        DeclareLaunchArgument("base_frame_id", default_value="base_link"),
+        DeclareLaunchArgument("lidar_frame_id", default_value="velodyne"),
+        DeclareLaunchArgument("imu_frame_id", default_value="imu_link"),
+        DeclareLaunchArgument("use_sim_time", default_value="false"),
+        DeclareLaunchArgument("publish_lidar_tf", default_value="true"),
+        DeclareLaunchArgument("publish_imu_tf", default_value="false"),
+        DeclareLaunchArgument("restore_saved_pose", default_value="true"),
+        DeclareLaunchArgument("initial_pose_preconfigured", default_value="false"),
+        DeclareLaunchArgument("enable_global_initialization", default_value="false"),
+        DeclareLaunchArgument("start_rviz", default_value="true"),
+        DeclareLaunchArgument("run_bringup_check", default_value="true"),
+        DeclareLaunchArgument("saved_pose_max_age_sec", default_value="0.0"),
+        DeclareLaunchArgument("min_candidate_score", default_value="0.6"),
+        DeclareLaunchArgument("min_score_margin", default_value="0.05"),
+        DeclareLaunchArgument("max_candidate_age_sec", default_value="30.0"),
+        DeclareLaunchArgument("global_query_timeout_sec", default_value="30.0"),
+        DeclareLaunchArgument("verification_samples", default_value="3"),
+        DeclareLaunchArgument("verification_fitness_threshold", default_value="1.5"),
+        DeclareLaunchArgument("max_global_attempts", default_value="6"),
+        DeclareLaunchArgument("global_consensus_samples", default_value="2"),
+        DeclareLaunchArgument("global_consensus_translation_m", default_value="2.0"),
+        DeclareLaunchArgument("global_consensus_yaw_deg", default_value="20.0"),
+        DeclareLaunchArgument("g2_use_cpp_backend", default_value="true"),
+        DeclareLaunchArgument("g2_enable_registration_scoring", default_value="true"),
+        DeclareLaunchArgument("require_global_registration_scoring", default_value="true"),
+        DeclareLaunchArgument("g2_registration_score_gate", default_value="6.0"),
+        DeclareLaunchArgument("g2_registration_refine_candidates", default_value="false"),
+        DeclareLaunchArgument("g2_registration_seed_z_m", default_value="0.0"),
+        DeclareLaunchArgument("g2_max_scan_points", default_value="256"),
+        DeclareLaunchArgument("g2_angular_resolution_deg", default_value="10.0"),
+        DeclareLaunchArgument("g2_max_candidates", default_value="8"),
+        DeclareLaunchArgument("g2_nms_radius_m", default_value="3.0"),
+    ]
+
+    global_localization = Node(
+        package="lidar_localization_ros2",
+        executable="global_localization_node.py",
+        name="global_localization_node",
+        output="screen",
+        condition=IfCondition(LaunchConfiguration("enable_global_initialization")),
+        parameters=[{
+            "occupancy_yaml": LaunchConfiguration("occupancy_yaml"),
+            "map_path": LaunchConfiguration("map_path"),
+            "cloud_topic": LaunchConfiguration("cloud_topic"),
+            "global_frame_id": LaunchConfiguration("global_frame_id"),
+            "use_cpp_backend": ParameterValue(
+                LaunchConfiguration("g2_use_cpp_backend"), value_type=bool),
+            "enable_registration_scoring": ParameterValue(
+                LaunchConfiguration("g2_enable_registration_scoring"), value_type=bool),
+            "registration_score_gate": ParameterValue(
+                LaunchConfiguration("g2_registration_score_gate"), value_type=float),
+            "registration_refine_candidates": ParameterValue(
+                LaunchConfiguration("g2_registration_refine_candidates"), value_type=bool),
+            "registration_seed_z_m": ParameterValue(
+                LaunchConfiguration("g2_registration_seed_z_m"), value_type=float),
+            "seed_z_m": ParameterValue(
+                LaunchConfiguration("g2_registration_seed_z_m"), value_type=float),
+            "max_scan_points": ParameterValue(
+                LaunchConfiguration("g2_max_scan_points"), value_type=int),
+            "angular_resolution_deg": ParameterValue(
+                LaunchConfiguration("g2_angular_resolution_deg"), value_type=float),
+            "max_candidates": ParameterValue(
+                LaunchConfiguration("g2_max_candidates"), value_type=int),
+            "nms_radius_m": ParameterValue(
+                LaunchConfiguration("g2_nms_radius_m"), value_type=float),
+            "use_sim_time": ParameterValue(
+                LaunchConfiguration("use_sim_time"), value_type=bool),
+        }],
+    )
+    startup_initialization = Node(
+        package="lidar_localization_ros2",
+        executable="startup_initialization_node.py",
+        name="startup_initialization",
+        output="screen",
+        parameters=[{
+            "map_path": LaunchConfiguration("map_path"),
+            "pose_state_path": LaunchConfiguration("pose_state_path"),
+            "restore_saved_pose": ParameterValue(
+                LaunchConfiguration("restore_saved_pose"), value_type=bool),
+            "initial_pose_preconfigured": ParameterValue(
+                LaunchConfiguration("initial_pose_preconfigured"), value_type=bool),
+            "enable_global_initialization": ParameterValue(
+                LaunchConfiguration("enable_global_initialization"), value_type=bool),
+            "require_global_registration_scoring": ParameterValue(
+                LaunchConfiguration("require_global_registration_scoring"),
+                value_type=bool),
+            "cloud_topic": LaunchConfiguration("cloud_topic"),
+            "pose_topic": LaunchConfiguration("pose_topic"),
+            "global_frame_id": LaunchConfiguration("global_frame_id"),
+            "saved_pose_max_age_sec": ParameterValue(
+                LaunchConfiguration("saved_pose_max_age_sec"), value_type=float),
+            "min_candidate_score": ParameterValue(
+                LaunchConfiguration("min_candidate_score"), value_type=float),
+            "min_score_margin": ParameterValue(
+                LaunchConfiguration("min_score_margin"), value_type=float),
+            "max_candidate_age_sec": ParameterValue(
+                LaunchConfiguration("max_candidate_age_sec"), value_type=float),
+            "query_timeout_sec": ParameterValue(
+                LaunchConfiguration("global_query_timeout_sec"), value_type=float),
+            "verification_samples": ParameterValue(
+                LaunchConfiguration("verification_samples"), value_type=int),
+            "verification_fitness_threshold": ParameterValue(
+                LaunchConfiguration("verification_fitness_threshold"), value_type=float),
+            "max_global_attempts": ParameterValue(
+                LaunchConfiguration("max_global_attempts"), value_type=int),
+            "global_consensus_samples": ParameterValue(
+                LaunchConfiguration("global_consensus_samples"), value_type=int),
+            "global_consensus_translation_m": ParameterValue(
+                LaunchConfiguration("global_consensus_translation_m"), value_type=float),
+            "global_consensus_yaw_deg": ParameterValue(
+                LaunchConfiguration("global_consensus_yaw_deg"), value_type=float),
+            "default_z_m": ParameterValue(
+                LaunchConfiguration("g2_registration_seed_z_m"), value_type=float),
+            "use_sim_time": ParameterValue(
+                LaunchConfiguration("use_sim_time"), value_type=bool),
+        }],
+    )
+    rviz = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="quickstart_rviz",
+        arguments=["-d", os.path.join(package_share, "rviz", "localization.rviz")],
+        condition=IfCondition(LaunchConfiguration("start_rviz")),
+        output="screen",
+    )
+
+    return LaunchDescription(
+        declarations
+        + [OpaqueFunction(function=_localization_include),
+           OpaqueFunction(function=_bringup_check), global_localization,
+           startup_initialization, rviz]
+    )

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,7 @@ moving files into subdirectories.
 
 | Task | Entry point |
 | --- | --- |
+| One-command guarded bringup | `quickstart.py` |
 | Generate a site preset | `create_lidar_localization_config.py` |
 | Check generic bringup | `check_lidar_localization_bringup.py` |
 | Check MID-360 bringup | `check_mid360_legged_bringup.py` |
@@ -39,6 +40,8 @@ moving files into subdirectories.
   localization and relocalization planning stages.
 - `global_localization_*`, `reinitialization_supervisor_*`: runtime G2/G3
   localization and recovery components.
+- `quickstart.py`, `quickstart_model.py`, `startup_initialization_node.py`:
+  first-bringup orchestration, ROS-free startup policy/persistence, and its ROS I/O node.
 - `render_*`: GIF and gallery rendering.
 - `setup_local_env.sh`, `bootstrap_colcon_workspace.sh`: local developer
   environment setup; source or run these from the repository checkout.

--- a/scripts/global_localization_node.py
+++ b/scripts/global_localization_node.py
@@ -206,6 +206,7 @@ class GlobalLocalizationNode(Node):
             entry = {
                 "x": round(candidate.x_m, 3),
                 "y": round(candidate.y_m, 3),
+                "z": round(candidate.z_m, 3),
                 "yaw_deg": round(math.degrees(candidate.yaw_rad), 1),
                 "score": round(candidate.score, 4),
                 "bbs_score": round(candidate.bbs_score, 4),

--- a/scripts/quickstart.py
+++ b/scripts/quickstart.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Generate a safe configuration and start lidar localization in one command."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import math
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional, Sequence
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _load_sibling(name: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPT_DIR / f"{name}.py")
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {name}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+config_tool = _load_sibling("create_lidar_localization_config")
+model = _load_sibling("quickstart_model")
+
+
+def default_config_path() -> Path:
+    return Path.home() / ".config" / "lidar_localization_ros2" / "quickstart.yaml"
+
+
+def default_state_path(map_path: Path) -> Path:
+    safe_stem = re.sub(r"[^A-Za-z0-9_.-]+", "_", map_path.stem) or "map"
+    return Path.home() / ".local" / "state" / "lidar_localization_ros2" / f"{safe_stem}.json"
+
+
+def parse_typed_topics(output: str):
+    topics = []
+    for line in output.splitlines():
+        match = re.match(r"^(\S+)\s+\[([^,\]]+)", line.strip())
+        if match:
+            topics.append((match.group(1), match.group(2)))
+    return topics
+
+
+def discover_typed_topics(timeout_sec: float = 2.0):
+    try:
+        result = subprocess.run(
+            ["ros2", "topic", "list", "--types"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_sec,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return []
+    if result.returncode != 0:
+        return []
+    return parse_typed_topics(result.stdout)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="One-command lidar_localization_ros2 setup and guarded startup.")
+    parser.add_argument("--map", "--map-path", dest="map_path", required=True)
+    parser.add_argument("--occupancy-map", dest="occupancy_yaml")
+    parser.add_argument(
+        "--profile", choices=sorted(config_tool.PROFILE_DEFAULTS), default="standalone")
+    parser.add_argument("--output", type=Path, default=default_config_path())
+    parser.add_argument("--state-file", type=Path)
+    parser.add_argument("--cloud-topic")
+    parser.add_argument("--imu-topic")
+    parser.add_argument("--lidar-frame")
+    parser.add_argument("--imu-frame")
+    parser.add_argument("--global-frame", default="map")
+    parser.add_argument("--odom-frame", default="odom")
+    parser.add_argument("--base-frame", default="base_link")
+    parser.add_argument("--initial-pose", type=float, nargs=7)
+    parser.add_argument("--use-sim-time", action="store_true")
+    parser.add_argument(
+        "--auto-initialize",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Restore a verified saved pose, then use global search when configured.",
+    )
+    parser.add_argument(
+        "--restore-saved-pose", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--saved-pose-max-age-sec", type=float, default=0.0)
+    parser.add_argument(
+        "--discover-topics", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--rviz", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument(
+        "--bringup-check", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--publish-lidar-tf", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--publish-imu-tf", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--min-candidate-score", type=float, default=0.6)
+    parser.add_argument("--min-score-margin", type=float, default=0.05)
+    parser.add_argument("--max-candidate-age-sec", type=float, default=30.0)
+    parser.add_argument("--global-query-timeout-sec", type=float, default=30.0)
+    parser.add_argument("--verification-samples", type=int, default=3)
+    parser.add_argument("--verification-fitness-threshold", type=float, default=1.5)
+    parser.add_argument("--max-global-attempts", type=int, default=6)
+    parser.add_argument("--global-consensus-samples", type=int, default=2)
+    parser.add_argument("--global-consensus-translation-m", type=float, default=2.0)
+    parser.add_argument("--global-consensus-yaw-deg", type=float, default=20.0)
+    parser.add_argument(
+        "--global-cpp-backend", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument(
+        "--global-registration-scoring",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use the 3D NDT scorer to validate and rank G2 candidates.",
+    )
+    parser.add_argument(
+        "--require-global-registration-scoring",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Refuse automatic global pose publication if 3D scoring is unavailable.",
+    )
+    parser.add_argument("--global-registration-score-gate", type=float, default=6.0)
+    parser.add_argument(
+        "--refine-global-candidates",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument("--global-seed-z", type=float, default=0.0)
+    parser.add_argument("--global-max-scan-points", type=int, default=256)
+    parser.add_argument("--global-angular-resolution-deg", type=float, default=10.0)
+    parser.add_argument("--global-max-candidates", type=int, default=8)
+    parser.add_argument("--global-nms-radius-m", type=float, default=3.0)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def _config_args(args, cloud_topic: str, imu_topic: str):
+    argv = [
+        "--map-path", args.map_path,
+        "--output", str(args.output),
+        "--profile", args.profile,
+        "--cloud-topic", cloud_topic,
+        "--imu-topic", imu_topic,
+        "--global-frame", args.global_frame,
+        "--odom-frame", args.odom_frame,
+        "--base-frame", args.base_frame,
+        "--overwrite",
+    ]
+    if args.lidar_frame:
+        argv.extend(["--lidar-frame", args.lidar_frame])
+    if args.imu_frame:
+        argv.extend(["--imu-frame", args.imu_frame])
+    if args.initial_pose:
+        argv.append("--initial-pose")
+        argv.extend(str(value) for value in args.initial_pose)
+    if args.use_sim_time:
+        argv.append("--use-sim-time")
+    return config_tool.build_arg_parser().parse_args(argv)
+
+
+def launch_parts(args, config_args, config_path: Path, state_path: Path):
+    cloud_topic = str(config_tool._arg_or_profile(config_args, "cloud_topic"))
+    imu_topic = str(config_tool._arg_or_profile(config_args, "imu_topic"))
+    lidar_frame = str(config_tool._arg_or_profile(config_args, "lidar_frame"))
+    imu_frame = str(config_tool._arg_or_profile(config_args, "imu_frame"))
+    pose_topic = (
+        "/localization/pose_with_covariance"
+        if args.profile in {"nav2", "mid360"} else "/pcl_pose")
+    explicit_pose = args.initial_pose is not None
+    restore = args.auto_initialize and args.restore_saved_pose and not explicit_pose
+    global_enabled = (
+        args.auto_initialize and bool(args.occupancy_yaml) and not explicit_pose)
+    values = {
+        "profile": args.profile,
+        "localization_param_dir": str(config_path),
+        "map_path": str(Path(args.map_path).expanduser().resolve()),
+        "occupancy_yaml": str(Path(args.occupancy_yaml).expanduser().resolve())
+        if args.occupancy_yaml else "",
+        "pose_state_path": str(state_path),
+        "cloud_topic": cloud_topic,
+        "imu_topic": imu_topic,
+        "pose_topic": pose_topic,
+        "global_frame_id": args.global_frame,
+        "odom_frame_id": args.odom_frame,
+        "base_frame_id": args.base_frame,
+        "lidar_frame_id": lidar_frame,
+        "imu_frame_id": imu_frame,
+        "use_sim_time": str(args.use_sim_time).lower(),
+        "publish_lidar_tf": str(args.publish_lidar_tf).lower(),
+        "publish_imu_tf": str(args.publish_imu_tf).lower(),
+        "restore_saved_pose": str(restore).lower(),
+        "initial_pose_preconfigured": str(explicit_pose).lower(),
+        "enable_global_initialization": str(global_enabled).lower(),
+        "start_rviz": str(args.rviz).lower(),
+        "run_bringup_check": str(args.bringup_check).lower(),
+        "saved_pose_max_age_sec": args.saved_pose_max_age_sec,
+        "min_candidate_score": args.min_candidate_score,
+        "min_score_margin": args.min_score_margin,
+        "max_candidate_age_sec": args.max_candidate_age_sec,
+        "global_query_timeout_sec": args.global_query_timeout_sec,
+        "verification_samples": args.verification_samples,
+        "verification_fitness_threshold": args.verification_fitness_threshold,
+        "max_global_attempts": args.max_global_attempts,
+        "global_consensus_samples": args.global_consensus_samples,
+        "global_consensus_translation_m": args.global_consensus_translation_m,
+        "global_consensus_yaw_deg": args.global_consensus_yaw_deg,
+        "g2_use_cpp_backend": str(args.global_cpp_backend).lower(),
+        "g2_enable_registration_scoring": str(
+            args.global_registration_scoring).lower(),
+        "require_global_registration_scoring": str(
+            args.require_global_registration_scoring).lower(),
+        "g2_registration_score_gate": args.global_registration_score_gate,
+        "g2_registration_refine_candidates": str(
+            args.refine_global_candidates).lower(),
+        "g2_registration_seed_z_m": args.global_seed_z,
+        "g2_max_scan_points": args.global_max_scan_points,
+        "g2_angular_resolution_deg": args.global_angular_resolution_deg,
+        "g2_max_candidates": args.global_max_candidates,
+        "g2_nms_radius_m": args.global_nms_radius_m,
+    }
+    parts = ["ros2", "launch", "lidar_localization_ros2", "quickstart.launch.py"]
+    parts.extend(
+        f"{key}:={value}"
+        for key, value in values.items()
+        if not (key == "occupancy_yaml" and value == "")
+    )
+    return parts
+
+
+def _validate(args) -> Optional[str]:
+    map_path = Path(args.map_path).expanduser()
+    if not map_path.is_file():
+        return f"Map file does not exist: {map_path}"
+    if map_path.suffix.lower() not in config_tool.SUPPORTED_MAP_SUFFIXES:
+        return "Map must be a .pcd or .ply file."
+    if args.occupancy_yaml:
+        occupancy = Path(args.occupancy_yaml).expanduser()
+        if not occupancy.is_file():
+            return f"Occupancy map YAML does not exist: {occupancy}"
+        if occupancy.suffix.lower() not in {".yaml", ".yml"}:
+            return "Occupancy map must be a YAML file."
+    if (
+        args.verification_samples < 1
+        or args.max_global_attempts < 1
+        or args.global_consensus_samples < 1
+        or args.global_max_scan_points < 1
+        or args.global_max_candidates < 2
+    ):
+        return "Verification samples, candidates, points, and attempts must be positive."
+    if (
+        not math.isfinite(args.global_registration_score_gate)
+        or args.global_registration_score_gate <= 0.0
+    ):
+        return "global_registration_score_gate must be positive."
+    if (
+        not math.isfinite(args.global_angular_resolution_deg)
+        or args.global_angular_resolution_deg <= 0.0
+        or not math.isfinite(args.global_nms_radius_m)
+        or args.global_nms_radius_m < 0.0
+        or not math.isfinite(args.global_seed_z)
+    ):
+        return "Global search resolution, NMS radius, and seed z must be finite and valid."
+    policy_params = model.StartupParams(
+        min_candidate_score=args.min_candidate_score,
+        min_score_margin=args.min_score_margin,
+        max_candidate_age_sec=args.max_candidate_age_sec,
+        query_timeout_sec=args.global_query_timeout_sec,
+        verification_fitness_threshold=args.verification_fitness_threshold,
+        verification_samples=args.verification_samples,
+        max_global_attempts=args.max_global_attempts,
+        global_consensus_samples=args.global_consensus_samples,
+        global_consensus_translation_m=args.global_consensus_translation_m,
+        global_consensus_yaw_deg=args.global_consensus_yaw_deg,
+    )
+    policy_error = model.validate_startup_params(policy_params)
+    if policy_error:
+        return policy_error
+    return None
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    error = _validate(args)
+    if error:
+        print(f"quickstart: {error}", file=sys.stderr)
+        return 2
+
+    defaults = config_tool.PROFILE_DEFAULTS[args.profile]
+    cloud_topic = args.cloud_topic or str(defaults["cloud_topic"])
+    imu_topic = args.imu_topic or str(defaults["imu_topic"])
+    discovery_notes = []
+    if args.discover_topics and (args.cloud_topic is None or args.imu_topic is None):
+        typed = discover_typed_topics()
+        if args.cloud_topic is None:
+            cloud_topic, reason = model.select_discovered_topic(
+                typed, "sensor_msgs/msg/PointCloud2", cloud_topic)
+            discovery_notes.append(f"cloud={cloud_topic} ({reason})")
+        if args.imu_topic is None:
+            imu_topic, reason = model.select_discovered_topic(
+                typed, "sensor_msgs/msg/Imu", imu_topic)
+            discovery_notes.append(f"imu={imu_topic} ({reason})")
+
+    config_args = _config_args(args, cloud_topic, imu_topic)
+    validation_error = config_tool.validate_args(config_args)
+    if validation_error:
+        print(f"quickstart: {validation_error}", file=sys.stderr)
+        return 2
+    output = args.output.expanduser().resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        config_tool.render_ros_params(config_tool.make_params(config_args)),
+        encoding="utf-8",
+    )
+    state_path = (
+        args.state_file.expanduser().resolve()
+        if args.state_file else default_state_path(Path(args.map_path)).resolve())
+    parts = launch_parts(args, config_args, output, state_path)
+
+    print(f"Configuration: {output}")
+    print(f"Pose state:    {state_path}")
+    if discovery_notes:
+        print("Discovery:     " + ", ".join(discovery_notes))
+    if args.initial_pose:
+        print("Initialization: explicit pose")
+    elif args.auto_initialize and args.occupancy_yaml:
+        print("Initialization: verified saved pose -> guarded global search -> RViz")
+    elif args.auto_initialize:
+        print(
+            "Initialization: verified saved pose -> RViz "
+            "(add --occupancy-map for global search)"
+        )
+    else:
+        print("Initialization: explicit pose or RViz")
+    print("Launch:")
+    print("  " + shlex.join(parts))
+    print("Bringup check:")
+    print("  " + config_tool.doctor_command(config_args))
+    if args.dry_run:
+        return 0
+    sys.stdout.flush()
+    os.execvp(parts[0], parts)
+    return 127
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quickstart_model.py
+++ b/scripts/quickstart_model.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""ROS-free policy and persistence helpers for the quickstart workflow."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import tempfile
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Iterable, Optional, Sequence, Tuple
+
+
+POSE_STATE_SCHEMA = 1
+
+STATE_WAITING_FOR_SCAN = "waiting_for_scan"
+STATE_QUERYING_GLOBAL = "querying_global"
+STATE_VERIFYING = "verifying"
+STATE_ACTIVE = "active"
+STATE_NEEDS_OPERATOR = "needs_operator"
+
+ACTION_WAIT = "wait"
+ACTION_PUBLISH_SAVED = "publish_saved"
+ACTION_QUERY_GLOBAL = "query_global"
+ACTION_PUBLISH_GLOBAL = "publish_global"
+ACTION_ACTIVE = "active"
+ACTION_NEEDS_OPERATOR = "needs_operator"
+
+
+@dataclass(frozen=True)
+class MapIdentity:
+    size_bytes: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class StoredPose:
+    schema_version: int
+    map_identity: MapIdentity
+    frame_id: str
+    stamp_sec: float
+    saved_at_sec: float
+    position: Tuple[float, float, float]
+    orientation: Tuple[float, float, float, float]
+    covariance: Tuple[float, ...]
+
+
+@dataclass(frozen=True)
+class PoseLoadResult:
+    pose: Optional[StoredPose]
+    reason: str
+
+
+def compute_map_identity(path: Path, chunk_size: int = 4 * 1024 * 1024) -> MapIdentity:
+    """Return a content identity; paths and mtimes are deliberately not trusted."""
+    resolved = path.expanduser().resolve(strict=True)
+    digest = hashlib.sha256()
+    size = 0
+    with resolved.open("rb") as stream:
+        while True:
+            chunk = stream.read(chunk_size)
+            if not chunk:
+                break
+            size += len(chunk)
+            digest.update(chunk)
+    return MapIdentity(size_bytes=size, sha256=digest.hexdigest())
+
+
+def _finite(values: Iterable[float]) -> bool:
+    return all(math.isfinite(float(value)) for value in values)
+
+
+def validate_stored_pose(pose: StoredPose) -> Optional[str]:
+    if pose.schema_version != POSE_STATE_SCHEMA:
+        return "unsupported_schema"
+    if not pose.frame_id:
+        return "missing_frame"
+    if not _finite((*pose.position, *pose.orientation, pose.stamp_sec, pose.saved_at_sec)):
+        return "nonfinite_pose"
+    norm = math.sqrt(sum(value * value for value in pose.orientation))
+    if norm < 0.5 or norm > 1.5:
+        return "invalid_quaternion"
+    if len(pose.covariance) != 36 or not _finite(pose.covariance):
+        return "invalid_covariance"
+    if len(pose.map_identity.sha256) != 64 or pose.map_identity.size_bytes < 0:
+        return "invalid_map_identity"
+    return None
+
+
+def saved_pose_score_acceptable(converged: bool, fitness: float, threshold: float) -> bool:
+    return (
+        bool(converged)
+        and math.isfinite(float(fitness))
+        and math.isfinite(float(threshold))
+        and float(fitness) <= float(threshold)
+    )
+
+
+def global_registration_scoring_acceptable(
+        registration_scoring_enabled: object, required: bool) -> bool:
+    """Fail closed when automatic global initialization requires 3D scoring."""
+    return not required or registration_scoring_enabled is True
+
+
+def save_stored_pose(path: Path, pose: StoredPose) -> None:
+    error = validate_stored_pose(pose)
+    if error is not None:
+        raise ValueError(error)
+    target = path.expanduser()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = asdict(pose)
+    fd, temporary = tempfile.mkstemp(prefix=f".{target.name}.", dir=str(target.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, target)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _stored_pose_from_dict(raw: dict) -> StoredPose:
+    identity = raw["map_identity"]
+    return StoredPose(
+        schema_version=int(raw["schema_version"]),
+        map_identity=MapIdentity(
+            size_bytes=int(identity["size_bytes"]), sha256=str(identity["sha256"])),
+        frame_id=str(raw["frame_id"]),
+        stamp_sec=float(raw["stamp_sec"]),
+        saved_at_sec=float(raw["saved_at_sec"]),
+        position=tuple(float(value) for value in raw["position"]),
+        orientation=tuple(float(value) for value in raw["orientation"]),
+        covariance=tuple(float(value) for value in raw["covariance"]),
+    )
+
+
+def load_stored_pose(
+    path: Path,
+    expected_map: MapIdentity,
+    expected_frame: str,
+    now_sec: float,
+    max_age_sec: float = 0.0,
+) -> PoseLoadResult:
+    source = path.expanduser()
+    if not source.exists():
+        return PoseLoadResult(None, "not_found")
+    try:
+        raw = json.loads(source.read_text(encoding="utf-8"))
+        pose = _stored_pose_from_dict(raw)
+    except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
+        return PoseLoadResult(None, "invalid_file")
+    error = validate_stored_pose(pose)
+    if error is not None:
+        return PoseLoadResult(None, error)
+    if pose.map_identity != expected_map:
+        return PoseLoadResult(None, "map_mismatch")
+    if pose.frame_id != expected_frame:
+        return PoseLoadResult(None, "frame_mismatch")
+    if max_age_sec > 0.0 and now_sec - pose.saved_at_sec > max_age_sec:
+        return PoseLoadResult(None, "expired")
+    return PoseLoadResult(pose, "ok")
+
+
+def select_discovered_topic(
+    typed_topics: Sequence[Tuple[str, str]], message_type: str, preferred: str
+) -> Tuple[str, str]:
+    """Choose an unambiguous live topic, otherwise retain the profile default."""
+    candidates = sorted({name for name, type_name in typed_topics if type_name == message_type})
+    if preferred in candidates:
+        return preferred, "preferred_live"
+    if len(candidates) == 1:
+        return candidates[0], "single_detected"
+    if not candidates:
+        return preferred, "not_detected"
+    return preferred, "ambiguous"
+
+
+@dataclass(frozen=True)
+class StartupParams:
+    min_candidate_score: float = 0.6
+    min_score_margin: float = 0.05
+    max_candidate_age_sec: float = 30.0
+    query_timeout_sec: float = 30.0
+    verification_timeout_sec: float = 8.0
+    verification_fitness_threshold: float = 1.5
+    verification_samples: int = 3
+    max_global_attempts: int = 6
+    global_consensus_samples: int = 2
+    global_consensus_translation_m: float = 2.0
+    global_consensus_yaw_deg: float = 20.0
+
+
+def validate_startup_params(params: StartupParams) -> Optional[str]:
+    finite_values = (
+        params.min_candidate_score,
+        params.min_score_margin,
+        params.max_candidate_age_sec,
+        params.query_timeout_sec,
+        params.verification_timeout_sec,
+        params.verification_fitness_threshold,
+        params.global_consensus_translation_m,
+        params.global_consensus_yaw_deg,
+    )
+    if not _finite(finite_values):
+        return "startup thresholds must be finite"
+    if not 0.0 <= params.min_candidate_score <= 1.0:
+        return "min_candidate_score must be between 0 and 1"
+    if params.min_score_margin < 0.0:
+        return "min_score_margin must be non-negative"
+    if params.max_candidate_age_sec <= 0.0:
+        return "max_candidate_age_sec must be positive"
+    if params.query_timeout_sec <= 0.0 or params.verification_timeout_sec <= 0.0:
+        return "startup timeouts must be positive"
+    if params.verification_fitness_threshold < 0.0:
+        return "verification_fitness_threshold must be non-negative"
+    if params.verification_samples < 1 or params.max_global_attempts < 1:
+        return "verification samples and global attempts must be positive"
+    if params.global_consensus_samples < 1:
+        return "global_consensus_samples must be positive"
+    if params.global_consensus_translation_m < 0.0:
+        return "global_consensus_translation_m must be non-negative"
+    if not 0.0 <= params.global_consensus_yaw_deg <= 180.0:
+        return "global_consensus_yaw_deg must be between 0 and 180"
+    return None
+
+
+@dataclass(frozen=True)
+class StartupState:
+    name: str = STATE_WAITING_FOR_SCAN
+    source: str = ""
+    deadline_sec: Optional[float] = None
+    global_attempts: int = 0
+    confirmation_samples: int = 0
+    saved_attempted: bool = False
+    consensus_samples: int = 0
+    consensus_pose: Optional[Tuple[float, float, float]] = None
+    consensus_scan_stamp_sec: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class StartupObservation:
+    now_sec: float
+    scan_ready: bool
+    saved_pose_available: bool
+    global_available: bool
+    preconfigured_pose_available: bool = False
+    query_in_flight: bool = False
+    query_candidate_scores: Optional[Tuple[float, ...]] = None
+    query_candidate_age_sec: Optional[float] = None
+    query_top_pose: Optional[Tuple[float, float, float]] = None
+    query_scan_stamp_sec: Optional[float] = None
+    diagnostic_fresh: bool = False
+    tracking_good: bool = False
+    fitness: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class StartupDecision:
+    action: str
+    reason: str
+    state: StartupState
+    candidate_index: int = 0
+
+
+def _operator(state: StartupState, reason: str) -> StartupDecision:
+    return StartupDecision(
+        ACTION_NEEDS_OPERATOR, reason,
+        replace(state, name=STATE_NEEDS_OPERATOR, deadline_sec=None))
+
+
+def _query(params: StartupParams, state: StartupState, now_sec: float, reason: str):
+    if state.global_attempts >= params.max_global_attempts:
+        return _operator(state, "global_attempts_exhausted")
+    next_state = replace(
+        state,
+        name=STATE_QUERYING_GLOBAL,
+        source="global",
+        deadline_sec=now_sec + params.query_timeout_sec,
+        global_attempts=state.global_attempts + 1,
+        confirmation_samples=0,
+    )
+    return StartupDecision(ACTION_QUERY_GLOBAL, reason, next_state)
+
+
+def _angle_error_rad(first: float, second: float) -> float:
+    return abs(math.atan2(math.sin(first - second), math.cos(first - second)))
+
+
+def decide_startup(
+    params: StartupParams, state: StartupState, obs: StartupObservation
+) -> StartupDecision:
+    if state.name == STATE_ACTIVE:
+        return StartupDecision(ACTION_ACTIVE, "tracking", state)
+    if state.name == STATE_NEEDS_OPERATOR:
+        confirmations = state.confirmation_samples
+        if obs.diagnostic_fresh:
+            good = (
+                obs.tracking_good
+                and obs.fitness is not None
+                and math.isfinite(obs.fitness)
+                and obs.fitness <= params.verification_fitness_threshold
+            )
+            confirmations = confirmations + 1 if good else 0
+            state = replace(state, confirmation_samples=confirmations)
+            if confirmations >= params.verification_samples:
+                active = replace(
+                    state, name=STATE_ACTIVE, source="manual", deadline_sec=None)
+                return StartupDecision(ACTION_ACTIVE, "manual_pose_verified", active)
+        return StartupDecision(ACTION_NEEDS_OPERATOR, "manual_pose_required", state)
+
+    if state.name == STATE_WAITING_FOR_SCAN:
+        if not obs.scan_ready:
+            return StartupDecision(ACTION_WAIT, "waiting_for_scan", state)
+        if obs.preconfigured_pose_available:
+            next_state = replace(
+                state,
+                name=STATE_VERIFYING,
+                source="explicit",
+                deadline_sec=obs.now_sec + params.verification_timeout_sec,
+                confirmation_samples=0,
+            )
+            return StartupDecision(ACTION_WAIT, "verifying_explicit_pose", next_state)
+        if obs.saved_pose_available and not state.saved_attempted:
+            next_state = replace(
+                state,
+                name=STATE_VERIFYING,
+                source="saved",
+                deadline_sec=obs.now_sec + params.verification_timeout_sec,
+                saved_attempted=True,
+                confirmation_samples=0,
+            )
+            return StartupDecision(ACTION_PUBLISH_SAVED, "saved_pose_available", next_state)
+        if obs.global_available:
+            return _query(params, state, obs.now_sec, "query_global_startup")
+        return _operator(state, "no_safe_automatic_source")
+
+    if state.name == STATE_QUERYING_GLOBAL:
+        if obs.query_candidate_scores is None:
+            if state.deadline_sec is not None and obs.now_sec > state.deadline_sec:
+                if obs.query_in_flight:
+                    return _operator(state, "global_query_timeout")
+                return _query(params, state, obs.now_sec, "query_timeout_retry")
+            return StartupDecision(ACTION_WAIT, "awaiting_global_query", state)
+        scores = obs.query_candidate_scores
+        if not scores or not math.isfinite(scores[0]) or scores[0] < params.min_candidate_score:
+            return _query(params, state, obs.now_sec, "weak_candidate_retry")
+        if (
+            len(scores) > 1
+            and math.isfinite(scores[1])
+            and scores[0] - scores[1] < params.min_score_margin
+        ):
+            return _query(params, state, obs.now_sec, "ambiguous_candidate_retry")
+        if (
+            obs.query_candidate_age_sec is None
+            or not math.isfinite(obs.query_candidate_age_sec)
+            or obs.query_candidate_age_sec > params.max_candidate_age_sec
+        ):
+            return _query(params, state, obs.now_sec, "stale_candidate_retry")
+        if obs.query_top_pose is None or obs.query_scan_stamp_sec is None:
+            return _query(params, state, obs.now_sec, "candidate_pose_or_stamp_missing")
+        if state.consensus_samples == 0 or state.consensus_pose is None:
+            primed = replace(
+                state,
+                consensus_samples=1,
+                consensus_pose=obs.query_top_pose,
+                consensus_scan_stamp_sec=obs.query_scan_stamp_sec,
+            )
+            if params.global_consensus_samples > 1:
+                return _query(params, primed, obs.now_sec, "global_consensus_primed")
+        else:
+            if (
+                state.consensus_scan_stamp_sec is None
+                or obs.query_scan_stamp_sec <= state.consensus_scan_stamp_sec + 1.0e-9
+            ):
+                return StartupDecision(ACTION_WAIT, "awaiting_fresh_global_scan", state)
+            dx = obs.query_top_pose[0] - state.consensus_pose[0]
+            dy = obs.query_top_pose[1] - state.consensus_pose[1]
+            yaw_error = _angle_error_rad(obs.query_top_pose[2], state.consensus_pose[2])
+            consistent = (
+                math.hypot(dx, dy) <= params.global_consensus_translation_m
+                and math.degrees(yaw_error) <= params.global_consensus_yaw_deg
+            )
+            if not consistent:
+                restarted = replace(
+                    state,
+                    consensus_samples=1,
+                    consensus_pose=obs.query_top_pose,
+                    consensus_scan_stamp_sec=obs.query_scan_stamp_sec,
+                )
+                return _query(
+                    params, restarted, obs.now_sec, "global_consensus_mismatch_retry")
+            agreed = replace(
+                state,
+                consensus_samples=state.consensus_samples + 1,
+                consensus_pose=obs.query_top_pose,
+                consensus_scan_stamp_sec=obs.query_scan_stamp_sec,
+            )
+            if agreed.consensus_samples < params.global_consensus_samples:
+                return _query(params, agreed, obs.now_sec, "global_consensus_pending")
+            state = agreed
+        next_state = replace(
+            state,
+            name=STATE_VERIFYING,
+            source="global",
+            deadline_sec=obs.now_sec + params.verification_timeout_sec,
+            confirmation_samples=0,
+        )
+        return StartupDecision(ACTION_PUBLISH_GLOBAL, "global_candidate_accepted", next_state)
+
+    if state.name == STATE_VERIFYING:
+        confirmations = state.confirmation_samples
+        if obs.diagnostic_fresh:
+            good = (
+                obs.tracking_good
+                and obs.fitness is not None
+                and math.isfinite(obs.fitness)
+                and obs.fitness <= params.verification_fitness_threshold
+            )
+            confirmations = confirmations + 1 if good else 0
+            state = replace(state, confirmation_samples=confirmations)
+            if confirmations >= params.verification_samples:
+                active = replace(state, name=STATE_ACTIVE, deadline_sec=None)
+                return StartupDecision(ACTION_ACTIVE, f"{state.source}_pose_verified", active)
+        if state.deadline_sec is not None and obs.now_sec > state.deadline_sec:
+            if obs.global_available:
+                return _query(params, state, obs.now_sec, f"{state.source}_verification_failed")
+            return _operator(state, f"{state.source}_verification_failed")
+        return StartupDecision(ACTION_WAIT, "verifying_pose", state)
+
+    return _operator(state, "invalid_state")

--- a/scripts/startup_initialization_node.py
+++ b/scripts/startup_initialization_node.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""Safe startup pose restoration, global initialization, and pose persistence."""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+import time
+from pathlib import Path
+
+import rclpy
+from diagnostic_msgs.msg import DiagnosticArray
+from geometry_msgs.msg import PoseWithCovarianceStamped
+from rclpy.executors import ExternalShutdownException
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import PointCloud2
+from std_msgs.msg import String
+from std_srvs.srv import Trigger
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import quickstart_model as model  # noqa: E402
+
+
+_ACCEPT_ACTIONS = frozenset({
+    "accept_measurement",
+    "accept_measurement_with_warning",
+    "accept_measurement_after_recovery",
+})
+_ACCEPT_STATES = frozenset({"tracking", "degraded", "recovering"})
+
+
+class StartupInitializationNode(Node):
+    def __init__(self) -> None:
+        super().__init__("startup_initialization")
+        self.declare_parameter("map_path", "")
+        self.declare_parameter("pose_state_path", "")
+        self.declare_parameter("restore_saved_pose", True)
+        self.declare_parameter("initial_pose_preconfigured", False)
+        self.declare_parameter("saved_pose_max_age_sec", 0.0)
+        self.declare_parameter("preverify_saved_pose", True)
+        self.declare_parameter("saved_pose_score_threshold", 6.0)
+        self.declare_parameter("saved_pose_preverify_attempts", 3)
+        self.declare_parameter("enable_global_initialization", False)
+        self.declare_parameter("require_global_registration_scoring", True)
+        self.declare_parameter("cloud_topic", "/velodyne_points")
+        self.declare_parameter("pose_topic", "/pcl_pose")
+        self.declare_parameter("alignment_status_topic", "/alignment_status")
+        self.declare_parameter("initialpose_topic", "/initialpose")
+        self.declare_parameter("query_service", "/global_localization_node/query")
+        self.declare_parameter("status_topic", "~/status")
+        self.declare_parameter("global_frame_id", "map")
+        self.declare_parameter("default_z_m", 0.0)
+        self.declare_parameter("min_candidate_score", 0.6)
+        self.declare_parameter("min_score_margin", 0.05)
+        self.declare_parameter("max_candidate_age_sec", 30.0)
+        self.declare_parameter("query_timeout_sec", 30.0)
+        self.declare_parameter("verification_timeout_sec", 8.0)
+        self.declare_parameter("verification_fitness_threshold", 1.5)
+        self.declare_parameter("verification_samples", 3)
+        self.declare_parameter("max_global_attempts", 6)
+        self.declare_parameter("global_consensus_samples", 2)
+        self.declare_parameter("global_consensus_translation_m", 2.0)
+        self.declare_parameter("global_consensus_yaw_deg", 20.0)
+        self.declare_parameter("save_interval_sec", 2.0)
+        self.declare_parameter("position_std_m", 0.5)
+        self.declare_parameter("yaw_std_rad", 0.25)
+
+        self.global_frame = str(self.get_parameter("global_frame_id").value)
+        self.map_path = Path(str(self.get_parameter("map_path").value)).expanduser()
+        state_value = str(self.get_parameter("pose_state_path").value)
+        self.state_path = Path(state_value).expanduser() if state_value else None
+        self.restore_saved_pose = bool(self.get_parameter("restore_saved_pose").value)
+        self.initial_pose_preconfigured = bool(
+            self.get_parameter("initial_pose_preconfigured").value)
+        self.enable_global = bool(
+            self.get_parameter("enable_global_initialization").value)
+        self.require_global_registration_scoring = bool(
+            self.get_parameter("require_global_registration_scoring").value)
+        self.default_z = float(self.get_parameter("default_z_m").value)
+        self.save_interval_sec = float(self.get_parameter("save_interval_sec").value)
+        self.position_std = float(self.get_parameter("position_std_m").value)
+        self.yaw_std = float(self.get_parameter("yaw_std_rad").value)
+        self.params = model.StartupParams(
+            min_candidate_score=float(self.get_parameter("min_candidate_score").value),
+            min_score_margin=float(self.get_parameter("min_score_margin").value),
+            max_candidate_age_sec=float(
+                self.get_parameter("max_candidate_age_sec").value),
+            query_timeout_sec=float(self.get_parameter("query_timeout_sec").value),
+            verification_timeout_sec=float(
+                self.get_parameter("verification_timeout_sec").value),
+            verification_fitness_threshold=float(
+                self.get_parameter("verification_fitness_threshold").value),
+            verification_samples=max(
+                1, int(self.get_parameter("verification_samples").value)),
+            max_global_attempts=max(
+                1, int(self.get_parameter("max_global_attempts").value)),
+            global_consensus_samples=max(
+                1, int(self.get_parameter("global_consensus_samples").value)),
+            global_consensus_translation_m=float(
+                self.get_parameter("global_consensus_translation_m").value),
+            global_consensus_yaw_deg=float(
+                self.get_parameter("global_consensus_yaw_deg").value),
+        )
+        parameter_error = model.validate_startup_params(self.params)
+        if parameter_error is not None:
+            raise ValueError(parameter_error)
+        self.state = model.StartupState()
+        self.map_identity = model.compute_map_identity(self.map_path)
+        self.saved_pose = None
+        self.saved_pose_reason = "disabled"
+        if self.restore_saved_pose and self.state_path is not None:
+            loaded = model.load_stored_pose(
+                self.state_path,
+                self.map_identity,
+                self.global_frame,
+                now_sec=time.time(),
+                max_age_sec=float(
+                    self.get_parameter("saved_pose_max_age_sec").value),
+            )
+            self.saved_pose = loaded.pose
+            self.saved_pose_reason = loaded.reason
+        self.saved_pose_preverified = self.saved_pose is not None and not bool(
+            self.get_parameter("preverify_saved_pose").value)
+        self.saved_pose_score_threshold = float(
+            self.get_parameter("saved_pose_score_threshold").value)
+        self.saved_pose_preverify_attempts = max(
+            1, int(self.get_parameter("saved_pose_preverify_attempts").value))
+        self.saved_pose_preverify_count = 0
+        self.saved_pose_scorer = None
+        self._pointcloud2_xyz_array = None
+        if self.saved_pose is not None and not self.saved_pose_preverified:
+            self._prepare_saved_pose_scorer()
+
+        reliable = QoSProfile(depth=10)
+        reliable.reliability = ReliabilityPolicy.RELIABLE
+        transient = QoSProfile(depth=1)
+        transient.reliability = ReliabilityPolicy.RELIABLE
+        transient.durability = DurabilityPolicy.TRANSIENT_LOCAL
+        cloud_qos = QoSProfile(depth=1)
+        cloud_qos.reliability = ReliabilityPolicy.BEST_EFFORT
+
+        self.initialpose_pub = self.create_publisher(
+            PoseWithCovarianceStamped,
+            str(self.get_parameter("initialpose_topic").value),
+            reliable,
+        )
+        self.status_pub = self.create_publisher(
+            String, str(self.get_parameter("status_topic").value), transient)
+        self.create_subscription(
+            PointCloud2,
+            str(self.get_parameter("cloud_topic").value),
+            self._on_cloud,
+            cloud_qos,
+        )
+        self.create_subscription(
+            PoseWithCovarianceStamped,
+            str(self.get_parameter("pose_topic").value),
+            self._on_pose,
+            transient,
+        )
+        self.create_subscription(
+            DiagnosticArray,
+            str(self.get_parameter("alignment_status_topic").value),
+            self._on_alignment,
+            transient,
+        )
+        self.query_client = self.create_client(
+            Trigger, str(self.get_parameter("query_service").value))
+        self.create_timer(0.25, self._tick)
+
+        self.scan_ready = False
+        self.latest_pose = None
+        self.latest_fitness = None
+        self.latest_tracking_good = False
+        self.diagnostic_fresh = False
+        self.stable_samples = 0
+        self.last_save_sec = None
+        self.pending_scores = None
+        self.pending_candidate_age = None
+        self.pending_top_pose = None
+        self.pending_scan_stamp_sec = None
+        self.latest_cloud_stamp_sec = None
+        self.last_query_scan_stamp_sec = None
+        self.candidates = []
+        self.query_in_flight = False
+        self.last_report = None
+        self._report(
+            "starting",
+            extra={"saved_pose": self.saved_pose_reason, "map_sha256": self.map_identity.sha256},
+        )
+
+    def _on_cloud(self, _msg: PointCloud2) -> None:
+        self.latest_cloud_stamp_sec = (
+            float(_msg.header.stamp.sec) + float(_msg.header.stamp.nanosec) * 1e-9)
+        if self.saved_pose is not None and not self.saved_pose_preverified:
+            if self.saved_pose_scorer is not None:
+                self._preverify_saved_pose(_msg)
+                if (
+                    not self.saved_pose_preverified
+                    and self.saved_pose_preverify_count < self.saved_pose_preverify_attempts
+                ):
+                    return
+            else:
+                self.saved_pose_reason = "preverification_unavailable"
+        self.scan_ready = True
+
+    def _prepare_saved_pose_scorer(self) -> None:
+        try:
+            import global_localization_query as global_query
+            import make_bbs_relocalization_attempts as bbs_engine
+
+            global_query._append_module_dirs("g2_ndt_score")
+            import g2_ndt_score
+
+            self.saved_pose_scorer = g2_ndt_score.MapNdtScorer(str(self.map_path))
+            self._pointcloud2_xyz_array = bbs_engine.pointcloud2_xyz_array
+            self.saved_pose_reason = "awaiting_scan_preverification"
+        except (ImportError, RuntimeError, OSError) as exc:
+            self.saved_pose_scorer = None
+            self.saved_pose_reason = "preverification_unavailable"
+            self.get_logger().warning(
+                "saved pose will not be auto-published because NDT preverification "
+                f"is unavailable: {exc}")
+
+    @staticmethod
+    def _yaw_from_quaternion(orientation) -> float:
+        x, y, z, w = orientation
+        siny_cosp = 2.0 * (
+            w * z + x * y)
+        cosy_cosp = 1.0 - 2.0 * (
+            y * y + z * z)
+        return math.atan2(siny_cosp, cosy_cosp)
+
+    def _preverify_saved_pose(self, cloud: PointCloud2) -> None:
+        self.saved_pose_preverify_count += 1
+        try:
+            points = self._pointcloud2_xyz_array(cloud)
+            if points.shape[0] == 0:
+                self.saved_pose_reason = "empty_preverification_scan"
+                return
+            position = self.saved_pose.position
+            orientation = self.saved_pose.orientation
+            result = self.saved_pose_scorer.score_candidate(
+                points,
+                position[0],
+                position[1],
+                position[2],
+                self._yaw_from_quaternion(orientation),
+            )
+            if model.saved_pose_score_acceptable(
+                result.converged, result.fitness, self.saved_pose_score_threshold):
+                self.saved_pose_preverified = True
+                self.saved_pose_reason = "scan_preverified"
+                self.get_logger().info(
+                    "saved pose passed pre-publication NDT verification: "
+                    f"fitness={result.fitness:.3f}")
+            else:
+                self.saved_pose_reason = "scan_preverification_failed"
+        except (RuntimeError, TypeError, ValueError) as exc:
+            self.saved_pose_reason = "scan_preverification_error"
+            self.get_logger().warning(f"saved pose preverification failed: {exc}")
+        finally:
+            if (
+                self.saved_pose_preverified
+                or self.saved_pose_preverify_count >= self.saved_pose_preverify_attempts
+            ):
+                self.saved_pose_scorer = None
+                self._pointcloud2_xyz_array = None
+
+    def _on_pose(self, msg: PoseWithCovarianceStamped) -> None:
+        self.latest_pose = msg
+        self._maybe_save_pose()
+
+    def _on_alignment(self, msg: DiagnosticArray) -> None:
+        for status in msg.status:
+            values = {entry.key: entry.value for entry in status.values}
+            if "fitness_score" not in values:
+                continue
+            try:
+                fitness = float(values["fitness_score"])
+            except ValueError:
+                continue
+            reinit = str(values.get("reinitialization_requested", "false")).lower() == "true"
+            recovery_state = str(values.get("recovery_state", ""))
+            recovery_action = str(values.get("recovery_action", ""))
+            if recovery_state or recovery_action:
+                good = (
+                    status.message == "ok"
+                    and recovery_state in _ACCEPT_STATES
+                    and recovery_action in _ACCEPT_ACTIONS
+                    and not reinit
+                )
+            else:
+                good = status.message == "ok" and not reinit
+            self.latest_fitness = fitness
+            self.latest_tracking_good = good
+            self.diagnostic_fresh = True
+            if (
+                good
+                and math.isfinite(fitness)
+                and fitness <= self.params.verification_fitness_threshold
+            ):
+                self.stable_samples += 1
+            else:
+                self.stable_samples = 0
+            self._maybe_save_pose()
+            return
+
+    def _maybe_save_pose(self) -> None:
+        if (
+            self.state_path is None
+            or self.latest_pose is None
+            or self.stable_samples < self.params.verification_samples
+        ):
+            return
+        now = time.time()
+        if self.last_save_sec is not None and now - self.last_save_sec < self.save_interval_sec:
+            return
+        msg = self.latest_pose
+        if msg.header.frame_id and msg.header.frame_id != self.global_frame:
+            self.get_logger().error(
+                "refusing to save pose in frame "
+                f"{msg.header.frame_id!r}; expected {self.global_frame!r}")
+            return
+        pose = msg.pose.pose
+        stamp_sec = float(msg.header.stamp.sec) + float(msg.header.stamp.nanosec) * 1e-9
+        record = model.StoredPose(
+            schema_version=model.POSE_STATE_SCHEMA,
+            map_identity=self.map_identity,
+            frame_id=msg.header.frame_id or self.global_frame,
+            stamp_sec=stamp_sec,
+            saved_at_sec=now,
+            position=(pose.position.x, pose.position.y, pose.position.z),
+            orientation=(
+                pose.orientation.x,
+                pose.orientation.y,
+                pose.orientation.z,
+                pose.orientation.w,
+            ),
+            covariance=tuple(float(value) for value in msg.pose.covariance),
+        )
+        try:
+            model.save_stored_pose(self.state_path, record)
+            self.last_save_sec = now
+        except (OSError, ValueError) as exc:
+            self.get_logger().error(f"could not save verified pose: {exc}")
+
+    def _tick(self) -> None:
+        # The G2 service can take longer than the localizer to load a large map.
+        # Keep the configured fallback alive while its service is starting.
+        global_available = self.enable_global
+        observation = model.StartupObservation(
+            now_sec=time.monotonic(),
+            scan_ready=self.scan_ready,
+            saved_pose_available=(
+                self.saved_pose is not None and self.saved_pose_preverified),
+            global_available=global_available,
+            preconfigured_pose_available=self.initial_pose_preconfigured,
+            query_in_flight=self.query_in_flight,
+            query_candidate_scores=self.pending_scores,
+            query_candidate_age_sec=self.pending_candidate_age,
+            query_top_pose=self.pending_top_pose,
+            query_scan_stamp_sec=self.pending_scan_stamp_sec,
+            diagnostic_fresh=self.diagnostic_fresh,
+            tracking_good=self.latest_tracking_good,
+            fitness=self.latest_fitness,
+        )
+        self.pending_scores = None
+        self.pending_candidate_age = None
+        self.pending_top_pose = None
+        self.pending_scan_stamp_sec = None
+        self.diagnostic_fresh = False
+        decision = model.decide_startup(self.params, self.state, observation)
+        self.state = decision.state
+        if decision.action == model.ACTION_PUBLISH_SAVED:
+            self._publish_saved_pose()
+        elif decision.action == model.ACTION_QUERY_GLOBAL:
+            self._issue_query()
+        elif decision.action == model.ACTION_PUBLISH_GLOBAL:
+            self._publish_global_candidate(decision.candidate_index)
+        elif (
+            self.state.name == model.STATE_QUERYING_GLOBAL
+            and not self.query_in_flight
+            and self.pending_scores is None
+            and self.query_client.service_is_ready()
+        ):
+            self._issue_query()
+        if decision.action == model.ACTION_NEEDS_OPERATOR:
+            self._report(
+                decision.reason,
+                level="error",
+                extra={"action": "Set 2D Pose Estimate in RViz on /initialpose"},
+            )
+        else:
+            self._report(decision.reason)
+
+    def _issue_query(self) -> None:
+        if self.query_in_flight:
+            return
+        if not self.query_client.service_is_ready():
+            self.get_logger().warning("global localization service is not ready")
+            return
+        if (
+            self.last_query_scan_stamp_sec is not None
+            and (
+                self.latest_cloud_stamp_sec is None
+                or self.latest_cloud_stamp_sec <= self.last_query_scan_stamp_sec + 1.0e-9
+            )
+        ):
+            return
+        self.query_in_flight = True
+        future = self.query_client.call_async(Trigger.Request())
+        future.add_done_callback(self._on_query_response)
+
+    def _on_query_response(self, future) -> None:
+        self.query_in_flight = False
+        try:
+            response = future.result()
+            payload = json.loads(response.message)
+            if not response.success:
+                raise RuntimeError("G2 query returned no candidate")
+            if not model.global_registration_scoring_acceptable(
+                payload.get("registration_scoring_enabled"),
+                self.require_global_registration_scoring,
+            ):
+                detail = payload.get(
+                    "registration_scoring_error", "3D registration scorer unavailable")
+                raise RuntimeError(
+                    "refusing unverified 2D-only global candidate: " + str(detail))
+            candidates = payload.get("candidates") or (
+                [payload["top"]] if "top" in payload else [])
+            self.candidates = candidates
+            self.pending_scores = tuple(float(item["score"]) for item in candidates)
+            age = payload.get("candidate_age_sec")
+            self.pending_candidate_age = float(age) if age is not None else None
+            stamp = payload.get("scan_stamp_sec")
+            self.pending_scan_stamp_sec = float(stamp) if stamp is not None else None
+            self.last_query_scan_stamp_sec = self.pending_scan_stamp_sec
+            top = candidates[0]
+            self.pending_top_pose = (
+                float(top["x"]),
+                float(top["y"]),
+                math.radians(float(top["yaw_deg"])),
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.get_logger().warning(f"global localization query failed: {exc}")
+            self.candidates = []
+            self.pending_scores = ()
+            self.pending_candidate_age = None
+            self.pending_top_pose = None
+            self.pending_scan_stamp_sec = None
+
+    def _new_initialpose(self) -> PoseWithCovarianceStamped:
+        msg = PoseWithCovarianceStamped()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = self.global_frame
+        msg.pose.covariance[0] = self.position_std ** 2
+        msg.pose.covariance[7] = self.position_std ** 2
+        msg.pose.covariance[35] = self.yaw_std ** 2
+        return msg
+
+    def _publish_saved_pose(self) -> None:
+        if self.saved_pose is None:
+            return
+        msg = self._new_initialpose()
+        position = self.saved_pose.position
+        orientation = self.saved_pose.orientation
+        msg.pose.pose.position.x, msg.pose.pose.position.y, msg.pose.pose.position.z = position
+        (
+            msg.pose.pose.orientation.x,
+            msg.pose.pose.orientation.y,
+            msg.pose.pose.orientation.z,
+            msg.pose.pose.orientation.w,
+        ) = orientation
+        msg.pose.covariance = list(self.saved_pose.covariance)
+        self.initialpose_pub.publish(msg)
+        self.get_logger().info("published map-matched saved pose for verification")
+
+    def _publish_global_candidate(self, index: int) -> None:
+        if index >= len(self.candidates):
+            return
+        candidate = self.candidates[index]
+        yaw = math.radians(float(candidate["yaw_deg"]))
+        msg = self._new_initialpose()
+        msg.pose.pose.position.x = float(candidate["x"])
+        msg.pose.pose.position.y = float(candidate["y"])
+        if candidate.get("z") is not None:
+            msg.pose.pose.position.z = float(candidate["z"])
+        elif self.saved_pose is not None:
+            msg.pose.pose.position.z = self.saved_pose.position[2]
+        elif self.latest_pose is not None:
+            msg.pose.pose.position.z = self.latest_pose.pose.pose.position.z
+        else:
+            msg.pose.pose.position.z = self.default_z
+        msg.pose.pose.orientation.z = math.sin(yaw * 0.5)
+        msg.pose.pose.orientation.w = math.cos(yaw * 0.5)
+        self.initialpose_pub.publish(msg)
+        self.get_logger().info(
+            "published globally searched pose for verification: "
+            f"x={candidate['x']} y={candidate['y']} yaw={candidate['yaw_deg']}"
+        )
+
+    def _report(self, reason: str, level: str = "info", extra=None) -> None:
+        payload = {
+            "state": self.state.name,
+            "source": self.state.source,
+            "reason": reason,
+            "global_attempts": self.state.global_attempts,
+        }
+        if extra:
+            payload.update(extra)
+        text = json.dumps(payload, sort_keys=True)
+        if text == self.last_report:
+            return
+        self.last_report = text
+        self.status_pub.publish(String(data=text))
+        if level == "error":
+            self.get_logger().error(f"quickstart: {text}")
+        elif level == "warning":
+            self.get_logger().warning(f"quickstart: {text}")
+        else:
+            self.get_logger().info(f"quickstart: {text}")
+
+
+def main() -> None:
+    rclpy.init()
+    node = StartupInitializationNode()
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_launch_argument_contract.py
+++ b/test/test_launch_argument_contract.py
@@ -33,6 +33,14 @@ comparison_tool = importlib.util.module_from_spec(comparison_spec)
 assert comparison_spec.loader is not None
 comparison_spec.loader.exec_module(comparison_tool)
 
+QUICKSTART_SCRIPT_PATH = SCRIPTS_DIR / "quickstart.py"
+quickstart_spec = importlib.util.spec_from_file_location(
+    "quickstart", QUICKSTART_SCRIPT_PATH)
+quickstart_tool = importlib.util.module_from_spec(quickstart_spec)
+assert quickstart_spec.loader is not None
+sys.modules[quickstart_spec.name] = quickstart_tool
+quickstart_spec.loader.exec_module(quickstart_tool)
+
 
 LAUNCH_ARG_RE = re.compile(r"DeclareLaunchArgument\(\s*['\"]([^'\"]+)['\"]")
 
@@ -118,6 +126,24 @@ def assert_command_args_declared(testcase: unittest.TestCase, command: str) -> N
 
 
 class TestLaunchArgumentContract(unittest.TestCase):
+    def test_quickstart_command_uses_declared_launch_arguments(self):
+        args = quickstart_tool.build_arg_parser().parse_args([
+            "--map", "/maps/site.pcd",
+            "--occupancy-map", "/maps/site.yaml",
+            "--profile", "mid360",
+            "--no-discover-topics",
+        ])
+        generated_config_args = quickstart_tool._config_args(
+            args, "/livox/points", "/livox/imu")
+        command = shlex.join(quickstart_tool.launch_parts(
+            args,
+            generated_config_args,
+            Path("/tmp/quickstart.yaml"),
+            Path("/tmp/quickstart-pose.json"),
+        ))
+
+        assert_command_args_declared(self, command)
+
     def test_config_generator_commands_use_declared_launch_arguments(self):
         for profile in ("standalone", "nav2", "mid360"):
             with self.subTest(profile=profile):

--- a/test/test_package_install_contract.py
+++ b/test/test_package_install_contract.py
@@ -14,6 +14,8 @@ ROS_RUN_SCRIPTS = {
     "scripts/check_lidar_localization_bringup.py",
     "scripts/analyze_koide_imu_consistency.py",
     "scripts/create_lidar_localization_config.py",
+    "scripts/quickstart.py",
+    "scripts/startup_initialization_node.py",
     "scripts/prepare_koide_hard_relocalization_assets.sh",
     "scripts/run_koide_hard_imu_deskew_smoke.sh",
     "scripts/run_koide_corner_deskew_ab.sh",

--- a/test/test_quickstart_cli.py
+++ b/test/test_quickstart_cli.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+import contextlib
+import importlib.util
+import io
+import shlex
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "quickstart", ROOT / "scripts" / "quickstart.py")
+QUICKSTART = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = QUICKSTART
+SPEC.loader.exec_module(QUICKSTART)
+
+
+class TestQuickstartCli(unittest.TestCase):
+    def test_typed_topic_parser_and_safe_discovery(self):
+        parsed = QUICKSTART.parse_typed_topics(
+            "/cloud [sensor_msgs/msg/PointCloud2]\n/imu [sensor_msgs/msg/Imu]\n")
+        self.assertEqual(parsed, [
+            ("/cloud", "sensor_msgs/msg/PointCloud2"),
+            ("/imu", "sensor_msgs/msg/Imu"),
+        ])
+
+    def test_dry_run_generates_one_command_global_workflow(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            map_path = root / "site.pcd"
+            occupancy = root / "site.yaml"
+            output = root / "generated.yaml"
+            state = root / "pose.json"
+            map_path.write_bytes(b"pcd")
+            occupancy.write_text("image: site.pgm\n", encoding="utf-8")
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                result = QUICKSTART.main([
+                    "--map", str(map_path),
+                    "--occupancy-map", str(occupancy),
+                    "--output", str(output),
+                    "--state-file", str(state),
+                    "--no-discover-topics",
+                    "--dry-run",
+                ])
+            text = stdout.getvalue()
+            self.assertEqual(result, 0)
+            self.assertTrue(output.exists())
+            self.assertIn("quickstart.launch.py", text)
+            self.assertIn("restore_saved_pose:=true", text)
+            self.assertIn("enable_global_initialization:=true", text)
+            self.assertIn("g2_use_cpp_backend:=true", text)
+            self.assertIn("g2_enable_registration_scoring:=true", text)
+            self.assertIn("require_global_registration_scoring:=true", text)
+            self.assertIn("guarded global search", text)
+
+    def test_explicit_pose_disables_automatic_publishers(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            map_path = root / "site.ply"
+            occupancy = root / "site.yaml"
+            map_path.write_bytes(b"ply")
+            occupancy.write_text("image: site.pgm\n", encoding="utf-8")
+            args = QUICKSTART.build_arg_parser().parse_args([
+                "--map", str(map_path),
+                "--occupancy-map", str(occupancy),
+                "--initial-pose", "1", "2", "0", "0", "0", "0", "1",
+                "--no-discover-topics",
+            ])
+            config_args = QUICKSTART._config_args(args, "/cloud", "/imu")
+            parts = QUICKSTART.launch_parts(
+                args, config_args, root / "config.yaml", root / "pose.json")
+            command = shlex.join(parts)
+            self.assertIn("restore_saved_pose:=false", command)
+            self.assertIn("enable_global_initialization:=false", command)
+            self.assertIn("initial_pose_preconfigured:=true", command)
+
+    def test_mid360_records_the_remapped_pose_topic(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            map_path = root / "site.pcd"
+            map_path.write_bytes(b"pcd")
+            args = QUICKSTART.build_arg_parser().parse_args([
+                "--map", str(map_path), "--profile", "mid360",
+                "--no-discover-topics",
+            ])
+            config_args = QUICKSTART._config_args(args, "/livox/points", "/livox/imu")
+            command = shlex.join(QUICKSTART.launch_parts(
+                args, config_args, root / "config.yaml", root / "pose.json"))
+            self.assertIn("pose_topic:=/localization/pose_with_covariance", command)
+            self.assertNotIn("occupancy_yaml:=", command)
+
+    def test_missing_map_is_actionable_error(self):
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            result = QUICKSTART.main([
+                "--map", "/definitely/missing/map.pcd",
+                "--no-discover-topics",
+                "--dry-run",
+            ])
+        self.assertEqual(result, 2)
+        self.assertIn("Map file does not exist", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_quickstart_model.py
+++ b/test/test_quickstart_model.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "quickstart_model", ROOT / "scripts" / "quickstart_model.py")
+MODEL = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MODEL
+SPEC.loader.exec_module(MODEL)
+
+
+class TestPoseStore(unittest.TestCase):
+    def _pose(self, identity):
+        return MODEL.StoredPose(
+            schema_version=MODEL.POSE_STATE_SCHEMA,
+            map_identity=identity,
+            frame_id="map",
+            stamp_sec=12.5,
+            saved_at_sec=100.0,
+            position=(1.0, 2.0, 3.0),
+            orientation=(0.0, 0.0, 0.0, 1.0),
+            covariance=tuple([0.0] * 36),
+        )
+
+    def test_map_identity_uses_contents_not_path(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = root / "first.pcd"
+            second = root / "second.pcd"
+            first.write_bytes(b"same map")
+            second.write_bytes(b"same map")
+            self.assertEqual(
+                MODEL.compute_map_identity(first), MODEL.compute_map_identity(second))
+            second.write_bytes(b"different map")
+            self.assertNotEqual(
+                MODEL.compute_map_identity(first), MODEL.compute_map_identity(second))
+
+    def test_round_trip_and_map_guard(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            map_path = root / "map.pcd"
+            state_path = root / "state" / "pose.json"
+            map_path.write_bytes(b"map")
+            identity = MODEL.compute_map_identity(map_path)
+            MODEL.save_stored_pose(state_path, self._pose(identity))
+
+            loaded = MODEL.load_stored_pose(
+                state_path, identity, "map", now_sec=120.0, max_age_sec=30.0)
+            self.assertEqual(loaded.reason, "ok")
+            self.assertEqual(loaded.pose.position, (1.0, 2.0, 3.0))
+
+            mismatch = MODEL.load_stored_pose(
+                state_path,
+                MODEL.MapIdentity(3, "f" * 64),
+                "map",
+                now_sec=120.0,
+            )
+            self.assertEqual(mismatch.reason, "map_mismatch")
+
+    def test_expired_and_malformed_pose_fail_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            identity = MODEL.MapIdentity(3, "a" * 64)
+            state_path = root / "pose.json"
+            MODEL.save_stored_pose(state_path, self._pose(identity))
+            expired = MODEL.load_stored_pose(
+                state_path, identity, "map", now_sec=200.0, max_age_sec=20.0)
+            self.assertEqual(expired.reason, "expired")
+            state_path.write_text("not json", encoding="utf-8")
+            malformed = MODEL.load_stored_pose(
+                state_path, identity, "map", now_sec=time.time())
+            self.assertEqual(malformed.reason, "invalid_file")
+
+    def test_saved_pose_score_must_converge_and_be_finite(self):
+        self.assertTrue(MODEL.saved_pose_score_acceptable(True, 0.5, 1.0))
+        self.assertFalse(MODEL.saved_pose_score_acceptable(False, 0.5, 1.0))
+        self.assertFalse(MODEL.saved_pose_score_acceptable(True, float("nan"), 1.0))
+        self.assertFalse(MODEL.saved_pose_score_acceptable(True, 2.0, 1.0))
+
+    def test_global_registration_scoring_requirement_fails_closed(self):
+        self.assertTrue(MODEL.global_registration_scoring_acceptable(True, True))
+        self.assertFalse(MODEL.global_registration_scoring_acceptable(False, True))
+        self.assertFalse(MODEL.global_registration_scoring_acceptable(None, True))
+        self.assertTrue(MODEL.global_registration_scoring_acceptable(False, False))
+
+
+class TestDiscovery(unittest.TestCase):
+    def test_single_topic_is_detected(self):
+        selected, reason = MODEL.select_discovered_topic(
+            [("/livox/points", "sensor_msgs/msg/PointCloud2")],
+            "sensor_msgs/msg/PointCloud2",
+            "/velodyne_points",
+        )
+        self.assertEqual((selected, reason), ("/livox/points", "single_detected"))
+
+    def test_ambiguous_topics_do_not_guess(self):
+        selected, reason = MODEL.select_discovered_topic(
+            [
+                ("/front", "sensor_msgs/msg/PointCloud2"),
+                ("/rear", "sensor_msgs/msg/PointCloud2"),
+            ],
+            "sensor_msgs/msg/PointCloud2",
+            "/velodyne_points",
+        )
+        self.assertEqual((selected, reason), ("/velodyne_points", "ambiguous"))
+
+
+class TestStartupPolicy(unittest.TestCase):
+    def setUp(self):
+        self.params = MODEL.StartupParams(
+            verification_samples=2,
+            max_global_attempts=6,
+            min_score_margin=0.05,
+        )
+
+    def obs(self, now, **overrides):
+        values = {
+            "now_sec": now,
+            "scan_ready": True,
+            "saved_pose_available": False,
+            "global_available": True,
+        }
+        values.update(overrides)
+        return MODEL.StartupObservation(**values)
+
+    def test_invalid_safety_parameters_are_rejected(self):
+        self.assertIsNone(MODEL.validate_startup_params(self.params))
+        self.assertIn(
+            "between 0 and 1",
+            MODEL.validate_startup_params(MODEL.StartupParams(min_candidate_score=2.0)),
+        )
+        self.assertIn(
+            "positive",
+            MODEL.validate_startup_params(MODEL.StartupParams(global_consensus_samples=0)),
+        )
+
+    def test_saved_pose_is_verified_before_active(self):
+        state = MODEL.StartupState()
+        decision = MODEL.decide_startup(
+            self.params, state, self.obs(0.0, saved_pose_available=True))
+        self.assertEqual(decision.action, MODEL.ACTION_PUBLISH_SAVED)
+        state = decision.state
+        decision = MODEL.decide_startup(
+            self.params,
+            state,
+            self.obs(1.0, diagnostic_fresh=True, tracking_good=True, fitness=0.5),
+        )
+        self.assertEqual(decision.action, MODEL.ACTION_WAIT)
+        decision = MODEL.decide_startup(
+            self.params,
+            decision.state,
+            self.obs(2.0, diagnostic_fresh=True, tracking_good=True, fitness=0.4),
+        )
+        self.assertEqual(decision.action, MODEL.ACTION_ACTIVE)
+        self.assertEqual(decision.reason, "saved_pose_verified")
+
+    def test_explicit_pose_is_monitored_without_republication_or_operator_error(self):
+        decision = MODEL.decide_startup(
+            self.params,
+            MODEL.StartupState(),
+            self.obs(0.0, preconfigured_pose_available=True),
+        )
+        self.assertEqual(decision.action, MODEL.ACTION_WAIT)
+        self.assertEqual(decision.reason, "verifying_explicit_pose")
+        self.assertEqual(decision.state.source, "explicit")
+
+    def test_failed_saved_pose_falls_back_to_global(self):
+        decision = MODEL.decide_startup(
+            self.params,
+            MODEL.StartupState(),
+            self.obs(0.0, saved_pose_available=True),
+        )
+        decision = MODEL.decide_startup(
+            self.params, decision.state, self.obs(9.0))
+        self.assertEqual(decision.action, MODEL.ACTION_QUERY_GLOBAL)
+
+    def test_global_candidate_needs_score_margin_freshness_and_confirmation(self):
+        decision = MODEL.decide_startup(
+            self.params, MODEL.StartupState(), self.obs(0.0))
+        self.assertEqual(decision.action, MODEL.ACTION_QUERY_GLOBAL)
+
+        ambiguous = MODEL.decide_startup(
+            self.params,
+            decision.state,
+            self.obs(
+                1.0,
+                query_candidate_scores=(0.80, 0.78),
+                query_candidate_age_sec=0.2,
+            ),
+        )
+        self.assertEqual(ambiguous.action, MODEL.ACTION_QUERY_GLOBAL)
+        accepted = MODEL.decide_startup(
+            self.params,
+            ambiguous.state,
+            self.obs(
+                2.0,
+                query_candidate_scores=(0.90, 0.70),
+                query_candidate_age_sec=0.2,
+                query_top_pose=(1.0, 2.0, 0.1),
+                query_scan_stamp_sec=10.0,
+            ),
+        )
+        self.assertEqual(accepted.action, MODEL.ACTION_QUERY_GLOBAL)
+        self.assertEqual(accepted.reason, "global_consensus_primed")
+        accepted = MODEL.decide_startup(
+            self.params,
+            accepted.state,
+            self.obs(
+                3.0,
+                query_candidate_scores=(0.91, 0.68),
+                query_candidate_age_sec=0.1,
+                query_top_pose=(1.2, 2.1, 0.12),
+                query_scan_stamp_sec=10.1,
+            ),
+        )
+        self.assertEqual(accepted.action, MODEL.ACTION_PUBLISH_GLOBAL)
+
+    def test_no_source_never_falls_back_to_identity(self):
+        decision = MODEL.decide_startup(
+            self.params,
+            MODEL.StartupState(),
+            self.obs(0.0, global_available=False),
+        )
+        self.assertEqual(decision.action, MODEL.ACTION_NEEDS_OPERATOR)
+        self.assertEqual(decision.reason, "no_safe_automatic_source")
+
+        decision = MODEL.decide_startup(
+            self.params,
+            decision.state,
+            self.obs(
+                1.0,
+                global_available=False,
+                diagnostic_fresh=True,
+                tracking_good=True,
+                fitness=0.4,
+            ),
+        )
+        decision = MODEL.decide_startup(
+            self.params,
+            decision.state,
+            self.obs(
+                2.0,
+                global_available=False,
+                diagnostic_fresh=True,
+                tracking_good=True,
+                fitness=0.4,
+            ),
+        )
+        self.assertEqual(decision.action, MODEL.ACTION_ACTIVE)
+        self.assertEqual(decision.reason, "manual_pose_verified")
+
+    def test_weak_candidates_exhaust_to_operator(self):
+        params = MODEL.StartupParams(max_global_attempts=2)
+        decision = MODEL.decide_startup(
+            params, MODEL.StartupState(), self.obs(0.0))
+        decision = MODEL.decide_startup(
+            params,
+            decision.state,
+            self.obs(1.0, query_candidate_scores=(0.2,), query_candidate_age_sec=0.1),
+        )
+        self.assertEqual(decision.action, MODEL.ACTION_QUERY_GLOBAL)
+        decision = MODEL.decide_startup(
+            params,
+            decision.state,
+            self.obs(2.0, query_candidate_scores=(0.2,), query_candidate_age_sec=0.1),
+        )
+        self.assertEqual(decision.action, MODEL.ACTION_NEEDS_OPERATOR)
+
+    def test_consensus_rejects_different_scan_pose(self):
+        decision = MODEL.decide_startup(
+            self.params, MODEL.StartupState(), self.obs(0.0))
+        primed = MODEL.decide_startup(
+            self.params,
+            decision.state,
+            self.obs(
+                1.0,
+                query_candidate_scores=(0.9, 0.7),
+                query_candidate_age_sec=0.1,
+                query_top_pose=(0.0, 0.0, 0.0),
+                query_scan_stamp_sec=10.0,
+            ),
+        )
+        mismatch = MODEL.decide_startup(
+            self.params,
+            primed.state,
+            self.obs(
+                2.0,
+                query_candidate_scores=(0.9, 0.7),
+                query_candidate_age_sec=0.1,
+                query_top_pose=(20.0, 0.0, 0.0),
+                query_scan_stamp_sec=10.1,
+            ),
+        )
+        self.assertEqual(mismatch.action, MODEL.ACTION_QUERY_GLOBAL)
+        self.assertEqual(mismatch.reason, "global_consensus_mismatch_retry")
+
+    def test_in_flight_query_timeout_falls_back_without_duplicate_attempt(self):
+        decision = MODEL.decide_startup(
+            self.params, MODEL.StartupState(), self.obs(0.0))
+        timed_out = MODEL.decide_startup(
+            self.params,
+            decision.state,
+            self.obs(31.0, query_in_flight=True),
+        )
+        self.assertEqual(timed_out.action, MODEL.ACTION_NEEDS_OPERATOR)
+        self.assertEqual(timed_out.reason, "global_query_timeout")
+        self.assertEqual(timed_out.state.global_attempts, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_quickstart_ros_integration.py
+++ b/test/test_quickstart_ros_integration.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import rclpy
+from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
+from geometry_msgs.msg import PoseWithCovarianceStamped
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import PointCloud2
+from std_msgs.msg import String
+from std_srvs.srv import Trigger
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+SPEC = importlib.util.spec_from_file_location(
+    "startup_initialization_node", SCRIPTS / "startup_initialization_node.py")
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def spin_until(executor, predicate, timeout_sec=5.0):
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        executor.spin_once(timeout_sec=0.05)
+        if predicate():
+            return True
+    return False
+
+
+def main():
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        map_path = root / "map.pcd"
+        state_path = root / "pose.json"
+        map_path.write_bytes(b"quickstart integration map")
+        rclpy.init(args=[
+            "--ros-args",
+            "-p", f"map_path:={map_path}",
+            "-p", f"pose_state_path:={state_path}",
+            "-p", "restore_saved_pose:=false",
+            "-p", "enable_global_initialization:=true",
+            "-p", "verification_samples:=2",
+            "-p", "min_score_margin:=0.05",
+        ])
+        startup = MODULE.StartupInitializationNode()
+        harness = Node("quickstart_test_harness")
+        received_poses = []
+        received_status = []
+        query_count = {"value": 0}
+
+        transient = QoSProfile(depth=1)
+        transient.reliability = ReliabilityPolicy.RELIABLE
+        transient.durability = DurabilityPolicy.TRANSIENT_LOCAL
+        cloud_qos = QoSProfile(depth=1)
+        cloud_qos.reliability = ReliabilityPolicy.BEST_EFFORT
+
+        harness.create_service(
+            Trigger,
+            "/global_localization_node/query",
+            lambda _request, response: _query_response(response, query_count),
+        )
+        cloud_pub = harness.create_publisher(PointCloud2, "/velodyne_points", cloud_qos)
+        pose_pub = harness.create_publisher(
+            PoseWithCovarianceStamped, "/pcl_pose", transient)
+        diagnostics_pub = harness.create_publisher(
+            DiagnosticArray, "/alignment_status", transient)
+        harness.create_subscription(
+            PoseWithCovarianceStamped,
+            "/initialpose",
+            lambda message: received_poses.append(message),
+            10,
+        )
+        harness.create_subscription(
+            String,
+            "/startup_initialization/status",
+            lambda message: received_status.append(json.loads(message.data)),
+            transient,
+        )
+
+        executor = SingleThreadedExecutor()
+        executor.add_node(startup)
+        executor.add_node(harness)
+        try:
+            first_cloud = PointCloud2()
+            first_cloud.header.stamp.sec = 1
+            for _ in range(3):
+                cloud_pub.publish(first_cloud)
+                executor.spin_once(timeout_sec=0.1)
+            assert spin_until(
+                executor, lambda: startup.state.consensus_samples == 1), (
+                "first global candidate did not prime consensus")
+            second_cloud = PointCloud2()
+            second_cloud.header.stamp.sec = 2
+            cloud_pub.publish(second_cloud)
+            assert spin_until(executor, lambda: bool(received_poses)), (
+                "startup node did not publish a global candidate")
+            seed = received_poses[-1]
+            assert abs(seed.pose.pose.position.x - 4.0) < 1.0e-9
+            assert abs(seed.pose.pose.position.y - 5.0) < 1.0e-9
+            assert abs(seed.pose.pose.position.z - 1.25) < 1.0e-9
+
+            pose = PoseWithCovarianceStamped()
+            pose.header.frame_id = "map"
+            pose.pose.pose.position.x = 4.1
+            pose.pose.pose.position.y = 5.1
+            pose.pose.pose.orientation.w = 1.0
+            pose_pub.publish(pose)
+            for expected in (1, 2):
+                diagnostics_pub.publish(_healthy_diagnostic())
+                assert spin_until(
+                    executor,
+                    lambda: (
+                        startup.state.name == MODULE.model.STATE_ACTIVE
+                        or startup.state.confirmation_samples >= expected),
+                    timeout_sec=2.0,
+                ), f"diagnostic confirmation {expected} was not consumed"
+            assert spin_until(
+                executor,
+                lambda: startup.state.name == MODULE.model.STATE_ACTIVE,
+            ), "startup candidate never reached verified active state"
+            assert spin_until(executor, state_path.exists), "verified pose was not saved"
+            saved = json.loads(state_path.read_text(encoding="utf-8"))
+            assert saved["map_identity"]["sha256"] == startup.map_identity.sha256
+            assert saved["position"][:2] == [4.1, 5.1]
+            assert any(item["reason"] == "global_pose_verified" for item in received_status)
+            # rclpy rejects changing severity at one dynamic logger callsite.
+            # The manual fallback must remain callable after informational reports.
+            startup._report("manual_fallback_smoke", level="error")
+        finally:
+            executor.remove_node(harness)
+            executor.remove_node(startup)
+            harness.destroy_node()
+            startup.destroy_node()
+            executor.shutdown()
+            rclpy.shutdown()
+
+
+def _query_response(response, query_count):
+    query_count["value"] += 1
+    response.success = True
+    response.message = json.dumps({
+        "registration_scoring_enabled": True,
+        "candidate_age_sec": 0.1,
+        "scan_stamp_sec": float(query_count["value"]),
+        "candidates": [
+            {"x": 4.0, "y": 5.0, "z": 1.25, "yaw_deg": 30.0, "score": 0.9},
+            {"x": -4.0, "y": -5.0, "z": 1.25, "yaw_deg": 210.0, "score": 0.7},
+        ],
+    })
+    return response
+
+
+def _healthy_diagnostic():
+    message = DiagnosticArray()
+    status = DiagnosticStatus()
+    status.message = "ok"
+    status.values = [KeyValue(key="fitness_score", value="0.4")]
+    message.status = [status]
+    return message
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- add a one-command `quickstart.py` workflow for standalone, Nav2, and MID-360 profiles
- add map-content-bound, atomic saved-pose persistence with pre-publication NDT verification
- add guarded G2 startup initialization with required 3D scoring, distinct-scan consensus, bounded attempts, and RViz fallback
- add ROS-free policy/CLI/launch tests and an rclpy graph integration test
- update the concise README while preserving the Koide gallery link, and add detailed usage and validation docs

## Why

First-time localization bringup required several manual configuration and initialization steps. The new workflow makes the common path one command while refusing unsafe origin guesses, stale or ambiguous global candidates, mismatched saved poses, and unverified 2D-only results.

## Validation

- `colcon build --symlink-install --packages-select lidar_localization_ros2`
- `colcon test --packages-select lidar_localization_ros2`
- `colcon test-result --verbose`: 91 tests, 0 errors, 0 failures, 0 skipped
- `ros2 run lidar_localization_ros2 run_experiment_suite.py`
- installed CLI and launch argument smoke tests
- Koide `outdoor_hard_01a` real-bag cold start reached `global_pose_verified` and `active`
- Koide saved-pose restart passed NDT preverification and reached `saved_pose_verified` and `active`

HDL replay was not run because only standalone cloud snapshots were mounted without a matching bag/map pair. Istanbul replay was not run because its bag and pointcloud map were absent. These boundaries are recorded in `docs/quickstart_validation.md`.
